### PR TITLE
Import new tokens - 2026-08-14-0946

### DIFF
--- a/duckduckgo.pot
+++ b/duckduckgo.pot
@@ -43,6 +43,14 @@ msgid "% Vaccinated"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -461,6 +469,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -744,6 +759,12 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -1408,6 +1429,12 @@ msgid "Add to Home Screen"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr ""
@@ -1757,6 +1784,13 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -2253,6 +2287,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -5078,6 +5118,12 @@ msgid "Copy"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5116,6 +5162,28 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -5792,6 +5860,14 @@ msgid "Delete recent chats?"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -5801,6 +5877,14 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -6051,6 +6135,13 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -6819,6 +6910,13 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -7617,9 +7715,24 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -8936,6 +9049,14 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -9038,6 +9159,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -10964,6 +11091,12 @@ msgid "Learn %sMore%s"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11593,6 +11726,13 @@ msgid "Manage"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -11841,6 +11981,12 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -12210,6 +12356,12 @@ msgid "More about Duck.ai"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -12401,6 +12553,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -13466,6 +13624,30 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14198,6 +14380,12 @@ msgid "Past year"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14207,6 +14395,12 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -14260,6 +14454,20 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -15488,6 +15696,12 @@ msgid "Reading website…"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -15666,6 +15880,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -15917,6 +16137,12 @@ msgid "Remove %s"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -15956,6 +16182,18 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -16617,6 +16855,12 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -17559,6 +17803,13 @@ msgid "Serbian (Latin)"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -17709,6 +17960,14 @@ msgid "Share"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -17850,6 +18109,18 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -18513,6 +18784,12 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -19346,6 +19623,12 @@ msgid "Switch model"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -19579,6 +19862,13 @@ msgid "Synced Devices"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr ""
 
@@ -19608,6 +19898,12 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "TV"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -20152,6 +20448,22 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20232,6 +20544,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -20329,6 +20647,18 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -20948,6 +21278,12 @@ msgid "Try Free"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21058,6 +21394,12 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -21298,6 +21640,12 @@ msgid "Turkmenistan"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -21307,6 +21655,12 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -21773,6 +22127,12 @@ msgid "Unmute"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -21805,6 +22165,12 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -22722,6 +23088,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -22762,6 +23136,14 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -22790,6 +23172,14 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -23079,6 +23469,12 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -23635,6 +24031,14 @@ msgid "Without zero provider visibility"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -24114,6 +24518,13 @@ msgid "You have 1 attempt left."
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -24307,6 +24718,23 @@ msgid "YouTube Standard"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -24327,6 +24755,14 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 # smartling.placeholder_format=C

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: af_ZA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,8 +22,7 @@ msgstr "!Knal-soeksnelsleutels"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
+msgstr "\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -49,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Hierdie toestel)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -443,8 +442,7 @@ msgstr "%1$s woorde"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
+msgstr "%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -499,7 +497,7 @@ msgstr "%1$sVind uit hoe ons jou ligging privaat hou%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sKom meer te wete%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -514,8 +512,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
+msgstr "%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -796,7 +793,7 @@ msgstr "2de in Groep %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2de opinie"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -880,8 +877,7 @@ msgstr "6-uur-gebruikslimiet is bereik."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
+msgstr "6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1356,8 +1352,7 @@ msgstr "Voeg DuckDuckGo-uitbreiding by"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
+msgstr "Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1487,7 +1482,7 @@ msgstr "Voeg by tot tuisskerm"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Voeg by my kletse"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1600,8 +1595,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"Gevorderde modelle kan limiete 2-5x vinniger as ander modelle opgebruik. %1$s"
+msgstr "Gevorderde modelle kan limiete 2-5x vinniger as ander modelle opgebruik. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1815,8 +1809,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
+msgstr "Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1857,7 +1850,7 @@ msgstr "Alle tipes"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Al jou toestelle is ontkoppel van Sync."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1894,8 +1887,7 @@ msgstr "Laat anonieme lêerhersiening vir hierdie kletsgesprek toe?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
+msgstr "Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2228,8 +2220,7 @@ msgstr "Is jy nog daar?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
+msgstr "Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2384,7 +2375,7 @@ msgstr "Vra enigiets privaat"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Vra enigiets privaat"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2447,8 +2438,8 @@ msgstr ""
 "verskyn: Nooit (verwyder Assist UI heeltemal uit soekresultate), Op aanvraag "
 "(wys slegs KI-gesteunde antwoorde as jy op die Assist-knoppie klik), Soms "
 "(wys slegs KI-gesteunde antwoorde wanneer dit baie relevant is) of Dikwels "
-"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is KI-"
-"gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
+"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is "
+"KI-gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2564,8 +2555,7 @@ msgstr ""
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
+msgstr "Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2613,8 +2603,7 @@ msgstr "Outo-antwoord"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
+msgstr "Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2819,8 +2808,7 @@ msgstr "Strepieskode"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
-"Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
+msgstr "Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -3751,8 +3739,7 @@ msgstr "Verander hoe resultaat-URL'e vertoon word"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
+msgstr "Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3904,10 +3891,10 @@ msgid ""
 msgstr ""
 "Met Chat (via ons Duck.ai-diens) kan jy anonieme gesprekke voer met "
 "derdeparty-KI-kletsmodelle, wat modelle van OpenAI, Anthropic en meer "
-"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en -"
-"skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
-"Chat kry wanneer hierdie instelling afgeskakel is, deur %1$shttps://duck."
-"ai%2$s direk te besoek."
+"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en "
+"-skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
+"Chat kry wanneer hierdie instelling afgeskakel is, deur "
+"%1$shttps://duck.ai%2$s direk te besoek."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3962,16 +3949,14 @@ msgstr "Gesels privaat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
+msgstr "Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
+msgstr "Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4040,9 +4025,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Kletse word plaaslik op jou toestel gestoor in plaas van op DuckDuckGo-"
-"bedieners of afgeleë bedieners. As jy kletsgeskiedenis deaktiveer, sal "
-"vasgespelde kletse uitgevee word."
+"Kletse word plaaslik op jou toestel gestoor in plaas van op "
+"DuckDuckGo-bedieners of afgeleë bedieners. As jy kletsgeskiedenis "
+"deaktiveer, sal vasgespelde kletse uitgevee word."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4592,8 +4577,7 @@ msgstr "Klik %1$sJa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
+msgstr "Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -5331,7 +5315,7 @@ msgstr "Kopieer"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopieer"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5380,13 +5364,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Kopieer gedeelde skakel"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Kopieer die kode vanaf ’n ander toestel"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5395,6 +5379,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Kopieer die kode vanaf ’n ander toestel. Gaan na %1$sDuck.ai-instellings › "
+"Chats › Sync & Backup › Sync With Another Device%2$s en probeer weer."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5446,8 +5432,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
+msgstr "Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6068,8 +6053,7 @@ msgstr "Wil jy oudste kletsgesprekke skrap om stoorplek te maak?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
+msgstr "Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6083,7 +6067,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Wis gedeelde skakel uit"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6104,6 +6088,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Deur ’n skakel uit te wis, hou dit op om te werk. Mense wat dit oopgemaak en "
+"die gesprek by hulle kletsgesprekke gevoeg het, behou hul eie kopie."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6131,8 +6117,7 @@ msgstr "Beskryf veranderinge gebaseer op die beeld"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
+msgstr "Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6366,7 +6351,7 @@ msgstr "Wys van die hand"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Wys van die hand"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6419,8 +6404,7 @@ msgstr "Vertoon taal"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
+msgstr "Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6941,8 +6925,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai laat jou privaat met gewilde KI-modelle gesels. As jy dit afskakel, "
-"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds %1$sduck."
-"ai%2$s direk besoek."
+"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds "
+"%1$sduck.ai%2$s direk besoek."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7022,9 +7006,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme KI-"
-"klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, oopbron "
-"KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
+"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme "
+"KI-klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, "
+"oopbron KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7193,8 +7177,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
+msgstr "DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7227,7 +7210,7 @@ msgstr "DuckDuckGo-blaaier %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo-hulpbladsye"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7344,8 +7327,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, e-"
-"posadresse, telefoonnommers en identifiserende metadata, te verwyder."
+"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, "
+"e-posadresse, telefoonnommers en identifiserende metadata, te verwyder."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7451,8 +7434,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
+msgstr "DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7731,8 +7713,7 @@ msgstr "Aktiveer diktasie in Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
+msgstr "Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8055,15 +8036,14 @@ msgstr "Vou kaart uit"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
+msgstr "Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Het verval"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8077,7 +8057,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Verval op %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8340,8 +8320,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
-"verbeterings."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
+"-verbeterings."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8350,8 +8330,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
-"verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
+"-verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8494,8 +8474,7 @@ msgstr "Vind <b>%1$s</b> in jou aflaaivouer"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
+msgstr "Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8532,8 +8511,7 @@ msgstr "Vind resultate nader aan jou."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
+msgstr "Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8715,8 +8693,7 @@ msgstr "Gratis en privaat geselsies, geanonimiseer deur ons"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
+msgstr "Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8829,8 +8806,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is ..."
-"</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
+"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is "
+"...</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
 "opdatering</strong>."
 
 # smartling.placeholder_format=C
@@ -9237,8 +9214,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n DuckDuckGo-"
-"intekening, wat ook ons VPN en ander premium "
+"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n "
+"DuckDuckGo-intekening, wat ook ons VPN en ander premium "
 "privaatheidsbeskermingsmaatreëls insluit."
 
 # smartling.placeholder_format=C
@@ -9308,8 +9285,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
+msgstr "Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9346,8 +9322,8 @@ msgstr "Kry die app"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Kry die gratis DuckDuckGo-blaaier %1$som advertensies op YouTube te blokkeer."
-"%2$s"
+"Kry die gratis DuckDuckGo-blaaier %1$som advertensies op YouTube te "
+"blokkeer.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9406,9 +9382,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel › Kopieer tekskode%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel › Kopieer tekskode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9417,9 +9393,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9429,9 +9405,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel%4$s en skandeer hierdie kode:"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel%4$s en skandeer hierdie kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9441,9 +9417,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9452,6 +9428,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Gaan na %1$sDuck.ai-instellings%2$s › %3$sChats › Sync & Backup › Sync With "
+"Another Device%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9567,7 +9545,7 @@ msgstr "Reg so"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Reg so"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9991,8 +9969,7 @@ msgstr "Help jou vriende en familie om by die Duck-kant aan te sluit!"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
+msgstr "Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10129,8 +10106,7 @@ msgstr "Versteek jou e-posadres"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
+msgstr "Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10378,8 +10354,7 @@ msgstr "Hoe dikwels wil jy KI-gesteunde antwoorde sien?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
+msgstr "Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10622,8 +10597,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
+msgstr "Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10772,8 +10746,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en -"
-"kleur"
+"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en "
+"-kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11203,8 +11177,7 @@ msgstr "Dit is vinnig, gratis en gee jou selfs meer aanlyn beskerming."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
+msgstr "Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11547,7 +11520,7 @@ msgstr "Leer %1$smeer%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Kom meer te wete"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11722,8 +11695,7 @@ msgstr "Laat jou anoniem soek met DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Laat jou wissel tussen die indiening van soeknavrae en aanwysings aan Duck.ai"
+msgstr "Laat jou wissel tussen die indiening van soeknavrae en aanwysings aan Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11815,8 +11787,7 @@ msgstr "Skakels:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
+msgstr "Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12185,7 +12156,7 @@ msgstr "Bestuur"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Bestuur"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12442,7 +12413,7 @@ msgstr "Kieslys"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Boodskappe vanaf hierdie punt is slegs vir jou sigbaar."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12472,8 +12443,7 @@ msgstr "Mikronesië"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
+msgstr "Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12819,7 +12789,7 @@ msgstr "Meer oor Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Meer aksies"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13019,7 +12989,7 @@ msgstr "Sagte rooi"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "My toestelle"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13261,11 +13231,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n DuckDuckGo-"
-"bediener gestoor nadat dit gestuur is om te help om ’n klets te herstel as "
-"jy jou internetverbinding verloor. As jy kletsgeskiedenis deaktiveer, sal "
-"vasgespelde kletse uitgevee word en die tydelike berging van nuwe "
-"aanporrings en antwoorde deaktiveer."
+"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n "
+"DuckDuckGo-bediener gestoor nadat dit gestuur is om te help om ’n klets te "
+"herstel as jy jou internetverbinding verloor. As jy kletsgeskiedenis "
+"deaktiveer, sal vasgespelde kletse uitgevee word en die tydelike berging van "
+"nuwe aanporrings en antwoorde deaktiveer."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13580,8 +13550,7 @@ msgstr "Geen resultate gevind nie."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
+msgstr "Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14098,6 +14067,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Gaan op ’n ander toestel na %1$sDuck.ai-instellings%2$s › %3$sChats › Sync & "
+"Backup › Sync With Another Device%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14106,6 +14077,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Gaan op ’n ander toestel na %1$sDuck.ai-instellings%2$s › %3$sChats › Sync & "
+"Backup › Sync With Another Device%4$s en skandeer hierdie kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14114,6 +14087,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Gaan op ’n ander toestel na %1$sDuck.ai-instellings%2$s › %3$sChats › Sync & "
+"Backup › Sync With Another Device%4$s. Of skandeer die QR op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14408,8 +14383,7 @@ msgstr "Maak die paneel oop oor hoe Duck.ai werk."
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
+msgstr "Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14869,7 +14843,7 @@ msgstr "Afgelope jaar"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Plak"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14887,7 +14861,7 @@ msgstr "Plak sinkronisasiekode"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Plak dit hier onder"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14946,7 +14920,7 @@ msgstr "Persies"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14955,6 +14929,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal vind jou inligting op datamakelaarswebwerwe wat "
+"dit verkoop. Dan werk ons daaraan om dit vir jou verwyder te kry."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15052,8 +15028,8 @@ msgid ""
 msgstr ""
 "As jy jou soektog as 'n vraag en in 'n volsin fraseer, sal DuckAssist meer "
 "geneig wees om outomaties te verskyn en dikwels beter antwoorde lewer. Om "
-"dit af te skakel en die Assist-knoppie te verberg, kan jy na %1$sDuckAssist-"
-"instellings%2$s gaan."
+"dit af te skakel en die Assist-knoppie te verberg, kan jy na "
+"%1$sDuckAssist-instellings%2$s gaan."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15168,8 +15144,7 @@ msgstr "Vasgespeld"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Vasgespelde kletsgesprekke sal boaan jou onlangse kletsgesprekke verskyn."
+msgstr "Vasgespelde kletsgesprekke sal boaan jou onlangse kletsgesprekke verskyn."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -16009,8 +15984,7 @@ msgstr "Vra my"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
+msgstr "Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16229,7 +16203,7 @@ msgstr "Besig om webwerf te lees …"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Gereed vir die sonverduistering?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16271,15 +16245,13 @@ msgstr "Redenasievermoë kan beter antwoorde op ingewikkelde vrae gee."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Redenasievermoë is deegliker, maar bereik gebruikslimiete 2-5x gouer. %1$s"
+msgstr "Redenasievermoë is deegliker, maar bereik gebruikslimiete 2-5x gouer. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Redenasievermoë is deegliker, maar gebruik limiete 2-5x vinniger op. %1$s"
+msgstr "Redenasievermoë is deegliker, maar gebruik limiete 2-5x vinniger op. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16427,7 +16399,7 @@ msgstr "Herstelkode"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Herstelkode"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16684,7 +16656,7 @@ msgstr "Verwyder %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Verwyder toestel"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16732,13 +16704,13 @@ msgstr "Verwyder onnodige leestekens"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Verwyder jou inligting van die internet"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Verwyder jou inligting aanlyn"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17397,8 +17369,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met end-tot-"
-"end-enkripsie."
+"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met "
+"end-tot-end-enkripsie."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17434,7 +17406,7 @@ msgstr "Sê hallo vir Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Sê hallo vir Duck.ai – gratis, private KI-klets deur DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17581,8 +17553,7 @@ msgstr "Rol af en soek %1$sjou blaaier%2$s op die lys."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
+msgstr "Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17818,8 +17789,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte POST-"
-"versoeke gebruik)"
+"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte "
+"POST-versoeke gebruik)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17968,8 +17939,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Stoor jou gesprekke veilig op ons bediener met behulp van punt-tot-punt-"
-"enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
+"Stoor jou gesprekke veilig op ons bediener met behulp van "
+"punt-tot-punt-enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18102,8 +18073,7 @@ msgstr "Kyk na 'n paar van ons nuutste opdaterings"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
+msgstr "Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18130,8 +18100,7 @@ msgstr "Kies %1$s%2$s%3$s, dan %4$sSoekenjin%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
+msgstr "Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18286,8 +18255,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
+msgstr "Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18432,7 +18400,7 @@ msgstr "Serwies (Latyn)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Bedienerdata geskrap"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18535,8 +18503,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
+msgstr "Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18593,7 +18560,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Deel"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18637,8 +18604,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. Duck."
-"ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
+"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. "
+"Duck.ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18747,13 +18714,13 @@ msgstr "Deel jou gedagtes oor die soekboks."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Gedeelde kletsgesprekskakels"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Gedeelde kletsgesprekskakels"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18883,8 +18850,7 @@ msgstr "Wys DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
+msgstr "Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19194,8 +19160,7 @@ msgstr "Wys voorstelle onder die soekkassie soos jy tik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
+msgstr "Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19210,8 +19175,7 @@ msgstr "Wys verwelkomingsboodskap bo-aan die bladsy met soekresultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
+msgstr "Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19283,8 +19247,7 @@ msgstr "Webwerfname"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
+msgstr "Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19436,14 +19399,13 @@ msgstr "Iets het skeefgeloop"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Iets het verkeerd geloop met die laai van hierdie gedeelde kletsgesprek."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
+msgstr "Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19481,8 +19443,7 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
+msgstr "Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19539,8 +19500,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om Duck."
-"ai te vra."
+"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om "
+"Duck.ai te vra."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19556,8 +19517,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
+msgstr "Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20291,7 +20251,7 @@ msgstr "Verander van model"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Verander van model"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20426,8 +20386,7 @@ msgstr "Sync & Backup is geaktiveer!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
+msgstr "Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20476,8 +20435,8 @@ msgid ""
 msgstr ""
 "Sinkronisasieherstelkode\n"
 "\n"
-"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en Duck.ai-"
-"kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
+"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en "
+"Duck.ai-kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
 "gesinkroniseerde data terug te kry as jy toegang tot ’n toestel verloor.\n"
 "\n"
 "Hou hierdie inligting veilig en seker.\n"
@@ -20555,7 +20514,7 @@ msgstr "Gesinkroniseerde toestelle"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Gesinkroniseer op %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20593,7 +20552,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabel"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20918,8 +20877,7 @@ msgstr "Die aangehegte lêers oorskry die totale groottelimiet van %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
+msgstr "Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20944,8 +20902,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
+msgstr "Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21036,8 +20993,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
+msgstr "Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21109,8 +21065,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
+msgstr "Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21185,7 +21140,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Hierdie toestel"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21196,6 +21151,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Hierdie toestel sal nie meer toegang tot jou gesinkroniseerde data op ander "
+"toestelle kan kry nie. Die laaste %1$s kletsgesprekke sal steeds in "
+"plaaslike berging beskikbaar bly."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21227,8 +21185,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
+msgstr "Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21236,8 +21193,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
+msgstr "Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21290,7 +21246,7 @@ msgstr "Hierdie inligting is nie nuttig nie"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Dit is ’n kopie van ’n gedeelde kletsgesprek."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21358,8 +21314,7 @@ msgstr "Hierdie bladsy vereis Javascript om te funksioneer."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
+msgstr "Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21390,8 +21345,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
-"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
+"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
+"antwoorde sien."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21401,22 +21357,24 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
-"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien. Ons "
-"het egter ook 'n beginbladsy wat nooit KI-gesteunde antwoorde by %1$s wys "
-"nie."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
+"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
+"antwoorde sien. Ons het egter ook 'n beginbladsy wat nooit KI-gesteunde "
+"antwoorde by %1$s wys nie."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
 msgstr ""
+"Hierdie gedeelde kletsgesprek kon nie oopgemaak word nie. Die skakel is "
+"moontlik onvolledig."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Hierdie gedeelde kletsgesprekskakel is nie meer beskikbaar nie."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21487,8 +21445,7 @@ msgstr "Dit sal alle instellings wis. Gaan voort?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
+msgstr "Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21601,8 +21558,7 @@ msgstr "Om voort te gaan, moet jy instem tot Duck.ai se %1$s en %2$s"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
+msgstr "Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21634,8 +21590,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou DuckDuckGo-"
-"blaaier by tot die nuutste weergawe en probeer weer."
+"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou "
+"DuckDuckGo-blaaier by tot die nuutste weergawe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22067,7 +22023,7 @@ msgstr "Probeer gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Probeer gratis!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22164,8 +22120,7 @@ msgstr "Probeer om anonieme ligging te aktiveer vir meer akkurate resultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
+msgstr "Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22189,7 +22144,7 @@ msgstr "Probeer gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Probeer gratis!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22438,7 +22393,7 @@ msgstr "Turkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Skakel af"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22456,7 +22411,7 @@ msgstr "Skakel Sync & Backup af"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Skakel Sync & Backup af en skrap bedienerdata?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22527,8 +22482,7 @@ msgstr "Skakel %1$s\"Presiese Ligging\"%2$s aan vir meer akkurate resultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
+msgstr "Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22739,14 +22693,13 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in https://"
-"duckduckgo.com"
+"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
+msgstr "Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22773,8 +22726,7 @@ msgstr "Onder %1$sSoek%2$s-afdeling, klik %3$sBestuur soekenjins …%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
+msgstr "Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22880,8 +22832,7 @@ msgstr "Ontsluit met 'n DuckDuckGo-intekening"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
+msgstr "Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22938,7 +22889,7 @@ msgstr "Ontdemp"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Naamlose kletsgesprek"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22950,8 +22901,7 @@ msgstr "Onbevestigde inligting"
 #. Text explaining the limit on the number of recent chats that can be stored. Example: 'Up to 30 of your most recent chats can be saved at a time.'
 msgctxt "Information about the limit of recent chats that can be saved"
 msgid "Up to %s of your most recent chats can be saved at a time."
-msgstr ""
-"Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
+msgstr "Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22980,7 +22930,7 @@ msgstr "Dateer blaaier op"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Werk Duck.ai by om hierdie gedeelde kletsgesprek te sien."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23296,8 +23246,7 @@ msgstr "Gebruik jy openbare Wi-Fi? Gebruik ons VPN."
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
-"Gebruik die Fire Button om ’n kletsgesprek te skrap van die geskiedenislys."
+msgstr "Gebruik die Fire Button om ’n kletsgesprek te skrap van die geskiedenislys."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23458,8 +23407,7 @@ msgstr "Bekyk pryse vir jou verblyf"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
+msgstr "Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23509,8 +23457,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
+msgstr "Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23561,9 +23508,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak Duck.ai-"
-"instellings oop. Kies “Skakel aan” onder Sync & Backup en kies “Sinkroniseer "
-"met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
+"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak "
+"Duck.ai-instellings oop. Kies “Skakel aan” onder Sync & Backup en kies "
+"“Sinkroniseer met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23862,8 +23809,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
+msgstr "Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23968,6 +23914,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Ons vind en verwyder jou persoonlike inligting vanaf datamakelaarswebwerwe. "
+"Plus kry ’n VPN en meer."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24024,6 +23972,9 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Ons skandeer gereeld datamakelaarswebwerwe vir jou persoonlike inligting, en "
+"ons deel ons vordering met jou op ’n kontroleskerm wat maklik is om te "
+"gebruik."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24072,6 +24023,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Ons sal datamakelaarswebwerwe vir jou e-posadres, naam, adres en meer "
+"skandeer, en daaraan werk om enigiets wat ons oor jou vind, verwyder te kry."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24105,8 +24058,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
+msgstr "Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24362,8 +24314,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
+msgstr "Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -24393,7 +24344,7 @@ msgstr "Wat is 'n paar voor- en nadele van annuïteite?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Wat is die voordele van Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24407,10 +24358,11 @@ msgid ""
 "experience."
 msgstr ""
 "Wat is die voordele daarvan om die DuckDuckGo-blaaier af te laai vir iemand "
-"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike DuckDuckGo-"
-"bronne. Verdeel die antwoord in duidelike afdelings met titels, met ’n fokus "
-"op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, eenvoudig en "
-"maklik om te verstaan vir mense met of sonder veel KI- of tegniese ervaring."
+"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike "
+"DuckDuckGo-bronne. Verdeel die antwoord in duidelike afdelings met titels, "
+"met ’n fokus op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, "
+"eenvoudig en maklik om te verstaan vir mense met of sonder veel KI- of "
+"tegniese ervaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24495,8 +24447,7 @@ msgstr "Wat is die beste geregte wat jy hier kan probeer?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
+msgstr "Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24647,8 +24598,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL parameter-"
-"boekmerkie?"
+"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL "
+"parameter-boekmerkie?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24757,8 +24708,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
+msgstr "Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24970,6 +24920,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Werk direk vanaf jou toestel om jou e-posadres, naam, adres en meer van "
+"datamakelaarswebwerwe te verwyder."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25217,8 +25169,7 @@ msgstr "Ja, nuwe gebruiker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
+msgstr "Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25278,8 +25229,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
+msgstr "Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -25355,8 +25305,7 @@ msgstr "Jy kan aanhou gesels deur jou maandelikse limiet te gebruik."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
+msgstr "Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25457,8 +25406,7 @@ msgstr "Jy kan oor begin op hierdie nuwe domein (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
+msgstr "Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -25477,7 +25425,7 @@ msgstr "Jy het 1 poging oor."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Jy het geen gedeelde kletsgesprekskakels nie."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25540,8 +25488,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
+msgstr "Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25645,8 +25592,7 @@ msgstr "Jy het die maksimum stemkletsduur vir een sessie bereik."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
+msgstr "Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25711,13 +25657,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Jou %1$s mees onlangse kletsgesprekke sal in plaaslike berging op hierdie "
+"blaaiers beskikbaar wees:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Jou Duck.ai-kletsgesprekke word met end-tot-end-enkripsie gesinchroniseer."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25749,6 +25697,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Jou rugsteunlêer sal van DuckDuckGo se bediener geskrap word. Alle toestelle "
+"sal ontkoppel word van sinchronisasie."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25837,8 +25787,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
+msgstr "Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25846,8 +25795,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
-"modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
+"KI-modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25855,8 +25804,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
-"modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
+"KI-modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25948,8 +25897,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
+msgstr "Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25978,8 +25926,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure Hash-"
-"algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
+"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure "
+"Hash-algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
 "instellingslêer verlaat jou blaaier. Ons stoor die instellingslêer deur die "
 "sleutel as naam te gebruik. DuckDuckGo ken nooit jou kenfrase nie."
 
@@ -26216,8 +26164,7 @@ msgstr "deur %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
+msgstr "deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: af_ZA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,7 +22,8 @@ msgstr "!Knal-soeksnelsleutels"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr "\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
+msgstr ""
+"\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -41,6 +42,14 @@ msgstr "% Volledig ingeënt"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% Ingeënt"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -434,7 +443,8 @@ msgstr "%1$s woorde"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
+msgstr ""
+"%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -485,6 +495,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sVind uit hoe ons jou ligging privaat hou%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -497,7 +514,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
+msgstr ""
+"%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -775,6 +793,12 @@ msgid "2nd in Group %s"
 msgstr "2de in Groep %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -856,7 +880,8 @@ msgstr "6-uur-gebruikslimiet is bereik."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
+msgstr ""
+"6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1331,7 +1356,8 @@ msgstr "Voeg DuckDuckGo-uitbreiding by"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
+msgstr ""
+"Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1458,6 +1484,12 @@ msgid "Add to Home Screen"
 msgstr "Voeg by tot tuisskerm"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Byvoegings"
@@ -1568,7 +1600,8 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "Gevorderde modelle kan limiete 2-5x vinniger as ander modelle opgebruik. %1$s"
+msgstr ""
+"Gevorderde modelle kan limiete 2-5x vinniger as ander modelle opgebruik. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1782,7 +1815,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
+msgstr ""
+"Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1819,6 +1853,13 @@ msgid "All types"
 msgstr "Alle tipes"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1853,7 +1894,8 @@ msgstr "Laat anonieme lêerhersiening vir hierdie kletsgesprek toe?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
+msgstr ""
+"Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2186,7 +2228,8 @@ msgstr "Is jy nog daar?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
+msgstr ""
+"Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2338,6 +2381,12 @@ msgid "Ask anything privately"
 msgstr "Vra enigiets privaat"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2398,8 +2447,8 @@ msgstr ""
 "verskyn: Nooit (verwyder Assist UI heeltemal uit soekresultate), Op aanvraag "
 "(wys slegs KI-gesteunde antwoorde as jy op die Assist-knoppie klik), Soms "
 "(wys slegs KI-gesteunde antwoorde wanneer dit baie relevant is) of Dikwels "
-"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is "
-"KI-gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
+"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is KI-"
+"gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2515,7 +2564,8 @@ msgstr ""
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
+msgstr ""
+"Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2563,7 +2613,8 @@ msgstr "Outo-antwoord"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
+msgstr ""
+"Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2768,7 +2819,8 @@ msgstr "Strepieskode"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr "Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
+msgstr ""
+"Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -3699,7 +3751,8 @@ msgstr "Verander hoe resultaat-URL'e vertoon word"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
+msgstr ""
+"Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3851,10 +3904,10 @@ msgid ""
 msgstr ""
 "Met Chat (via ons Duck.ai-diens) kan jy anonieme gesprekke voer met "
 "derdeparty-KI-kletsmodelle, wat modelle van OpenAI, Anthropic en meer "
-"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en "
-"-skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
-"Chat kry wanneer hierdie instelling afgeskakel is, deur "
-"%1$shttps://duck.ai%2$s direk te besoek."
+"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en -"
+"skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
+"Chat kry wanneer hierdie instelling afgeskakel is, deur %1$shttps://duck."
+"ai%2$s direk te besoek."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3909,14 +3962,16 @@ msgstr "Gesels privaat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
+msgstr ""
+"Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
+msgstr ""
+"Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3985,9 +4040,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Kletse word plaaslik op jou toestel gestoor in plaas van op "
-"DuckDuckGo-bedieners of afgeleë bedieners. As jy kletsgeskiedenis "
-"deaktiveer, sal vasgespelde kletse uitgevee word."
+"Kletse word plaaslik op jou toestel gestoor in plaas van op DuckDuckGo-"
+"bedieners of afgeleë bedieners. As jy kletsgeskiedenis deaktiveer, sal "
+"vasgespelde kletse uitgevee word."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4537,7 +4592,8 @@ msgstr "Klik %1$sJa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
+msgstr ""
+"Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -5272,6 +5328,12 @@ msgid "Copy"
 msgstr "Kopieer"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5311,6 +5373,28 @@ msgstr "Kopieer of stoor hierdie kode"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Kopieer herstelkode"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5362,7 +5446,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
+msgstr ""
+"Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5983,13 +6068,22 @@ msgstr "Wil jy oudste kletsgesprekke skrap om stoorplek te maak?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
+msgstr ""
+"Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
 msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr "Wil jy onlangse kletse uitvee?"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6002,6 +6096,14 @@ msgstr "Wil jy hierdie klets skrap?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Geskrapte kletse"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6029,7 +6131,8 @@ msgstr "Beskryf veranderinge gebaseer op die beeld"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
+msgstr ""
+"Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6259,6 +6362,13 @@ msgid "Dismiss"
 msgstr "Wys van die hand"
 
 # smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
 msgctxt "duckassist"
 msgid "Dismiss"
@@ -6309,7 +6419,8 @@ msgstr "Vertoon taal"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr "Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
+msgstr ""
+"Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6830,8 +6941,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai laat jou privaat met gewilde KI-modelle gesels. As jy dit afskakel, "
-"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds "
-"%1$sduck.ai%2$s direk besoek."
+"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds %1$sduck."
+"ai%2$s direk besoek."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6911,9 +7022,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme "
-"KI-klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, "
-"oopbron KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
+"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme KI-"
+"klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, oopbron "
+"KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7082,7 +7193,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
+msgstr ""
+"DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7109,6 +7221,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo-blaaier %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7225,8 +7344,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, "
-"e-posadresse, telefoonnommers en identifiserende metadata, te verwyder."
+"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, e-"
+"posadresse, telefoonnommers en identifiserende metadata, te verwyder."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7332,7 +7451,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
+msgstr ""
+"DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7611,7 +7731,8 @@ msgstr "Aktiveer diktasie in Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
+msgstr ""
+"Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7934,13 +8055,29 @@ msgstr "Vou kaart uit"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
+msgstr ""
+"Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
+
+# smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Het verval"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8203,8 +8340,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
-"-verbeterings."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
+"verbeterings."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8213,8 +8350,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
-"-verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
+"verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8357,7 +8494,8 @@ msgstr "Vind <b>%1$s</b> in jou aflaaivouer"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
+msgstr ""
+"Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8394,7 +8532,8 @@ msgstr "Vind resultate nader aan jou."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
+msgstr ""
+"Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8576,7 +8715,8 @@ msgstr "Gratis en privaat geselsies, geanonimiseer deur ons"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
+msgstr ""
+"Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8689,8 +8829,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is "
-"...</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
+"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is ..."
+"</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
 "opdatering</strong>."
 
 # smartling.placeholder_format=C
@@ -9097,8 +9237,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n "
-"DuckDuckGo-intekening, wat ook ons VPN en ander premium "
+"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n DuckDuckGo-"
+"intekening, wat ook ons VPN en ander premium "
 "privaatheidsbeskermingsmaatreëls insluit."
 
 # smartling.placeholder_format=C
@@ -9168,7 +9308,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
+msgstr ""
+"Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9205,8 +9346,8 @@ msgstr "Kry die app"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Kry die gratis DuckDuckGo-blaaier %1$som advertensies op YouTube te "
-"blokkeer.%2$s"
+"Kry die gratis DuckDuckGo-blaaier %1$som advertensies op YouTube te blokkeer."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9265,9 +9406,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
-"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
-"ander toestel › Kopieer tekskode%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
+"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
+"toestel › Kopieer tekskode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9276,9 +9417,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
-"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
-"ander toestel%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
+"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
+"toestel%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9288,9 +9429,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
-"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
-"ander toestel%4$s en skandeer hierdie kode:"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
+"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
+"toestel%4$s en skandeer hierdie kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9300,9 +9441,17 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
-"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
-"ander toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
+"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
+"toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9413,6 +9562,12 @@ msgstr "Reg so"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Reg so"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9836,7 +9991,8 @@ msgstr "Help jou vriende en familie om by die Duck-kant aan te sluit!"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
+msgstr ""
+"Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9973,7 +10129,8 @@ msgstr "Versteek jou e-posadres"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
+msgstr ""
+"Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10221,7 +10378,8 @@ msgstr "Hoe dikwels wil jy KI-gesteunde antwoorde sien?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
+msgstr ""
+"Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10464,7 +10622,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
+msgstr ""
+"Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10613,8 +10772,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en "
-"-kleur"
+"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en -"
+"kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11044,7 +11203,8 @@ msgstr "Dit is vinnig, gratis en gee jou selfs meer aanlyn beskerming."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
+msgstr ""
+"Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11384,6 +11544,12 @@ msgid "Learn %sMore%s"
 msgstr "Leer %1$smeer%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11556,7 +11722,8 @@ msgstr "Laat jou anoniem soek met DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Laat jou wissel tussen die indiening van soeknavrae en aanwysings aan Duck.ai"
+msgstr ""
+"Laat jou wissel tussen die indiening van soeknavrae en aanwysings aan Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11648,7 +11815,8 @@ msgstr "Skakels:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
+msgstr ""
+"Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12013,6 +12181,13 @@ msgid "Manage"
 msgstr "Bestuur"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12264,6 +12439,12 @@ msgid "Menu"
 msgstr "Kieslys"
 
 # smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
 msgstr "Meting (Kilogramme, Meter, Celcius)"
@@ -12291,7 +12472,8 @@ msgstr "Mikronesië"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
+msgstr ""
+"Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12634,6 +12816,12 @@ msgid "More about Duck.ai"
 msgstr "Meer oor Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Meer by"
@@ -12826,6 +13014,12 @@ msgstr "Gedemp"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Sagte rooi"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13067,11 +13261,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n "
-"DuckDuckGo-bediener gestoor nadat dit gestuur is om te help om ’n klets te "
-"herstel as jy jou internetverbinding verloor. As jy kletsgeskiedenis "
-"deaktiveer, sal vasgespelde kletse uitgevee word en die tydelike berging van "
-"nuwe aanporrings en antwoorde deaktiveer."
+"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n DuckDuckGo-"
+"bediener gestoor nadat dit gestuur is om te help om ’n klets te herstel as "
+"jy jou internetverbinding verloor. As jy kletsgeskiedenis deaktiveer, sal "
+"vasgespelde kletse uitgevee word en die tydelike berging van nuwe "
+"aanporrings en antwoorde deaktiveer."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13386,7 +13580,8 @@ msgstr "Geen resultate gevind nie."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
+msgstr ""
+"Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13897,6 +14092,30 @@ msgstr ""
 "ikoon > Instellings%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14189,7 +14408,8 @@ msgstr "Maak die paneel oop oor hoe Duck.ai werk."
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
+msgstr ""
+"Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14646,6 +14866,12 @@ msgid "Past year"
 msgstr "Afgelope jaar"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14656,6 +14882,12 @@ msgstr "Plak"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Plak sinkronisasiekode"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14709,6 +14941,20 @@ msgstr "Permanent gesluit"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persies"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14806,8 +15052,8 @@ msgid ""
 msgstr ""
 "As jy jou soektog as 'n vraag en in 'n volsin fraseer, sal DuckAssist meer "
 "geneig wees om outomaties te verskyn en dikwels beter antwoorde lewer. Om "
-"dit af te skakel en die Assist-knoppie te verberg, kan jy na "
-"%1$sDuckAssist-instellings%2$s gaan."
+"dit af te skakel en die Assist-knoppie te verberg, kan jy na %1$sDuckAssist-"
+"instellings%2$s gaan."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14922,7 +15168,8 @@ msgstr "Vasgespeld"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Vasgespelde kletsgesprekke sal boaan jou onlangse kletsgesprekke verskyn."
+msgstr ""
+"Vasgespelde kletsgesprekke sal boaan jou onlangse kletsgesprekke verskyn."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15762,7 +16009,8 @@ msgstr "Vra my"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
+msgstr ""
+"Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15978,6 +16226,12 @@ msgid "Reading website…"
 msgstr "Besig om webwerf te lees …"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16017,13 +16271,15 @@ msgstr "Redenasievermoë kan beter antwoorde op ingewikkelde vrae gee."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Redenasievermoë is deegliker, maar bereik gebruikslimiete 2-5x gouer. %1$s"
+msgstr ""
+"Redenasievermoë is deegliker, maar bereik gebruikslimiete 2-5x gouer. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Redenasievermoë is deegliker, maar gebruik limiete 2-5x vinniger op. %1$s"
+msgstr ""
+"Redenasievermoë is deegliker, maar gebruik limiete 2-5x vinniger op. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16166,6 +16422,12 @@ msgstr "Herstel"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Herstelkode"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16419,6 +16681,12 @@ msgid "Remove %s"
 msgstr "Verwyder %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16459,6 +16727,18 @@ msgstr "Verwyder tekskeuse"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Verwyder onnodige leestekens"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17117,8 +17397,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met "
-"end-tot-end-enkripsie."
+"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met end-tot-"
+"end-enkripsie."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17149,6 +17429,12 @@ msgstr "Stoor jou instellings anoniem op die wolk"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Sê hallo vir Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17295,7 +17581,8 @@ msgstr "Rol af en soek %1$sjou blaaier%2$s op die lys."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
+msgstr ""
+"Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17531,8 +17818,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte "
-"POST-versoeke gebruik)"
+"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte POST-"
+"versoeke gebruik)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17681,8 +17968,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Stoor jou gesprekke veilig op ons bediener met behulp van "
-"punt-tot-punt-enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
+"Stoor jou gesprekke veilig op ons bediener met behulp van punt-tot-punt-"
+"enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17815,7 +18102,8 @@ msgstr "Kyk na 'n paar van ons nuutste opdaterings"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
+msgstr ""
+"Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17842,7 +18130,8 @@ msgstr "Kies %1$s%2$s%3$s, dan %4$sSoekenjin%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
+msgstr ""
+"Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17997,7 +18286,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
+msgstr ""
+"Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18138,6 +18428,13 @@ msgid "Serbian (Latin)"
 msgstr "Serwies (Latyn)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18238,7 +18535,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
+msgstr ""
+"Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18290,6 +18588,14 @@ msgid "Share"
 msgstr "Deel"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18331,8 +18637,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. "
-"Duck.ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
+"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. Duck."
+"ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18436,6 +18742,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Deel jou gedagtes oor die soekboks."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18565,7 +18883,8 @@ msgstr "Wys DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
+msgstr ""
+"Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18875,7 +19194,8 @@ msgstr "Wys voorstelle onder die soekkassie soos jy tik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
+msgstr ""
+"Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18890,7 +19210,8 @@ msgstr "Wys verwelkomingsboodskap bo-aan die bladsy met soekresultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
+msgstr ""
+"Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18962,7 +19283,8 @@ msgstr "Webwerfname"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
+msgstr ""
+"Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19111,10 +19433,17 @@ msgid "Something went wrong"
 msgstr "Iets het skeefgeloop"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
+msgstr ""
+"Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19152,7 +19481,8 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
+msgstr ""
+"Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19209,8 +19539,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om "
-"Duck.ai te vra."
+"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om Duck."
+"ai te vra."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19226,7 +19556,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
+msgstr ""
+"Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19957,6 +20288,12 @@ msgid "Switch model"
 msgstr "Verander van model"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20089,7 +20426,8 @@ msgstr "Sync & Backup is geaktiveer!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
+msgstr ""
+"Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20138,8 +20476,8 @@ msgid ""
 msgstr ""
 "Sinkronisasieherstelkode\n"
 "\n"
-"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en "
-"Duck.ai-kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
+"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en Duck.ai-"
+"kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
 "gesinkroniseerde data terug te kry as jy toegang tot ’n toestel verloor.\n"
 "\n"
 "Hou hierdie inligting veilig en seker.\n"
@@ -20213,6 +20551,13 @@ msgid "Synced Devices"
 msgstr "Gesinkroniseerde toestelle"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Sirië"
 
@@ -20243,6 +20588,12 @@ msgstr "MBW"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20567,7 +20918,8 @@ msgstr "Die aangehegte lêers oorskry die totale groottelimiet van %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
+msgstr ""
+"Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20592,7 +20944,8 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr "Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
+msgstr ""
+"Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20683,7 +21036,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
+msgstr ""
+"Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20755,7 +21109,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
+msgstr ""
+"Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20827,6 +21182,22 @@ msgstr ""
 "vertoon (sien %4$s vir meer inligting)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20856,7 +21227,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
+msgstr ""
+"Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -20864,7 +21236,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
+msgstr ""
+"Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -20912,6 +21285,12 @@ msgstr ""
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Hierdie inligting is nie nuttig nie"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -20979,7 +21358,8 @@ msgstr "Hierdie bladsy vereis Javascript om te funksioneer."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
+msgstr ""
+"Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21010,9 +21390,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
-"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
-"antwoorde sien."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
+"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21022,10 +21401,22 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
-"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
-"antwoorde sien. Ons het egter ook 'n beginbladsy wat nooit KI-gesteunde "
-"antwoorde by %1$s wys nie."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
+"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien. Ons "
+"het egter ook 'n beginbladsy wat nooit KI-gesteunde antwoorde by %1$s wys "
+"nie."
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21096,7 +21487,8 @@ msgstr "Dit sal alle instellings wis. Gaan voort?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
+msgstr ""
+"Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21209,7 +21601,8 @@ msgstr "Om voort te gaan, moet jy instem tot Duck.ai se %1$s en %2$s"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
+msgstr ""
+"Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21241,8 +21634,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou "
-"DuckDuckGo-blaaier by tot die nuutste weergawe en probeer weer."
+"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou DuckDuckGo-"
+"blaaier by tot die nuutste weergawe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21671,6 +22064,12 @@ msgid "Try Free"
 msgstr "Probeer gratis"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21765,7 +22164,8 @@ msgstr "Probeer om anonieme ligging te aktiveer vir meer akkurate resultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
+msgstr ""
+"Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21784,6 +22184,12 @@ msgstr "Probeer gratis"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Probeer gratis"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22029,6 +22435,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22039,6 +22451,12 @@ msgstr "Skakel Sync & Backup af"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Skakel Sync & Backup af"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22109,7 +22527,8 @@ msgstr "Skakel %1$s\"Presiese Ligging\"%2$s aan vir meer akkurate resultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
+msgstr ""
+"Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22320,13 +22739,14 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in "
-"https://duckduckgo.com"
+"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
+msgstr ""
+"Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22353,7 +22773,8 @@ msgstr "Onder %1$sSoek%2$s-afdeling, klik %3$sBestuur soekenjins …%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
+msgstr ""
+"Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22459,7 +22880,8 @@ msgstr "Ontsluit met 'n DuckDuckGo-intekening"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
+msgstr ""
+"Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22513,6 +22935,12 @@ msgid "Unmute"
 msgstr "Ontdemp"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22522,7 +22950,8 @@ msgstr "Onbevestigde inligting"
 #. Text explaining the limit on the number of recent chats that can be stored. Example: 'Up to 30 of your most recent chats can be saved at a time.'
 msgctxt "Information about the limit of recent chats that can be saved"
 msgid "Up to %s of your most recent chats can be saved at a time."
-msgstr "Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
+msgstr ""
+"Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22546,6 +22975,12 @@ msgstr "Opdatering"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Dateer blaaier op"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22861,7 +23296,8 @@ msgstr "Gebruik jy openbare Wi-Fi? Gebruik ons VPN."
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr "Gebruik die Fire Button om ’n kletsgesprek te skrap van die geskiedenislys."
+msgstr ""
+"Gebruik die Fire Button om ’n kletsgesprek te skrap van die geskiedenislys."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23022,7 +23458,8 @@ msgstr "Bekyk pryse vir jou verblyf"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
+msgstr ""
+"Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23072,7 +23509,8 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
+msgstr ""
+"Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23123,9 +23561,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak "
-"Duck.ai-instellings oop. Kies “Skakel aan” onder Sync & Backup en kies "
-"“Sinkroniseer met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
+"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak Duck.ai-"
+"instellings oop. Kies “Skakel aan” onder Sync & Backup en kies “Sinkroniseer "
+"met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23424,7 +23862,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
+msgstr ""
+"Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23523,6 +23962,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Ons het die klets beëindig weens onaktiwiteit. Wil jy weer probeer?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23571,6 +24018,14 @@ msgstr ""
 "aan jou. Jy kan altyd later van plan verander."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23611,6 +24066,14 @@ msgstr ""
 "blaai."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
 msgctxt "noresults"
 msgid ""
@@ -23642,7 +24105,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
+msgstr ""
+"Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23898,7 +24362,8 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
+msgstr ""
+"Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -23925,6 +24390,12 @@ msgid "What are some pros and cons of annuities?"
 msgstr "Wat is 'n paar voor- en nadele van annuïteite?"
 
 # smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
 msgctxt "User prompt seeded by Learn More CTA"
 msgid ""
@@ -23936,11 +24407,10 @@ msgid ""
 "experience."
 msgstr ""
 "Wat is die voordele daarvan om die DuckDuckGo-blaaier af te laai vir iemand "
-"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike "
-"DuckDuckGo-bronne. Verdeel die antwoord in duidelike afdelings met titels, "
-"met ’n fokus op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, "
-"eenvoudig en maklik om te verstaan vir mense met of sonder veel KI- of "
-"tegniese ervaring."
+"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike DuckDuckGo-"
+"bronne. Verdeel die antwoord in duidelike afdelings met titels, met ’n fokus "
+"op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, eenvoudig en "
+"maklik om te verstaan vir mense met of sonder veel KI- of tegniese ervaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24025,7 +24495,8 @@ msgstr "Wat is die beste geregte wat jy hier kan probeer?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
+msgstr ""
+"Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24176,8 +24647,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL "
-"parameter-boekmerkie?"
+"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL parameter-"
+"boekmerkie?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24286,7 +24757,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
+msgstr ""
+"Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24490,6 +24962,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Sonder geenverskaffersigbaarheid"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24737,7 +25217,8 @@ msgstr "Ja, nuwe gebruiker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
+msgstr ""
+"Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24797,7 +25278,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
+msgstr ""
+"Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -24873,7 +25355,8 @@ msgstr "Jy kan aanhou gesels deur jou maandelikse limiet te gebruik."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
+msgstr ""
+"Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24974,7 +25457,8 @@ msgstr "Jy kan oor begin op hierdie nuwe domein (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
+msgstr ""
+"Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -24987,6 +25471,13 @@ msgstr "Jy het %1$s pogings oor."
 msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Jy het 1 poging oor."
+
+# smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25049,7 +25540,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
+msgstr ""
+"Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25153,7 +25645,8 @@ msgstr "Jy het die maksimum stemkletsduur vir een sessie bereik."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
+msgstr ""
+"Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25210,6 +25703,23 @@ msgid "YouTube Standard"
 msgstr "Standaard-YouTube"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Jou DuckDuckGo-soekgeskiedenis is privaat"
@@ -25231,6 +25741,14 @@ msgstr "Jou werklike ligging bly privaat"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Jou werklike ligging bly privaat."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25319,7 +25837,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
+msgstr ""
+"Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25327,8 +25846,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
-"KI-modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
+"modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25336,8 +25855,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
-"KI-modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
+"modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25429,7 +25948,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
+msgstr ""
+"Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25458,8 +25978,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure "
-"Hash-algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
+"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure Hash-"
+"algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
 "instellingslêer verlaat jou blaaier. Ons stoor die instellingslêer deur die "
 "sleutel as naam te gebruik. DuckDuckGo ken nooit jou kenfrase nie."
 
@@ -25696,7 +26216,8 @@ msgstr "deur %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
+msgstr ""
+"deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
@@ -43,6 +43,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -393,6 +400,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -627,6 +640,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1180,6 +1198,11 @@ msgstr "%s إضافة إلى"
 msgid "Add to Home Screen"
 msgstr "إضافة إلى الشاشة الرئيسية"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Translate 'Add-ons' into Arabic in Algeria"
@@ -1470,6 +1493,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1880,6 +1909,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4194,6 +4228,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4226,6 +4265,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4786,6 +4844,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4794,6 +4859,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5000,6 +5072,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5649,6 +5727,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6315,9 +6399,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7408,6 +7505,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7492,6 +7596,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9082,6 +9191,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9599,6 +9713,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9804,6 +9924,11 @@ msgstr "القائمة"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10106,6 +10231,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10263,6 +10393,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "أحمر مصمت"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11140,6 +11275,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11748,6 +11904,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11756,6 +11917,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11800,6 +11966,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12814,6 +12992,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12963,6 +13146,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13170,6 +13358,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13203,6 +13396,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13751,6 +13954,11 @@ msgstr "احفظ اعداداتك بسرية في السحابة"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14519,6 +14727,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14643,6 +14857,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14762,6 +14983,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15309,6 +15540,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15998,6 +16234,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16197,6 +16438,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16221,6 +16468,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16674,6 +16926,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16742,6 +17008,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16825,6 +17096,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17339,6 +17620,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17431,6 +17717,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17630,6 +17921,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17638,6 +17934,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18015,6 +18316,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18042,6 +18348,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18810,6 +19121,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18844,6 +19162,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18868,6 +19193,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19112,6 +19444,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19574,6 +19911,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19974,6 +20318,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20138,6 +20488,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20155,6 +20520,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/ar_EG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_EG/LC_MESSAGES/duckduckgo.po
@@ -43,6 +43,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -393,6 +400,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -627,6 +640,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1182,6 +1200,11 @@ msgstr "%s اضف إلى"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "إضافات"
@@ -1472,6 +1495,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1884,6 +1913,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4201,6 +4235,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4233,6 +4272,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4793,6 +4851,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4801,6 +4866,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5007,6 +5079,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5656,6 +5734,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #  Marked fuzzy because of translated trademark
@@ -6334,9 +6418,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7429,6 +7526,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7513,6 +7617,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9104,6 +9213,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "اعرف %sالمزيد%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9621,6 +9735,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9826,6 +9946,11 @@ msgstr "القائمة"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10128,6 +10253,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "المزيد في"
@@ -10285,6 +10415,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "أحمر خفيف"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11162,6 +11297,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11768,6 +11924,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11776,6 +11937,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11820,6 +11986,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12834,6 +13012,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12983,6 +13166,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13190,6 +13378,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13223,6 +13416,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13771,6 +13974,11 @@ msgstr "احفظ اعداداتك بسرية في السحابة"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14541,6 +14749,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14665,6 +14879,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14784,6 +15005,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15331,6 +15562,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16020,6 +16256,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16217,6 +16458,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16242,6 +16489,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "تلفزيون"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16694,6 +16946,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16762,6 +17028,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16845,6 +17116,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17359,6 +17640,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17451,6 +17737,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17650,6 +17941,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17658,6 +17954,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18035,6 +18336,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18062,6 +18368,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18828,6 +19139,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18862,6 +19180,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18886,6 +19211,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19130,6 +19462,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19592,6 +19929,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19994,6 +20338,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20160,6 +20510,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20177,6 +20542,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/ar_JO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_JO/LC_MESSAGES/duckduckgo.po
@@ -43,6 +43,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -393,6 +400,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -627,6 +640,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1182,6 +1200,11 @@ msgstr "أضف إلى %s"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "الاضافات"
@@ -1472,6 +1495,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1882,6 +1911,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4198,6 +4232,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4230,6 +4269,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4790,6 +4848,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4798,6 +4863,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5004,6 +5076,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5653,6 +5731,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #  Marked fuzzy because of translated trademark
@@ -6331,9 +6415,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7424,6 +7521,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7508,6 +7612,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9094,6 +9203,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9611,6 +9725,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9816,6 +9936,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10118,6 +10243,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "المزيد فـ"
@@ -10275,6 +10405,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "الأحمر القاتم"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11152,6 +11287,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11756,6 +11912,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11764,6 +11925,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11808,6 +11974,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12822,6 +13000,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12971,6 +13154,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13178,6 +13366,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13211,6 +13404,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13759,6 +13962,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14525,6 +14733,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14649,6 +14863,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14768,6 +14989,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15315,6 +15546,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16004,6 +16240,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16201,6 +16442,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16225,6 +16472,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16678,6 +16930,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16746,6 +17012,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16829,6 +17100,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17343,6 +17624,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17435,6 +17721,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17634,6 +17925,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17642,6 +17938,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18019,6 +18320,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18046,6 +18352,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18812,6 +19123,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18846,6 +19164,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18870,6 +19195,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19114,6 +19446,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19576,6 +19913,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19977,6 +20321,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20141,6 +20491,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20158,6 +20523,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/ar_SA/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_SA/LC_MESSAGES/duckduckgo.po
@@ -43,6 +43,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -393,6 +400,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -627,6 +640,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1184,6 +1202,11 @@ msgstr "اضف إلى %s"
 msgid "Add to Home Screen"
 msgstr "إضافة إلى الشاشة الرئيسية "
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "إضافات"
@@ -1474,6 +1497,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1884,6 +1913,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4203,6 +4237,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4235,6 +4274,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4795,6 +4853,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4803,6 +4868,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5009,6 +5081,12 @@ msgstr "رفض"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5656,6 +5734,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6325,9 +6409,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7419,6 +7516,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7503,6 +7607,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9093,6 +9202,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "اعرف %sالمزيد%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9610,6 +9724,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9815,6 +9935,11 @@ msgstr "القائمة"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10117,6 +10242,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "المزيد في "
@@ -10274,6 +10404,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "أحمر مطفي"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11155,6 +11290,27 @@ msgstr ""
 "في Mac، %sاضغط Maxthon > التفضيلات%s، في Windows، %sاضغط على %s الأيقونة > "
 "الإعدادات%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11762,6 +11918,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11770,6 +11931,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11814,6 +11980,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12828,6 +13006,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12977,6 +13160,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13184,6 +13372,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13217,6 +13410,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13765,6 +13968,11 @@ msgstr "حفظ اعداداتك بشكل مجهول في التخزين السح
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14537,6 +14745,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14661,6 +14875,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14780,6 +15001,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15327,6 +15558,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16016,6 +16252,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16215,6 +16456,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16240,6 +16487,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "التلفاز"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16692,6 +16944,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16760,6 +17026,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16843,6 +17114,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17357,6 +17638,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17449,6 +17735,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17648,6 +17939,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17656,6 +17952,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18037,6 +18338,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18064,6 +18370,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18832,6 +19143,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18866,6 +19184,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18890,6 +19215,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19134,6 +19466,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19598,6 +19935,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20000,6 +20344,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20166,6 +20516,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20183,6 +20548,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/ast_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ast_ES/LC_MESSAGES/duckduckgo.po
@@ -37,6 +37,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -387,6 +394,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -621,6 +634,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1176,6 +1194,11 @@ msgstr "Añádilu a %s"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Complementos"
@@ -1466,6 +1489,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1876,6 +1905,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4193,6 +4227,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4225,6 +4264,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4785,6 +4843,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4793,6 +4858,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -4999,6 +5071,12 @@ msgstr "Escartar"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5646,6 +5724,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6308,9 +6392,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7401,6 +7498,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7485,6 +7589,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9071,6 +9180,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Deprendi %smás%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9588,6 +9702,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9794,6 +9914,11 @@ msgstr "Menú"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menú"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10095,6 +10220,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Más en"
@@ -10251,6 +10381,11 @@ msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
+msgstr ""
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
 msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -11129,6 +11264,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11737,6 +11893,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11745,6 +11906,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11789,6 +11955,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12803,6 +12981,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12952,6 +13135,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13159,6 +13347,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13192,6 +13385,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13740,6 +13943,11 @@ msgstr "Guarda los tos axustes anónimamente na ñube"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14504,6 +14712,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14628,6 +14842,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14748,6 +14969,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15295,6 +15526,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15984,6 +16220,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16181,6 +16422,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16205,6 +16452,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16658,6 +16910,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16726,6 +16992,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16809,6 +17080,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17323,6 +17604,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17415,6 +17701,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17614,6 +17905,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17622,6 +17918,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -17999,6 +18300,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18026,6 +18332,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18792,6 +19103,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18826,6 +19144,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18850,6 +19175,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19094,6 +19426,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19556,6 +19893,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19958,6 +20302,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20124,6 +20474,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube Standard"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20141,6 +20506,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/az_AZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/az_AZ/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "%s səyyahına əlavə et"
 msgid "Add to Home Screen"
 msgstr "Əsas ekrana əlavə edin"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Əlavələr"
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1882,6 +1911,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4201,6 +4235,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4233,6 +4272,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4793,6 +4851,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4801,6 +4866,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5007,6 +5079,12 @@ msgstr "Çıxarın"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5654,6 +5732,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6316,9 +6400,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7411,6 +7508,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7495,6 +7599,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9085,6 +9194,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "%sƏtraflı%s Öyrən"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9602,6 +9716,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9807,6 +9927,11 @@ msgstr "Menyu"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10109,6 +10234,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Daha çox "
@@ -10266,6 +10396,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Qırmızı"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11143,6 +11278,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11753,6 +11909,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11761,6 +11922,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11805,6 +11971,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12819,6 +12997,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12968,6 +13151,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13175,6 +13363,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13208,6 +13401,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13756,6 +13959,11 @@ msgstr "Parametrlərinizi buluda anonim olaraq saxlayın "
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14522,6 +14730,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14646,6 +14860,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14766,6 +14987,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15313,6 +15544,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16002,6 +16238,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16199,6 +16440,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16223,6 +16470,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16676,6 +16928,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16744,6 +17010,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16827,6 +17098,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17341,6 +17622,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17433,6 +17719,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17632,6 +17923,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17640,6 +17936,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18019,6 +18320,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18046,6 +18352,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18814,6 +19125,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18848,6 +19166,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18872,6 +19197,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19116,6 +19448,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19579,6 +19916,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19983,6 +20327,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20150,6 +20500,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20167,6 +20532,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: be_BY\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -49,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Гэта прылада)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -308,8 +307,7 @@ msgstr "Рэйтынгі %1$s яшчэ недаступныя"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s дасягае лімітаў выкарыстання ў 2-5 разоў хутчэй за базавыя мадэлі. %2$s"
+msgstr "%1$s дасягае лімітаў выкарыстання ў 2-5 разоў хутчэй за базавыя мадэлі. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -494,15 +492,15 @@ msgstr "%1$sДаведацца больш%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага месцазнаходжання."
-"%2$s"
+"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага "
+"месцазнаходжання.%2$s"
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sДаведацца больш%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -525,8 +523,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
+msgstr "%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -801,7 +798,7 @@ msgstr "2-е месца ў групе %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2-е меркаванне"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1074,10 +1071,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "У цяперашні час ў адказах з дапамогай штучнага інтэлекту не падтрымліваюцца "
-"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс %1$sDuck."
-"ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш прыватны "
-"чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад OpenAI, "
-"Anthropic і іншых."
+"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс "
+"%1$sDuck.ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш "
+"прыватны чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад "
+"OpenAI, Anthropic і іншых."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1491,7 +1488,7 @@ msgstr "Дадаць на хатні экран"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Дадаць у «Мае чаты»"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1819,8 +1816,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
+msgstr "Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1861,7 +1857,7 @@ msgstr "Усе тыпы"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Усе вашы прылады адключаны ад Cінхранізацыі."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1950,8 +1946,7 @@ msgstr "Ужо сінхранізавана."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
+msgstr "Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2253,8 +2248,7 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr ""
-"Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
+msgstr "Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2388,7 +2382,7 @@ msgstr "Спытайце прыватна што хочаце"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Спытайце прыватна што хочаце"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -3012,8 +3006,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
+msgstr "Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3775,8 +3768,7 @@ msgstr "Змяняе колер фону на ўсім сайце"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
+msgstr "Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3909,8 +3901,8 @@ msgstr ""
 "мадэлямі чата на базе штучнага інтэлекту, якімі падтрымліваюцца мадэлі "
 "OpenAI, Anthropic і іншыя. Адключэнне гэтай налады схавае кнопкі і спасылкі "
 "чата ў DuckDuckGo Search. Тым не менш, можна атрымаць доступ да чата, калі "
-"гэты параметр выключаны. Для гэтага трэба перайсці на сайт %1$shttps://duck."
-"ai%2$s ."
+"гэты параметр выключаны. Для гэтага трэба перайсці на сайт "
+"%1$shttps://duck.ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3975,8 +3967,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі Duck."
-"ai ў нашым бясплатным браўзеры."
+"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі "
+"Duck.ai ў нашым бясплатным браўзеры."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4156,8 +4148,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
+msgstr "Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4222,8 +4213,7 @@ msgstr "Выбар мадэляў штучнага інтэлекту, у тым
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
+msgstr "Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4643,8 +4633,7 @@ msgstr "Націсніце на %1$sПастаўшчыкі пошуку%2$s па
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
+msgstr "Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -5338,7 +5327,7 @@ msgstr "Капіраваць"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Капіраваць"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5387,13 +5376,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Скапіраваць абагуленую спасылку"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Скапіруйце код з іншай прылады"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5402,6 +5391,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Скапіруйце код з іншай прылады. Перайдзіце ў %1$sНалады Duck.ai › Чаты › "
+"Sync & Backup › Сінхранізацыя з іншай прыладай%2$s і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6090,7 +6081,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Выдаліць абагуленую спасылку"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6111,6 +6102,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Выдаленне спасылкі спыняе яе працу. Людзі, якія адкрылі яе і дадалі размову "
+"ў свае чаты, захаваюць уласную копію."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6373,7 +6366,7 @@ msgstr "Адхіліць"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Адхіліць"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -7017,8 +7010,7 @@ msgstr "Duck.ai абноўлены!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
+msgstr "Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7028,10 +7020,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны AI-"
-"чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI з "
-"адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без уліковага "
-"запісу"
+"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны "
+"AI-чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI "
+"з адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без "
+"уліковага запісу"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7197,8 +7189,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
+msgstr "DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7237,7 +7228,7 @@ msgstr "Браўзер DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Старонкі даведкі DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7854,8 +7845,7 @@ msgstr "Падабаецца Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7867,22 +7857,19 @@ msgstr "Упэўніцеся, што %1$sўключана%2$s налада \"С�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7900,8 +7887,7 @@ msgstr "Упэўніцеся, што %1$sдазволены%2$s доступ д�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
+msgstr "Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8015,8 +8001,7 @@ msgstr "Экватарыяльная Гвінея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
+msgstr "Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8076,15 +8061,14 @@ msgstr "Разгарнуць карту"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
+msgstr "Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Скончыўся тэрмін дзеяння"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8098,7 +8082,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Тэрмін дзеяння заканчваецца %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8459,8 +8443,7 @@ msgstr "Фільтры неэфектыўныя"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
+msgstr "Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8772,8 +8755,7 @@ msgstr "Можна абагульваць і выкарыстоўваць у к�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
+msgstr "Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9336,8 +9318,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
+msgstr "У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9397,8 +9378,7 @@ msgstr "Атрымаць гэту песню на:"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr ""
-"Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
+msgstr "Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
 
 # smartling.placeholder_format=C
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
@@ -9481,6 +9461,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Перайдзіце ў меню %1$sНалады Duck.ai%2$s › %3$sЧаты › Sync & Backup › "
+"Сінхранізацыя з іншай прыладай%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9597,7 +9579,7 @@ msgstr "Зразумела"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Зразумела"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10408,8 +10390,7 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
+msgstr "Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -11582,7 +11563,7 @@ msgstr "Даведацца %1$sбольш%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Даведацца больш"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11759,8 +11740,7 @@ msgstr "Дазваляе вам шукаць ананімна з дапамог�
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Дазваляе пераключацца паміж адпраўкай пошукавых запытаў і падказак у Duck.ai"
+msgstr "Дазваляе пераключацца паміж адпраўкай пошукавых запытаў і падказак у Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12149,8 +12129,7 @@ msgstr "Пераканайцеся, што ўсе словы напісаны п
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
+msgstr "Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12222,7 +12201,7 @@ msgstr "Кіраваць"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Кіраваць"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12479,7 +12458,7 @@ msgstr "Меню"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Паведамленні далей бачныя толькі вам."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12855,7 +12834,7 @@ msgstr "Падрабязней пра Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Больш дзеянняў"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13055,7 +13034,7 @@ msgstr "Прыглушаны зялёны"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Мае прылады"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13615,8 +13594,7 @@ msgstr "Вынікі не знойдзены."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
+msgstr "Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14085,8 +14063,7 @@ msgstr "Аман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
+msgstr "Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14134,6 +14111,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"На іншай прыладзе перайдзіце ў меню %1$sНалады Duck.ai%2$s › %3$sЧаты › Sync "
+"& Backup › Сінхранізацыя з іншай прыладай%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14142,6 +14121,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"На іншай прыладзе перайдзіце ў меню %1$sНалады Duck.ai%2$s › %3$sЧаты › Sync "
+"& Backup › Сінхранізацыя з іншай прыладай%4$s і адсканіруйце гэты код:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14150,6 +14131,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"На іншай прыладзе перайдзіце ў меню %1$sНалады Duck.ai%2$s › %3$sЧаты › Sync "
+"& Backup › Сінхранізацыя з іншай прыладай%4$s. Або адсканіруйце QR-код у "
+"вашым PDF-файле аднаўлення."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14909,7 +14893,7 @@ msgstr "За год"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Уставіць"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14927,7 +14911,7 @@ msgstr "Уставіць код сінхранізацыі"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Устаўце яго ніжэй"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14986,7 +14970,7 @@ msgstr "Персідская"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14995,6 +14979,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Сэрвіс Personal Information Removal знаходзіць вашу інфармацыю на сайтах "
+"брокераў даных, якія прадаюць яе. Затым мы працуем над тым, каб выдаліць яе "
+"за вас."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15248,8 +15235,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
+msgstr "Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15257,8 +15243,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
+msgstr "Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15286,8 +15271,7 @@ msgstr "Калі ласка, увядзіце кодавую фразу"
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
 msgctxt "Description for the wrong code error screen"
 msgid "Please make sure the correct code was entered or scanned."
-msgstr ""
-"Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
+msgstr "Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
 
 # smartling.placeholder_format=C
 #. Disclaimer text displayed in a modal that informs the user that starting a new chat with any AI model will delete their current chat session.
@@ -16265,7 +16249,7 @@ msgstr "Чытанне вэб-сайта..."
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Гатовыя да сонечнага зацьмення?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16464,7 +16448,7 @@ msgstr "Код аднаўлення"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Код аднаўлення"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16674,8 +16658,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку &quot;"
-"Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
+"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку "
+"&quot;Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16721,7 +16705,7 @@ msgstr "Выдаліць %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Выдаліць прыладу"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16769,13 +16753,13 @@ msgstr "Выдаліце непатрэбныя знакі прыпынку"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Выдаліце свае даныя з інтэрнэту"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Выдаліце свае даныя ў інтэрнэце"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17221,8 +17205,7 @@ msgstr "SE"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
+msgstr "Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -17475,7 +17458,7 @@ msgstr "Прывітайце Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Прывітайце Duck.ai – бясплатны, прыватны чат з AI ад DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17789,8 +17772,7 @@ msgstr "Бачнасць пошуку"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
+msgstr "Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -17865,8 +17847,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць POST-"
-"запыты)"
+"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць "
+"POST-запыты)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18154,8 +18136,7 @@ msgstr "Паглядзіце апошнія абнаўленні"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
+msgstr "Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18234,8 +18215,7 @@ msgstr "Выберыце %1$sDuckDuckGo%2$s у спісе сайтаў пошу�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
+msgstr "Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18416,8 +18396,7 @@ msgstr "Выбраны тэкст з %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
+msgstr "Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18489,7 +18468,7 @@ msgstr "Сербская (лацініца)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Даныя сервера выдалены"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18651,7 +18630,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Абагуліць"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18806,13 +18785,13 @@ msgstr "Падзяліся сваім меркаваннем пра пошука
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Абагуленыя спасылкі на чаты"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Абагуленыя спасылкі на чаты"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19348,8 +19327,7 @@ msgstr "Пошук па сайце часова недаступны. Мы пр�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
+msgstr "Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19496,14 +19474,13 @@ msgstr "Адбылася памылка"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Адбылася памылка пры загрузцы гэтага супольнага чата."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
+msgstr "Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19882,15 +19859,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20023,8 +19998,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў Duck."
-"ai, або вярніцеся пазней, каб стварыць больш відарысаў."
+"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў "
+"Duck.ai, або вярніцеся пазней, каб стварыць больш відарысаў."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20351,14 +20326,13 @@ msgstr "Пераключыць мадэль"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Пераключыць мадэль"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr ""
-"Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
+msgstr "Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -20616,7 +20590,7 @@ msgstr "Сінхранізаваныя прылады"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Сінхранізавана %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20654,7 +20628,7 @@ msgstr "ТБ"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Табліца"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -21244,7 +21218,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Гэтая прылада"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21255,6 +21229,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Гэтая прылада больш не зможа атрымаць доступ да вашых сінхранізаваных даных "
+"на іншых прыладах. Апошнія %1$s чатаў застануцца даступнымі ў лакальным "
+"сховішчы."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21343,7 +21320,7 @@ msgstr "Гэтыя звесткі не карысныя"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Гэта копія абагуленага чата."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21413,8 +21390,7 @@ msgstr "Для работы гэтай старонкі патрабуецца J
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
+msgstr "Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21467,13 +21443,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Не ўдалося адкрыць гэты абагулены чат. Магчыма, спасылка няпоўная."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Гэтая спасылка на абагулены чат больш недаступная."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21496,15 +21472,13 @@ msgstr "Гэты пераклад няправільны"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
+msgstr "Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
+msgstr "На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21643,8 +21617,7 @@ msgstr "Падкрэсліванне загалоўка"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
+msgstr "Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -21669,8 +21642,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны маршрут."
-"%3$sНацісніце на значок друку.%4$s"
+"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны "
+"маршрут.%3$sНацісніце на значок друку.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21902,8 +21875,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя DuckDuckGo."
-"Спіс будзе абнаўляцца па меры вашага выкарыстання."
+"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя "
+"DuckDuckGo.Спіс будзе абнаўляцца па меры вашага выкарыстання."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22127,7 +22100,7 @@ msgstr "Паспрабаваць бясплатна"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Паспрабуйце бясплатна!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22217,16 +22190,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
+msgstr "Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
+msgstr "Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22250,7 +22221,7 @@ msgstr "Паспрабуйце бясплатна"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Паспрабуйце бясплатна!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22319,8 +22290,7 @@ msgstr "Паспрабуйце наш браўзер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
+msgstr "Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22401,15 +22371,13 @@ msgstr "Паспрабуйце новы прыватны галасавы чат
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
+msgstr "Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
+msgstr "Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -22503,7 +22471,7 @@ msgstr "Туркменістан"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Адключыць"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22521,7 +22489,7 @@ msgstr "Адключыць Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Адключыць Sync & Backup і выдаліць даныя сервера?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22836,8 +22804,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі сістэмамі..."
-"%4$s"
+"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі "
+"сістэмамі...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22961,15 +22929,13 @@ msgstr ""
 msgctxt ""
 "Text that shows users they can unlock advanced AI models with a subscription."
 msgid "Unlock advanced AI models with a %s"
-msgstr ""
-"Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
+msgstr "Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
 
 # smartling.placeholder_format=C
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
+msgstr "Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -22987,8 +22953,7 @@ msgstr "Разблакіраваць перадавыя мадэлі"
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
+msgstr "Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -23016,7 +22981,7 @@ msgstr "Уключыць гук"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Чат без назвы"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23057,7 +23022,7 @@ msgstr "Абнавіць браўзер"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Абнавіце Duck.ai, каб праглядзець гэты абагулены чат."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23229,8 +23194,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
+msgstr "Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23340,8 +23304,7 @@ msgstr "Выкарыстаць прыватны пошук DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
+msgstr "Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23400,8 +23363,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
+msgstr "Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23604,8 +23566,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады Duck."
-"ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
+"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады "
+"Duck.ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
 "%7$sСінхранізаваць з іншай прыладай%8$s."
 
 # smartling.placeholder_format=C
@@ -23921,8 +23883,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
+msgstr "Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24049,6 +24010,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Мы знаходзім і выдаляем сваю асабістую інфармацыю з сайтаў брокераў даных. "
+"Акрамя таго, атрымайце VPN і многае іншае."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24104,6 +24067,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Мы рэгулярна скануем сайты брокераў даных у пошуках вашай асабістай "
+"інфармацыі і дзелімся з вамі прагрэсам у зручнай панэлі кіравання."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24140,8 +24105,8 @@ msgstr ""
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду вэб-"
-"старонак."
+"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду "
+"вэб-старонак."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24150,6 +24115,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Мы праскануем сайты брокераў даных на наяўнасць вашага адраса электроннай "
+"пошты, імя, адраса і іншых даных і папрацуем над тым, каб выдаліць усё, што "
+"знойдзем пра вас."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24183,8 +24151,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
+msgstr "Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24444,8 +24411,7 @@ msgstr "Якія фактары варта ўлічваць пры куплі м
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
+msgstr "Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24453,8 +24419,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
+msgstr "Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24466,7 +24431,7 @@ msgstr "Якія плюсы і мінусы аблігацый?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Якія перавагі Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -25046,6 +25011,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Працуе непасрэдна з вашай прылады, каб выдаляць адрас электроннай пошты, "
+"імя, адрас і іншыя даныя з сайтаў брокераў даных."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25549,7 +25516,7 @@ msgstr "Засталося спроб: 1."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "У вас няма абагуленых спасылак на чат."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25711,16 +25678,14 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
+msgstr "Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
+msgstr "Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25785,13 +25750,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Вашы апошнія чаты (%1$s) будуць даступныя ў лакальным сховішчы ў наступных "
+"браўзерах:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Вашы чаты Duck.ai сінхранізуюцца са скразным шыфраваннем."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25823,6 +25790,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Ваша рэзервовая копія будзе выдалена з сервера DuckDuckGo. Усе прылады "
+"будуць адключаны ад сінхранізацыі."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25975,8 +25944,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у Duck."
-"ai."
+"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: be_BY\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -41,6 +42,14 @@ msgstr "% поўнасцю вакцынаваных"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% вакцынаваных"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -299,7 +308,8 @@ msgstr "Рэйтынгі %1$s яшчэ недаступныя"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s дасягае лімітаў выкарыстання ў 2-5 разоў хутчэй за базавыя мадэлі. %2$s"
+msgstr ""
+"%1$s дасягае лімітаў выкарыстання ў 2-5 разоў хутчэй за базавыя мадэлі. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -484,8 +494,15 @@ msgstr "%1$sДаведацца больш%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага "
-"месцазнаходжання.%2$s"
+"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага месцазнаходжання."
+"%2$s"
+
+# smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -508,7 +525,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
+msgstr ""
+"%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -778,6 +796,12 @@ msgstr "Ачкі з 2-й падачы"
 msgctxt "Sports module"
 msgid "2nd in Group %s"
 msgstr "2-е месца ў групе %1$s"
+
+# smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1050,10 +1074,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "У цяперашні час ў адказах з дапамогай штучнага інтэлекту не падтрымліваюцца "
-"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс "
-"%1$sDuck.ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш "
-"прыватны чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад "
-"OpenAI, Anthropic і іншых."
+"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс %1$sDuck."
+"ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш прыватны "
+"чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад OpenAI, "
+"Anthropic і іншых."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1464,6 +1488,12 @@ msgid "Add to Home Screen"
 msgstr "Дадаць на хатні экран"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Дадаткі"
@@ -1789,7 +1819,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
+msgstr ""
+"Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1824,6 +1855,13 @@ msgstr "Усе памеры"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Усе тыпы"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1912,7 +1950,8 @@ msgstr "Ужо сінхранізавана."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
+msgstr ""
+"Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2214,7 +2253,8 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr "Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
+msgstr ""
+"Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2343,6 +2383,12 @@ msgstr "Спытайцеся пра гэту старонку"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask anything privately"
 msgstr "Спытайце прыватна што хочаце"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2966,7 +3012,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
+msgstr ""
+"Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3728,7 +3775,8 @@ msgstr "Змяняе колер фону на ўсім сайце"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
+msgstr ""
+"Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3861,8 +3909,8 @@ msgstr ""
 "мадэлямі чата на базе штучнага інтэлекту, якімі падтрымліваюцца мадэлі "
 "OpenAI, Anthropic і іншыя. Адключэнне гэтай налады схавае кнопкі і спасылкі "
 "чата ў DuckDuckGo Search. Тым не менш, можна атрымаць доступ да чата, калі "
-"гэты параметр выключаны. Для гэтага трэба перайсці на сайт "
-"%1$shttps://duck.ai%2$s ."
+"гэты параметр выключаны. Для гэтага трэба перайсці на сайт %1$shttps://duck."
+"ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3927,8 +3975,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі "
-"Duck.ai ў нашым бясплатным браўзеры."
+"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі Duck."
+"ai ў нашым бясплатным браўзеры."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4108,7 +4156,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
+msgstr ""
+"Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4173,7 +4222,8 @@ msgstr "Выбар мадэляў штучнага інтэлекту, у тым
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
+msgstr ""
+"Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4593,7 +4643,8 @@ msgstr "Націсніце на %1$sПастаўшчыкі пошуку%2$s па
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
+msgstr ""
+"Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -5284,6 +5335,12 @@ msgid "Copy"
 msgstr "Капіраваць"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5323,6 +5380,28 @@ msgstr "Скапіруйце або захавайце гэты код"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Скапіраваць код аднаўлення"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6006,6 +6085,14 @@ msgid "Delete recent chats?"
 msgstr "Выдаліць апошнія чаты?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6016,6 +6103,14 @@ msgstr "Выдаліць гэты чат?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Выдаленыя чаты"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6272,6 +6367,13 @@ msgstr "Адхіліць"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Адхіліць"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6915,7 +7017,8 @@ msgstr "Duck.ai абноўлены!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
+msgstr ""
+"Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6925,10 +7028,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны "
-"AI-чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI "
-"з адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без "
-"уліковага запісу"
+"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны AI-"
+"чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI з "
+"адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без уліковага "
+"запісу"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7094,7 +7197,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
+msgstr ""
+"DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7127,6 +7231,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Браўзер DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7743,7 +7854,8 @@ msgstr "Падабаецца Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7755,19 +7867,22 @@ msgstr "Упэўніцеся, што %1$sўключана%2$s налада \"С�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7785,7 +7900,8 @@ msgstr "Упэўніцеся, што %1$sдазволены%2$s доступ д�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
+msgstr ""
+"Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7899,7 +8015,8 @@ msgstr "Экватарыяльная Гвінея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
+msgstr ""
+"Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7959,13 +8076,29 @@ msgstr "Разгарнуць карту"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
+msgstr ""
+"Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
+
+# smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Скончыўся тэрмін дзеяння"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8326,7 +8459,8 @@ msgstr "Фільтры неэфектыўныя"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
+msgstr ""
+"Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8638,7 +8772,8 @@ msgstr "Можна абагульваць і выкарыстоўваць у к�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
+msgstr ""
+"Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9201,7 +9336,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
+msgstr ""
+"У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9261,7 +9397,8 @@ msgstr "Атрымаць гэту песню на:"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr "Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
+msgstr ""
+"Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
 
 # smartling.placeholder_format=C
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
@@ -9336,6 +9473,14 @@ msgstr ""
 "Перайдзіце ў %1$sНалады Duck.ai%2$s у іншым браўзеры або ў праграме "
 "DuckDuckGo, адкрыйце %3$sЧаты › Sync & Backup › Сінхранізацыя з іншай "
 "прыладай%4$s. Або адсканіруйце QR-код у вашым PDF-файле для аднаўлення."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9447,6 +9592,12 @@ msgstr "Зразумела"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Зразумела"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10257,7 +10408,8 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
+msgstr ""
+"Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -11427,6 +11579,12 @@ msgid "Learn %sMore%s"
 msgstr "Даведацца %1$sбольш%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11601,7 +11759,8 @@ msgstr "Дазваляе вам шукаць ананімна з дапамог�
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Дазваляе пераключацца паміж адпраўкай пошукавых запытаў і падказак у Duck.ai"
+msgstr ""
+"Дазваляе пераключацца паміж адпраўкай пошукавых запытаў і падказак у Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11990,7 +12149,8 @@ msgstr "Пераканайцеся, што ўсе словы напісаны п
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
+msgstr ""
+"Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12056,6 +12216,13 @@ msgstr "Шкоднае праграмнае забеспячэнне"
 #. Text for generic link to send the user to a page to manage their settings.
 msgid "Manage"
 msgstr "Кіраваць"
+
+# smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12307,6 +12474,12 @@ msgstr "Меню"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Меню"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12679,6 +12852,12 @@ msgid "More about Duck.ai"
 msgstr "Падрабязней пра Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Больш на"
@@ -12871,6 +13050,12 @@ msgstr "Гук выключаны"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Прыглушаны зялёны"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13430,7 +13615,8 @@ msgstr "Вынікі не знойдзены."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
+msgstr ""
+"Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13899,7 +14085,8 @@ msgstr "Аман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
+msgstr ""
+"Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13939,6 +14126,30 @@ msgid ""
 msgstr ""
 "На Mac, %1$sнацісніце Maxthon > Параметры%2$s; у Windows, %3$sНацісніце "
 "значок %4$s > Налады%5$s"
+
+# smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14695,6 +14906,12 @@ msgid "Past year"
 msgstr "За год"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14705,6 +14922,12 @@ msgstr "Уставіць"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Уставіць код сінхранізацыі"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14758,6 +14981,20 @@ msgstr "Пастаянна зачынена"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Персідская"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15011,7 +15248,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
+msgstr ""
+"Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15019,7 +15257,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
+msgstr ""
+"Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15047,7 +15286,8 @@ msgstr "Калі ласка, увядзіце кодавую фразу"
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
 msgctxt "Description for the wrong code error screen"
 msgid "Please make sure the correct code was entered or scanned."
-msgstr "Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
+msgstr ""
+"Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
 
 # smartling.placeholder_format=C
 #. Disclaimer text displayed in a modal that informs the user that starting a new chat with any AI model will delete their current chat session.
@@ -16022,6 +16262,12 @@ msgid "Reading website…"
 msgstr "Чытанне вэб-сайта..."
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16213,6 +16459,12 @@ msgstr "Аднаўленне"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Код аднаўлення"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16422,8 +16674,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку "
-"&quot;Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
+"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку &quot;"
+"Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16466,6 +16718,12 @@ msgid "Remove %s"
 msgstr "Выдаліць %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16506,6 +16764,18 @@ msgstr "Выдаліць выбраны тэкст"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Выдаліце непатрэбныя знакі прыпынку"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16951,7 +17221,8 @@ msgstr "SE"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr "Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
+msgstr ""
+"Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -17199,6 +17470,12 @@ msgstr "Захавайце свае налады ананімна ў вобла�
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Прывітайце Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17512,7 +17789,8 @@ msgstr "Бачнасць пошуку"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr "Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
+msgstr ""
+"Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -17587,8 +17865,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць "
-"POST-запыты)"
+"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць POST-"
+"запыты)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17876,7 +18154,8 @@ msgstr "Паглядзіце апошнія абнаўленні"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
+msgstr ""
+"Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17955,7 +18234,8 @@ msgstr "Выберыце %1$sDuckDuckGo%2$s у спісе сайтаў пошу�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
+msgstr ""
+"Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18136,7 +18416,8 @@ msgstr "Выбраны тэкст з %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
+msgstr ""
+"Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18202,6 +18483,13 @@ msgstr "Сербская (кірыліца)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Сербская (лацініца)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18358,6 +18646,14 @@ msgid "Share"
 msgstr "Абагуліць"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18505,6 +18801,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Падзяліся сваім меркаваннем пра пошукавы радок."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19040,7 +19348,8 @@ msgstr "Пошук па сайце часова недаступны. Мы пр�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
+msgstr ""
+"Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19184,10 +19493,17 @@ msgid "Something went wrong"
 msgstr "Адбылася памылка"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
+msgstr ""
+"Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19566,13 +19882,15 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr ""
+"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr ""
+"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19705,8 +20023,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў "
-"Duck.ai, або вярніцеся пазней, каб стварыць больш відарысаў."
+"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў Duck."
+"ai, або вярніцеся пазней, каб стварыць больш відарысаў."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20030,10 +20348,17 @@ msgid "Switch model"
 msgstr "Пераключыць мадэль"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr "Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
+msgstr ""
+"Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -20287,6 +20612,13 @@ msgid "Synced Devices"
 msgstr "Сінхранізаваныя прылады"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Сірыя"
 
@@ -20317,6 +20649,12 @@ msgstr "TBD"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "ТБ"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20903,6 +21241,22 @@ msgstr ""
 "%4$s)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20986,6 +21340,12 @@ msgid "This information isn’t useful"
 msgstr "Гэтыя звесткі не карысныя"
 
 # smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
@@ -21053,7 +21413,8 @@ msgstr "Для работы гэтай старонкі патрабуецца J
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
+msgstr ""
+"Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21103,6 +21464,18 @@ msgstr ""
 "паказваюцца такія адказы: %1$s."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21123,13 +21496,15 @@ msgstr "Гэты пераклад няправільны"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
+msgstr ""
+"Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
+msgstr ""
+"На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21268,7 +21643,8 @@ msgstr "Падкрэсліванне загалоўка"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr "Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
+msgstr ""
+"Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -21293,8 +21669,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны "
-"маршрут.%3$sНацісніце на значок друку.%4$s"
+"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны маршрут."
+"%3$sНацісніце на значок друку.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21526,8 +21902,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя "
-"DuckDuckGo.Спіс будзе абнаўляцца па меры вашага выкарыстання."
+"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя DuckDuckGo."
+"Спіс будзе абнаўляцца па меры вашага выкарыстання."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21748,6 +22124,12 @@ msgid "Try Free"
 msgstr "Паспрабаваць бясплатна"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21835,14 +22217,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
+msgstr ""
+"Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
+msgstr ""
+"Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21861,6 +22245,12 @@ msgstr "Паспрабуйце бясплатна"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Паспрабуйце бясплатна"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21929,7 +22319,8 @@ msgstr "Паспрабуйце наш браўзер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
+msgstr ""
+"Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22010,13 +22401,15 @@ msgstr "Паспрабуйце новы прыватны галасавы чат
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr "Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
+msgstr ""
+"Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr "Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
+msgstr ""
+"Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -22107,6 +22500,12 @@ msgid "Turkmenistan"
 msgstr "Туркменістан"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22117,6 +22516,12 @@ msgstr "Адключыць Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Адключыць Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22431,8 +22836,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі "
-"сістэмамі...%4$s"
+"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі сістэмамі..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22556,13 +22961,15 @@ msgstr ""
 msgctxt ""
 "Text that shows users they can unlock advanced AI models with a subscription."
 msgid "Unlock advanced AI models with a %s"
-msgstr "Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
+msgstr ""
+"Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
 
 # smartling.placeholder_format=C
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr "Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
+msgstr ""
+"Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -22580,7 +22987,8 @@ msgstr "Разблакіраваць перадавыя мадэлі"
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr "Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
+msgstr ""
+"Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -22603,6 +23011,12 @@ msgstr "Разблакіраваць прэміяльныя сродкі аба�
 msgctxt "voice chat"
 msgid "Unmute"
 msgstr "Уключыць гук"
+
+# smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22638,6 +23052,12 @@ msgstr "Абнавіць"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Абнавіць браўзер"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22809,7 +23229,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
+msgstr ""
+"Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22919,7 +23340,8 @@ msgstr "Выкарыстаць прыватны пошук DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
+msgstr ""
+"Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22978,7 +23400,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
+msgstr ""
+"Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23181,8 +23604,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады "
-"Duck.ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
+"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады Duck."
+"ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
 "%7$sСінхранізаваць з іншай прыладай%8$s."
 
 # smartling.placeholder_format=C
@@ -23498,7 +23921,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
+msgstr ""
+"Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23619,6 +24043,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Мы завяршылі чат з-за неактыўнасці. Хочаце паспрабаваць зноў?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23666,6 +24098,14 @@ msgstr ""
 "адключыць гэту функцыю."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23700,8 +24140,16 @@ msgstr ""
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду "
-"вэб-старонак."
+"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду вэб-"
+"старонак."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23735,7 +24183,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
+msgstr ""
+"Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23995,7 +24444,8 @@ msgstr "Якія фактары варта ўлічваць пры куплі м
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
+msgstr ""
+"Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24003,13 +24453,20 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
+msgstr ""
+"Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Якія плюсы і мінусы аблігацый?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24583,6 +25040,14 @@ msgid "Without zero provider visibility"
 msgstr "Без рэжыму максімальнай прыватнасці"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -25080,6 +25545,13 @@ msgid "You have 1 attempt left."
 msgstr "Засталося спроб: 1."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25239,14 +25711,16 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
+msgstr ""
+"Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
+msgstr ""
+"Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25303,6 +25777,23 @@ msgid "YouTube Standard"
 msgstr "Стандартная ліцэнзія YouTube"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Ваша гісторыя пошуку ў DuckDuckGo застаецца прыватнай"
@@ -25324,6 +25815,14 @@ msgstr "Ваша рэальнае месцазнаходжанне застае�
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Ваша фактычнае месцазнаходжанне застаецца канфідэнцыяльным."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25476,8 +25975,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у "
-"Duck.ai."
+"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: bg_BG\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% напълно ваксинирани"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% ваксинирани"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -300,7 +308,8 @@ msgstr "Класирането на %1$s все още не е налично"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s достига лимитите за ползване 2-5 пъти по-бързо от основните модели. %2$s"
+msgstr ""
+"%1$s достига лимитите за ползване 2-5 пъти по-бързо от основните модели. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -370,7 +379,8 @@ msgstr "%1$s използвани"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s изразходва лимитите почти 2–5 пъти по-бързо от основните модели %2$s"
+msgstr ""
+"%1$s изразходва лимитите почти 2–5 пъти по-бързо от основните модели %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -486,7 +496,15 @@ msgstr "%1$sНаучи повече%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
+msgstr ""
+"%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
+
+# smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -783,6 +801,12 @@ msgid "2nd in Group %s"
 msgstr "2-ро място в група %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -995,8 +1019,8 @@ msgstr ""
 "AI Chat ви позволява да провеждате анонимни разговори с модели за чат с "
 "изкуствен интелект на трети страни. Изключването на това ще скрие функцията "
 "AI Chat в DuckDuckGo Search. Все още можете да получите достъп до AI Chat, "
-"когато тази настройка е изключена, като посетите "
-"%1$sduckduckgo.com/aichat%2$s."
+"когато тази настройка е изключена, като посетите %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1472,6 +1496,12 @@ msgid "Add to Home Screen"
 msgstr "Добавете към Начална страница"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Разширения"
@@ -1573,8 +1603,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"Усъвършенстваните модели могат да достигнат лимитите за ползване 2–5 пъти "
-"по-бързо от другите модели. %1$s"
+"Усъвършенстваните модели могат да достигнат лимитите за ползване 2–5 пъти по-"
+"бързо от другите модели. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1835,6 +1865,13 @@ msgstr "Всички размери"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Всички типове"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2213,7 +2250,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
+msgstr ""
+"Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2360,6 +2398,12 @@ msgstr "Попитай за тази страница"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask anything privately"
 msgstr "Задайте въпрос поверително"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2543,7 +2587,8 @@ msgstr "След приключване на чата аудиото не се �
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
+msgstr ""
+"След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3757,7 +3802,8 @@ msgstr "Променя фоновия цвят, когато курсорът б
 #. Description of a setting managing the color of search result snippet text.
 msgctxt "settings"
 msgid "Changes the color of descriptive content shown for results"
-msgstr "Променя цвета на описателното съдържание, което се показва с резултатите"
+msgstr ""
+"Променя цвета на описателното съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -4120,7 +4166,8 @@ msgstr "Проверете правописа"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
+msgstr ""
+"Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4529,7 +4576,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
+msgstr ""
+"Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4596,7 +4644,8 @@ msgstr "Щракнете върху %1$sБраузър%2$s в странично
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr "Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
+msgstr ""
+"Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4614,7 +4663,8 @@ msgstr "Щракнете върху %1$sТърсачки%2$s под Видове
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
+msgstr ""
+"Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4689,7 +4739,8 @@ msgstr "Щракнете върху %1$sиконата за разрешения
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
+msgstr ""
+"Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5305,6 +5356,12 @@ msgid "Copy"
 msgstr "Копиране"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5313,7 +5370,8 @@ msgstr "Копиране"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
+msgstr ""
+"Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5344,6 +5402,28 @@ msgstr "Копирайте или запазете този код"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Копиране на код за възстановяване"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5395,7 +5475,8 @@ msgstr "Коста Рика"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
+msgstr ""
+"Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6027,6 +6108,14 @@ msgid "Delete recent chats?"
 msgstr "Изтриване на последните чатове?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6037,6 +6126,14 @@ msgstr "Да бъде ли изтрит този чат?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Изтрити чатове"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6233,7 +6330,8 @@ msgstr "Деактивиране и изключване"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
+msgstr ""
+"Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6292,6 +6390,13 @@ msgstr "Отхвърли"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Отхвърляне"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6427,7 +6532,8 @@ msgstr "Не виждате DuckDuckGo в списъка?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
+msgstr ""
+"Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6751,7 +6857,8 @@ msgstr "Условия за ползване на Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
+msgstr ""
+"Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6797,7 +6904,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
+msgstr ""
+"Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6847,7 +6955,8 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
+msgstr ""
+"Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6878,8 +6987,8 @@ msgstr ""
 "интелект на трети страни, включително модели от OpenAI, Anthropic и други. "
 "Ако изключите тази настройка, бутоните и връзките на Duck.ai в DuckDuckGo "
 "Search ще се скрият. Въпреки това можете да получите достъп до Duck.ai, "
-"когато тази настройка е изключена, като посетите директно "
-"%1$shttps://duck.ai%2$s ."
+"когато тази настройка е изключена, като посетите директно %1$shttps://duck."
+"ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7119,8 +7228,8 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
 msgstr ""
-"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново "
-"по-късно."
+"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново по-"
+"късно."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7147,6 +7256,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Браузър DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7771,13 +7887,15 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
+msgstr ""
+"Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
+msgstr ""
+"Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7807,13 +7925,15 @@ msgstr "Уверете се, че достъпът до местоположен
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
+msgstr ""
+"Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr "Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
+msgstr ""
+"Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7919,7 +8039,8 @@ msgstr "Екваториална Гвинея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
+msgstr ""
+"Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7984,10 +8105,25 @@ msgstr ""
 "поверителността."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Изтекъл"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8012,7 +8148,8 @@ msgstr "Обясни приетия отговор с прости думи."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
+msgstr ""
+"Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8090,7 +8227,8 @@ msgstr "Разгледайте Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
+msgstr ""
+"Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8395,7 +8533,8 @@ msgstr "Финансов консултант"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
+msgstr ""
+"Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8630,7 +8769,8 @@ msgstr "Безплатни и поверителни чатове, аноним�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
+msgstr ""
+"Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8876,13 +9016,15 @@ msgstr "Общо предназначение"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr "Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
+msgstr ""
+"Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
+msgstr ""
+"Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -9040,7 +9182,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "Вземете DuckDuckGo VPN, усъвършенстван Duck.ai и Identity Theft Restoration."
+msgstr ""
+"Вземете DuckDuckGo VPN, усъвършенстван Duck.ai и Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9363,10 +9506,19 @@ msgstr ""
 "устройство%4$s. Или сканирайте QR кода в PDF файла за възстановяване."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
+msgstr ""
+"Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9472,6 +9624,12 @@ msgstr "Разбрах"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Разбрах"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10032,7 +10190,8 @@ msgstr "Скриване на Вашия имейл адрес"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
+msgstr ""
+"Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10294,7 +10453,8 @@ msgstr "Колко често искате да виждате отговори�
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr "Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
+msgstr ""
+"Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10432,8 +10592,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри "
-"книги/поредици има, които приличат най-много на нея, и защо?"
+"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри книги/"
+"поредици има, които приличат най-много на нея, и защо?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -11059,7 +11219,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
+msgstr ""
+"Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11109,7 +11270,8 @@ msgstr "Той е бърз, безплатен и осигурява още по
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
+msgstr ""
+"Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11451,6 +11613,12 @@ msgid "Learn %sMore%s"
 msgstr "Научете %1$sОще%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11683,7 +11851,8 @@ msgstr "Ограничено съхранение на данни за този 
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr "Ограничава количеството описателно съдържание, което се показва с резултатите"
+msgstr ""
+"Ограничава количеството описателно съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -11830,7 +11999,8 @@ msgstr "Зареждане на още резултати с изображен�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "При превъртане зарежда повече резултати в изображения, видео и пазаруване"
+msgstr ""
+"При превъртане зарежда повече резултати в изображения, видео и пазаруване"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11859,7 +12029,8 @@ msgstr "Местоположение"
 #. Message informing users that location-based search is private.
 msgctxt "precise_user_location"
 msgid "Location information is stored only on your device."
-msgstr "Информацията за местоположението се съхранява само на вашето устройство."
+msgstr ""
+"Информацията за местоположението се съхранява само на вашето устройство."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -12084,6 +12255,13 @@ msgstr "Зловреден софтуер"
 #. Text for generic link to send the user to a page to manage their settings.
 msgid "Manage"
 msgstr "Управление"
+
+# smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12335,6 +12513,12 @@ msgstr "Меню"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Меню"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12707,6 +12891,12 @@ msgid "More about Duck.ai"
 msgstr "Повече за Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Повече информация в"
@@ -12899,6 +13089,12 @@ msgstr "Заглушен"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Бледочервено"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13970,6 +14166,30 @@ msgstr ""
 "иконата %4$s > Настройки%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14266,7 +14486,8 @@ msgstr "Отваряне на панела Как работи Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
+msgstr ""
+"Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14724,6 +14945,12 @@ msgid "Past year"
 msgstr "Миналата година"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14734,6 +14961,12 @@ msgstr "Поставяне"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Поставяне на код за синхронизация"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14787,6 +15020,20 @@ msgstr "Затворено за постоянно"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Персийски"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14869,9 +15116,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"Ако формулирате своето търсене като въпрос и в пълно изречение, е "
-"по-вероятно DuckAssist да се появи и често допринася за по-добри отговори. "
-"За да настроите как да работи тази функция или да я изключите, отидете на "
+"Ако формулирате своето търсене като въпрос и в пълно изречение, е по-"
+"вероятно DuckAssist да се появи и често допринася за по-добри отговори. За "
+"да настроите как да работи тази функция или да я изключите, отидете на "
 "%1$sНастройки на DuckAssist%2$s."
 
 # smartling.placeholder_format=C
@@ -15000,7 +15247,8 @@ msgstr "Закачени"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Закачените чатове ще се показват най-отгоре в списъка с последни чатове."
+msgstr ""
+"Закачените чатове ще се показват най-отгоре в списъка с последни чатове."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -16052,6 +16300,12 @@ msgid "Reading website…"
 msgstr "Четене на уебсайт…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16092,14 +16346,15 @@ msgstr "С обосновка може да получите по-подробн
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"Обосновката е по-задълбочена, но достига лимитите за ползване 2–5 пъти "
-"по-бързо. %1$s"
+"Обосновката е по-задълбочена, но достига лимитите за ползване 2–5 пъти по-"
+"бързо. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Обосновката е по-задълбочена, но изчерпва лимитите 2-5 пъти по-бързо. %1$s"
+msgstr ""
+"Обосновката е по-задълбочена, но изчерпва лимитите 2-5 пъти по-бързо. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16242,6 +16497,12 @@ msgstr "Възстановяване"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Код за възстановяване"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16462,7 +16723,8 @@ msgstr "Запомни моя избор"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
+msgstr ""
+"Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16493,6 +16755,12 @@ msgstr "Премахване на %1$s"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "Премахване на %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16535,6 +16803,18 @@ msgstr "Премахване на избора на текст"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Премахнете ненужните препинателни знаци"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17229,6 +17509,12 @@ msgid "Say hello to Duck.ai"
 msgstr "Поздравете Duck.ai"
 
 # smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai!"
@@ -17330,13 +17616,15 @@ msgstr "Шотландия"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
+msgstr ""
+"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
+msgstr ""
+"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17775,7 +18063,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
+msgstr ""
+"Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17902,7 +18191,8 @@ msgstr "Вижте някои от най-новите ни актуализац
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
+msgstr ""
+"За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17942,7 +18232,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
+msgstr ""
+"Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17963,7 +18254,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
+msgstr ""
+"Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18234,6 +18526,13 @@ msgid "Serbian (Latin)"
 msgstr "Сръбски (латиница)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18388,6 +18687,14 @@ msgid "Share"
 msgstr "Споделяне"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18431,8 +18738,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Споделете местоположение на ниво град с AI моделите, за да получавате "
-"по-подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
+"Споделете местоположение на ниво град с AI моделите, за да получавате по-"
+"подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
 "нито на нас, нито на AI моделите."
 
 # smartling.placeholder_format=C
@@ -18537,6 +18844,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Споделете какво мислите в полето за търсене."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18851,7 +19170,8 @@ msgstr "Показване на страничната лента"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Показва съвети стъпка по стъпка за извличане на максимална полза от Duck.ai."
+msgstr ""
+"Показва съвети стъпка по стъпка за извличане на максимална полза от Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18949,7 +19269,8 @@ msgstr "Показва периодично напомняне за добавя
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
+msgstr ""
+"Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18967,7 +19288,8 @@ msgstr "Показва номерата на страниците в края н
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
+msgstr ""
+"Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18990,12 +19312,14 @@ msgstr "Показва фона на бутона за търсене"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Показва приветствие в горната част на страницата с резултати от търсенето"
+msgstr ""
+"Показва приветствие в горната част на страницата с резултати от търсенето"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
+msgstr ""
+"Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19067,12 +19391,14 @@ msgstr "Имена на сайтове"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
+msgstr ""
+"Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
+msgstr ""
+"Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19216,6 +19542,12 @@ msgid "Something went wrong"
 msgstr "Възникна някаква грешка"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19225,7 +19557,8 @@ msgstr "Нещо се обърка при запазването на сървъ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
+msgstr ""
+"Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19255,7 +19588,8 @@ msgstr "Понякога"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
+msgstr ""
+"Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19330,8 +19664,8 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново "
-"по-късно."
+"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново по-"
+"късно."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19647,7 +19981,8 @@ msgstr "Спрете скритите тракери, които се спота
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
+msgstr ""
+"Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20064,6 +20399,12 @@ msgid "Switch model"
 msgstr "Превключване на модела"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20324,6 +20665,13 @@ msgid "Synced Devices"
 msgstr "Синхронизирани устройства"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Сирия"
 
@@ -20354,6 +20702,12 @@ msgstr "Няма определен час"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "Телевизия"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20422,8 +20776,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим "
-"Duck.ai."
+"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20793,7 +21147,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
+msgstr ""
+"Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20847,7 +21202,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
+msgstr ""
+"Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20863,7 +21219,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
+msgstr ""
+"Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20933,6 +21290,22 @@ msgstr ""
 "Този разговор е генериран с DuckDuckGo AI Chat (%1$s) чрез модел %3$s на "
 "%2$s. Чатовете с изкуствен интелект могат да показват неточна или обидна "
 "информация (вижте %4$s за повече информация)."
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21016,6 +21389,12 @@ msgstr "Този тип изображение не се поддържа, пр�
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Тази информация не е полезна"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21136,6 +21515,18 @@ msgstr ""
 "интелект, в %1$s."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21156,7 +21547,8 @@ msgstr "Този превод е грешен"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
+msgstr ""
+"Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21610,8 +22002,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от английски на френски: „Как да стигна до "
-"най-близкото кино?“"
+"Преведи това изречение от английски на френски: „Как да стигна до най-"
+"близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21620,8 +22012,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от български на английски: „Как да стигна до "
-"най-близкото кино?“"
+"Преведи това изречение от български на английски: „Как да стигна до най-"
+"близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21739,7 +22131,8 @@ msgstr "Изпробвайте %1$s — първият ни модел с нул
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr "Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
+msgstr ""
+"Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -21781,6 +22174,12 @@ msgstr "Пробвайте безплатно"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Пробвайте безплатно"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21902,6 +22301,12 @@ msgid "Try for Free"
 msgstr "Пробвайте безплатно"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
 msgctxt ""
 "Link text shown to unauthenticated users in the subscription promo card to "
@@ -21968,7 +22373,8 @@ msgstr "Изпробвайте нашия браузър"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Опитайте нашата начална страница, която никога не показва тези съобщения:"
+msgstr ""
+"Опитайте нашата начална страница, която никога не показва тези съобщения:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22149,6 +22555,12 @@ msgid "Turkmenistan"
 msgstr "Туркменистан"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22159,6 +22571,12 @@ msgstr "Изключване на Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Изключване на Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22453,7 +22871,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
+msgstr ""
+"Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22471,7 +22890,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
+msgstr ""
+"В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22641,6 +23061,12 @@ msgid "Unmute"
 msgstr "Включване на звука"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22674,6 +23100,12 @@ msgstr "Актуализиране"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Актуализиране на браузъра"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23018,7 +23450,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Да се използва приблизителното Ви местоположение за по-точни резултати?"
+msgstr ""
+"Да се използва приблизителното Ви местоположение за по-точни резултати?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23496,8 +23929,8 @@ msgstr "Ние анонимизираме"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме "
-"по-точни резултати."
+"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме по-"
+"точни резултати."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23609,7 +24042,8 @@ msgstr "Ние не ви проследяваме. Никога."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
+msgstr ""
+"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23650,13 +24084,22 @@ msgstr "Не ви следим нито във, нито извън режима
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
+msgstr ""
+"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Прекратихме чата поради неактивност. Искате ли да опитате отново?"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23706,6 +24149,14 @@ msgstr ""
 "решението си по-късно."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23746,6 +24197,14 @@ msgstr ""
 "сърфирате."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
 msgctxt "noresults"
 msgid ""
@@ -23777,7 +24236,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
+msgstr ""
+"Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23942,7 +24402,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
+msgstr ""
+"Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24033,13 +24494,15 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
+msgstr ""
+"Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Кои атракции трябва да види един турист, който посещава Париж за първи път?"
+msgstr ""
+"Кои атракции трябва да види един турист, който посещава Париж за първи път?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24056,6 +24519,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Какви са плюсовете и минусите на годишната рента?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24158,7 +24627,8 @@ msgstr "Кои са ястията, които задължително тряб
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Какво е работното време, местоположението и данните за контакт на това място?"
+msgstr ""
+"Какво е работното време, местоположението и данните за контакт на това място?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24627,6 +25097,14 @@ msgid "Without zero provider visibility"
 msgstr "Без нулева видимост за доставчика"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -25010,7 +25488,8 @@ msgstr "Можете да продължите този чат, като изп�
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
+msgstr ""
+"Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25087,7 +25566,8 @@ msgstr "Можете да възстановите настройките си, 
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr "Можете да споделяте и използвате настройките си с други компютри и браузъри."
+msgstr ""
+"Можете да споделяте и използвате настройките си с други компютри и браузъри."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -25124,6 +25604,13 @@ msgstr "Остават ви %1$s опита."
 msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Остава ви 1 опит."
+
+# smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25277,14 +25764,15 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново "
-"по-късно."
+"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново по-"
+"късно."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Достигнали сте максималната продължителност на гласовия чат за една сесия."
+msgstr ""
+"Достигнали сте максималната продължителност на гласовия чат за една сесия."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -25296,7 +25784,8 @@ msgstr "Достигнали сте лимита за гласов чат за �
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
+msgstr ""
+"Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25305,8 +25794,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в "
-"Duck.ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
+"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в Duck."
+"ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
 "синхронизирането. Закачените чатове няма да бъдат изтрити."
 
 # smartling.placeholder_format=C
@@ -25334,8 +25823,8 @@ msgid ""
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
 "YouTube (притежаван от Google) не позволява да гледате видео анонимно. "
-"Следователно гледането на YouTube видео тук ще бъде следено от "
-"YouTube/Google."
+"Следователно гледането на YouTube видео тук ще бъде следено от YouTube/"
+"Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25347,6 +25836,23 @@ msgstr "Предупреждение за поверителността на Yo
 msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Стандартно за YouTube"
+
+# smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25370,6 +25876,14 @@ msgstr "Вашето реално местоположение остава по
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Вашето реално местоположение остава поверително."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25458,7 +25972,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Чатовете са поверителни и никога не се използват за обучение на AI модели"
+msgstr ""
+"Чатовете са поверителни и никога не се използват за обучение на AI модели"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25519,7 +26034,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
+msgstr ""
+"Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25748,7 +26264,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
+msgstr ""
+"Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25831,7 +26348,8 @@ msgstr "от %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
+msgstr ""
+"от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: bg_BG\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Това устройство)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -308,8 +308,7 @@ msgstr "Класирането на %1$s все още не е налично"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s достига лимитите за ползване 2-5 пъти по-бързо от основните модели. %2$s"
+msgstr "%1$s достига лимитите за ползване 2-5 пъти по-бързо от основните модели. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -379,8 +378,7 @@ msgstr "%1$s използвани"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s изразходва лимитите почти 2–5 пъти по-бързо от основните модели %2$s"
+msgstr "%1$s изразходва лимитите почти 2–5 пъти по-бързо от основните модели %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -496,15 +494,14 @@ msgstr "%1$sНаучи повече%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
+msgstr "%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sНаучете повече%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -804,7 +801,7 @@ msgstr "2-ро място в група %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2-ро мнение"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1019,8 +1016,8 @@ msgstr ""
 "AI Chat ви позволява да провеждате анонимни разговори с модели за чат с "
 "изкуствен интелект на трети страни. Изключването на това ще скрие функцията "
 "AI Chat в DuckDuckGo Search. Все още можете да получите достъп до AI Chat, "
-"когато тази настройка е изключена, като посетите %1$sduckduckgo.com/"
-"aichat%2$s."
+"когато тази настройка е изключена, като посетите "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1499,7 +1496,7 @@ msgstr "Добавете към Начална страница"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Добавяне към Моите чатове"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1603,8 +1600,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"Усъвършенстваните модели могат да достигнат лимитите за ползване 2–5 пъти по-"
-"бързо от другите модели. %1$s"
+"Усъвършенстваните модели могат да достигнат лимитите за ползване 2–5 пъти "
+"по-бързо от другите модели. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1871,7 +1868,7 @@ msgstr "Всички типове"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Всички устройства са изключени от Sync."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2250,8 +2247,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
+msgstr "Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2403,7 +2399,7 @@ msgstr "Задайте въпрос поверително"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Задайте въпрос поверително"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2587,8 +2583,7 @@ msgstr "След приключване на чата аудиото не се �
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
+msgstr "След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3802,8 +3797,7 @@ msgstr "Променя фоновия цвят, когато курсорът б
 #. Description of a setting managing the color of search result snippet text.
 msgctxt "settings"
 msgid "Changes the color of descriptive content shown for results"
-msgstr ""
-"Променя цвета на описателното съдържание, което се показва с резултатите"
+msgstr "Променя цвета на описателното съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -4166,8 +4160,7 @@ msgstr "Проверете правописа"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
+msgstr "Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4576,8 +4569,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
+msgstr "Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4644,8 +4636,7 @@ msgstr "Щракнете върху %1$sБраузър%2$s в странично
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
+msgstr "Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4663,8 +4654,7 @@ msgstr "Щракнете върху %1$sТърсачки%2$s под Видове
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
+msgstr "Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4739,8 +4729,7 @@ msgstr "Щракнете върху %1$sиконата за разрешения
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
+msgstr "Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5359,7 +5348,7 @@ msgstr "Копиране"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Копиране"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5370,8 +5359,7 @@ msgstr "Копиране"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
+msgstr "Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5409,13 +5397,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Копиране на споделената връзка"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Копирайте кода от друго устройство"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5424,6 +5412,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Копирайте кода от друго устройство. Отворете %1$sНастройки на Duck.ai › "
+"Чатове › Sync & Backup › Синхронизиране с друго устройство%2$s и опитайте "
+"отново."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5475,8 +5466,7 @@ msgstr "Коста Рика"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
+msgstr "Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6113,7 +6103,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Изтриване на споделената връзка"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6134,6 +6124,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Когато връзката бъде изтрита, тя ще спре да работи. Хората, които са я "
+"отворили и са добавили разговора към своите чатове, ще запазят своето копие."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6330,8 +6322,7 @@ msgstr "Деактивиране и изключване"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
+msgstr "Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6396,7 +6387,7 @@ msgstr "Отхвърляне"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Отхвърляне"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6532,8 +6523,7 @@ msgstr "Не виждате DuckDuckGo в списъка?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
+msgstr "Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6857,8 +6847,7 @@ msgstr "Условия за ползване на Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
+msgstr "Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6904,8 +6893,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
+msgstr "Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6955,8 +6943,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
+msgstr "Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6987,8 +6974,8 @@ msgstr ""
 "интелект на трети страни, включително модели от OpenAI, Anthropic и други. "
 "Ако изключите тази настройка, бутоните и връзките на Duck.ai в DuckDuckGo "
 "Search ще се скрият. Въпреки това можете да получите достъп до Duck.ai, "
-"когато тази настройка е изключена, като посетите директно %1$shttps://duck."
-"ai%2$s ."
+"когато тази настройка е изключена, като посетите директно "
+"%1$shttps://duck.ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7228,8 +7215,8 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
 msgstr ""
-"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново по-"
-"късно."
+"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7262,7 +7249,7 @@ msgstr "Браузър DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Помощни страници на DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7887,15 +7874,13 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
+msgstr "Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
+msgstr "Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7925,15 +7910,13 @@ msgstr "Уверете се, че достъпът до местоположен
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
+msgstr "Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
+msgstr "Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8039,8 +8022,7 @@ msgstr "Екваториална Гвинея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
+msgstr "Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8109,7 +8091,7 @@ msgstr ""
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Изтекъл срок"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8123,7 +8105,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Изтича на %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8148,8 +8130,7 @@ msgstr "Обясни приетия отговор с прости думи."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
+msgstr "Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8227,8 +8208,7 @@ msgstr "Разгледайте Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
+msgstr "Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8533,8 +8513,7 @@ msgstr "Финансов консултант"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
+msgstr "Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8769,8 +8748,7 @@ msgstr "Безплатни и поверителни чатове, аноним�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
+msgstr "Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9016,15 +8994,13 @@ msgstr "Общо предназначение"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
+msgstr "Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
+msgstr "Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -9182,8 +9158,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Вземете DuckDuckGo VPN, усъвършенстван Duck.ai и Identity Theft Restoration."
+msgstr "Вземете DuckDuckGo VPN, усъвършенстван Duck.ai и Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9512,13 +9487,14 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Отворете %1$sНастройки на Duck.ai%2$s › %3$sЧатове › Sync & Backup › "
+"Синхронизиране с друго устройство%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
+msgstr "Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9629,7 +9605,7 @@ msgstr "Разбрах"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Разбрах"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10190,8 +10166,7 @@ msgstr "Скриване на Вашия имейл адрес"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
+msgstr "Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10453,8 +10428,7 @@ msgstr "Колко често искате да виждате отговори�
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
+msgstr "Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10592,8 +10566,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри книги/"
-"поредици има, които приличат най-много на нея, и защо?"
+"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри "
+"книги/поредици има, които приличат най-много на нея, и защо?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -11219,8 +11193,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
+msgstr "Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11270,8 +11243,7 @@ msgstr "Той е бърз, безплатен и осигурява още по
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
+msgstr "Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11616,7 +11588,7 @@ msgstr "Научете %1$sОще%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Научете повече"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11851,8 +11823,7 @@ msgstr "Ограничено съхранение на данни за този 
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr ""
-"Ограничава количеството описателно съдържание, което се показва с резултатите"
+msgstr "Ограничава количеството описателно съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -11999,8 +11970,7 @@ msgstr "Зареждане на още резултати с изображен�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"При превъртане зарежда повече резултати в изображения, видео и пазаруване"
+msgstr "При превъртане зарежда повече резултати в изображения, видео и пазаруване"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12029,8 +11999,7 @@ msgstr "Местоположение"
 #. Message informing users that location-based search is private.
 msgctxt "precise_user_location"
 msgid "Location information is stored only on your device."
-msgstr ""
-"Информацията за местоположението се съхранява само на вашето устройство."
+msgstr "Информацията за местоположението се съхранява само на вашето устройство."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -12261,7 +12230,7 @@ msgstr "Управление"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Управление"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12518,7 +12487,7 @@ msgstr "Меню"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Съобщенията след тази точка са видими само за вас."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12894,7 +12863,7 @@ msgstr "Повече за Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Още действия"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13094,7 +13063,7 @@ msgstr "Бледочервено"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Моите устройства"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14172,6 +14141,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"На друго устройство отворете %1$sНастройки на Duck.ai%2$s › %3$sЧатове › "
+"Sync & Backup › Синхронизиране с друго устройство%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14180,6 +14151,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"На друго устройство отворете %1$sНастройки на Duck.ai%2$s › %3$sЧатове › "
+"Sync & Backup › Синхронизиране с друго устройство%4$s и сканирайте този код:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14188,6 +14161,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"На друго устройство отворете %1$sНастройки на Duck.ai%2$s › %3$sЧатове › "
+"Sync & Backup › Синхронизиране с друго устройство%4$s. Или сканирайте QR "
+"кода в PDF файла за възстановяване."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14486,8 +14462,7 @@ msgstr "Отваряне на панела Как работи Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
+msgstr "Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14948,7 +14923,7 @@ msgstr "Миналата година"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Поставяне"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14966,7 +14941,7 @@ msgstr "Поставяне на код за синхронизация"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Поставете го по-долу"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -15025,7 +15000,7 @@ msgstr "Персийски"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -15034,6 +15009,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal намира Вашата информация в сайтове на брокери "
+"на данни, които я продават. След това се стремим да я премахнем вместо Вас."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15116,9 +15093,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"Ако формулирате своето търсене като въпрос и в пълно изречение, е по-"
-"вероятно DuckAssist да се появи и често допринася за по-добри отговори. За "
-"да настроите как да работи тази функция или да я изключите, отидете на "
+"Ако формулирате своето търсене като въпрос и в пълно изречение, е "
+"по-вероятно DuckAssist да се появи и често допринася за по-добри отговори. "
+"За да настроите как да работи тази функция или да я изключите, отидете на "
 "%1$sНастройки на DuckAssist%2$s."
 
 # smartling.placeholder_format=C
@@ -15247,8 +15224,7 @@ msgstr "Закачени"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Закачените чатове ще се показват най-отгоре в списъка с последни чатове."
+msgstr "Закачените чатове ще се показват най-отгоре в списъка с последни чатове."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -16303,7 +16279,7 @@ msgstr "Четене на уебсайт…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Готови ли сте за слънчевото затъмнение?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16346,15 +16322,14 @@ msgstr "С обосновка може да получите по-подробн
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"Обосновката е по-задълбочена, но достига лимитите за ползване 2–5 пъти по-"
-"бързо. %1$s"
+"Обосновката е по-задълбочена, но достига лимитите за ползване 2–5 пъти "
+"по-бързо. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Обосновката е по-задълбочена, но изчерпва лимитите 2-5 пъти по-бързо. %1$s"
+msgstr "Обосновката е по-задълбочена, но изчерпва лимитите 2-5 пъти по-бързо. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16502,7 +16477,7 @@ msgstr "Код за възстановяване"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Код за възстановяване"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16723,8 +16698,7 @@ msgstr "Запомни моя избор"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
+msgstr "Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16760,7 +16734,7 @@ msgstr "Премахване на %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Премахване на устройство"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16808,13 +16782,13 @@ msgstr "Премахнете ненужните препинателни зна�
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Премахване на Вашата информация от интернет"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Премахване на Вашата информация онлайн"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17512,7 +17486,7 @@ msgstr "Поздравете Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Приветствайте Duck.ai – безплатен, поверителен AI чат от DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17616,15 +17590,13 @@ msgstr "Шотландия"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
+msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
+msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18063,8 +18035,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
+msgstr "Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18191,8 +18162,7 @@ msgstr "Вижте някои от най-новите ни актуализац
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
+msgstr "За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18232,8 +18202,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
+msgstr "Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18254,8 +18223,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
+msgstr "Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18530,7 +18498,7 @@ msgstr "Сръбски (латиница)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Данните от сървъра са изтрити"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18692,7 +18660,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Споделяне"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18738,8 +18706,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Споделете местоположение на ниво град с AI моделите, за да получавате по-"
-"подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
+"Споделете местоположение на ниво град с AI моделите, за да получавате "
+"по-подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
 "нито на нас, нито на AI моделите."
 
 # smartling.placeholder_format=C
@@ -18849,13 +18817,13 @@ msgstr "Споделете какво мислите в полето за тър
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Споделени връзки към чатове"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Споделени връзки към чатове"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19170,8 +19138,7 @@ msgstr "Показване на страничната лента"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Показва съвети стъпка по стъпка за извличане на максимална полза от Duck.ai."
+msgstr "Показва съвети стъпка по стъпка за извличане на максимална полза от Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19269,8 +19236,7 @@ msgstr "Показва периодично напомняне за добавя
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
+msgstr "Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19288,8 +19254,7 @@ msgstr "Показва номерата на страниците в края н
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
+msgstr "Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19312,14 +19277,12 @@ msgstr "Показва фона на бутона за търсене"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Показва приветствие в горната част на страницата с резултати от търсенето"
+msgstr "Показва приветствие в горната част на страницата с резултати от търсенето"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
+msgstr "Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19391,14 +19354,12 @@ msgstr "Имена на сайтове"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
+msgstr "Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
+msgstr "Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19545,7 +19506,7 @@ msgstr "Възникна някаква грешка"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Възникна грешка при зареждането на този споделен чат."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19557,8 +19518,7 @@ msgstr "Нещо се обърка при запазването на сървъ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
+msgstr "Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19588,8 +19548,7 @@ msgstr "Понякога"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
+msgstr "Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19664,8 +19623,8 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново по-"
-"късно."
+"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19981,8 +19940,7 @@ msgstr "Спрете скритите тракери, които се спота
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
+msgstr "Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20402,7 +20360,7 @@ msgstr "Превключване на модела"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Превключване на модела"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20669,7 +20627,7 @@ msgstr "Синхронизирани устройства"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Синхронизирано на %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20707,7 +20665,7 @@ msgstr "Телевизия"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Таблица"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20776,8 +20734,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим Duck."
-"ai."
+"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21147,8 +21105,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
+msgstr "Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21202,8 +21159,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
+msgstr "Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21219,8 +21175,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
+msgstr "Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21295,7 +21250,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Това устройство"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21306,6 +21261,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Това устройство вече няма да има достъп до синхронизираните данни на други "
+"устройства. Последните %1$s чата ще останат достъпни в локалното хранилище."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21394,7 +21351,7 @@ msgstr "Тази информация не е полезна"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Това е копие на споделен чат."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21518,13 +21475,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Този споделен чат не може да бъде отворен. Връзката може да е непълна."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Тази връзка към споделен чат вече не е налична."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21547,8 +21504,7 @@ msgstr "Този превод е грешен"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
+msgstr "Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -22002,8 +21958,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от английски на френски: „Как да стигна до най-"
-"близкото кино?“"
+"Преведи това изречение от английски на френски: „Как да стигна до "
+"най-близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22012,8 +21968,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от български на английски: „Как да стигна до най-"
-"близкото кино?“"
+"Преведи това изречение от български на английски: „Как да стигна до "
+"най-близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22131,8 +22087,7 @@ msgstr "Изпробвайте %1$s — първият ни модел с нул
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
+msgstr "Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -22179,7 +22134,7 @@ msgstr "Пробвайте безплатно"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Пробвайте безплатно!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22304,7 +22259,7 @@ msgstr "Пробвайте безплатно"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Пробвайте безплатно!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22373,8 +22328,7 @@ msgstr "Изпробвайте нашия браузър"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Опитайте нашата начална страница, която никога не показва тези съобщения:"
+msgstr "Опитайте нашата начална страница, която никога не показва тези съобщения:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22558,7 +22512,7 @@ msgstr "Туркменистан"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Изключване"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22576,7 +22530,7 @@ msgstr "Изключване на Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Изключване на Sync & Backup и изтриване на данните от сървъра?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22871,8 +22825,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
+msgstr "Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22890,8 +22843,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
+msgstr "В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23064,7 +23016,7 @@ msgstr "Включване на звука"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Чат без заглавие"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23105,7 +23057,7 @@ msgstr "Актуализиране на браузъра"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Актуализирайте Duck.ai, за да видите този споделен чат."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23450,8 +23402,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Да се използва приблизителното Ви местоположение за по-точни резултати?"
+msgstr "Да се използва приблизителното Ви местоположение за по-точни резултати?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23929,8 +23880,8 @@ msgstr "Ние анонимизираме"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме по-"
-"точни резултати."
+"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме "
+"по-точни резултати."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24042,8 +23993,7 @@ msgstr "Ние не ви проследяваме. Никога."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
+msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24084,8 +24034,7 @@ msgstr "Не ви следим нито във, нито извън режима
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
+msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24100,6 +24049,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Намираме и премахваме Вашата лична информация от сайтове на брокери на "
+"данни. Освен това получавате VPN и други функции."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24155,6 +24106,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Редовно сканираме сайтове на брокери на данни за Ваша лична информация и Ви "
+"информираме за напредъка в лесно за използване табло за управление."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24203,6 +24156,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Ще сканираме сайтове на брокери на данни за Вашия имейл, име, адрес и други "
+"данни и ще се стараем да премахнем всичко, което открием за Вас."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24236,8 +24191,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
+msgstr "Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24402,8 +24356,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
+msgstr "Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24494,15 +24447,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
+msgstr "Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Кои атракции трябва да види един турист, който посещава Париж за първи път?"
+msgstr "Кои атракции трябва да види един турист, който посещава Париж за първи път?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24524,7 +24475,7 @@ msgstr "Какви са плюсовете и минусите на годишн
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Какви са предимствата на Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24627,8 +24578,7 @@ msgstr "Кои са ястията, които задължително тряб
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Какво е работното време, местоположението и данните за контакт на това място?"
+msgstr "Какво е работното време, местоположението и данните за контакт на това място?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25103,6 +25053,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Работи директно от Вашето устройство за премахване на Ваши данни като имейл, "
+"име, адрес и други от сайтове на брокери на данни."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25488,8 +25440,7 @@ msgstr "Можете да продължите този чат, като изп�
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
+msgstr "Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25566,8 +25517,7 @@ msgstr "Можете да възстановите настройките си, 
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr ""
-"Можете да споделяте и използвате настройките си с други компютри и браузъри."
+msgstr "Можете да споделяте и използвате настройките си с други компютри и браузъри."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -25610,7 +25560,7 @@ msgstr "Остава ви 1 опит."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Нямате споделени връзки към чатове."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25764,15 +25714,14 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново по-"
-"късно."
+"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Достигнали сте максималната продължителност на гласовия чат за една сесия."
+msgstr "Достигнали сте максималната продължителност на гласовия чат за една сесия."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -25784,8 +25733,7 @@ msgstr "Достигнали сте лимита за гласов чат за �
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
+msgstr "Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25794,8 +25742,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в Duck."
-"ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
+"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в "
+"Duck.ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
 "синхронизирането. Закачените чатове няма да бъдат изтрити."
 
 # smartling.placeholder_format=C
@@ -25823,8 +25771,8 @@ msgid ""
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
 "YouTube (притежаван от Google) не позволява да гледате видео анонимно. "
-"Следователно гледането на YouTube видео тук ще бъде следено от YouTube/"
-"Google."
+"Следователно гледането на YouTube видео тук ще бъде следено от "
+"YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25846,13 +25794,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Последните %1$s чата ще бъдат достъпни в локалното хранилище на тези "
+"браузъри:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Вашите чатове с Duck.ai се синхронизират с криптиране от край до край."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25884,6 +25834,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Резервното копие ще бъде изтрито от сървъра на DuckDuckGo. Всички устройства "
+"ще бъдат изключени от синхронизацията."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25972,8 +25924,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Чатовете са поверителни и никога не се използват за обучение на AI модели"
+msgstr "Чатовете са поверителни и никога не се използват за обучение на AI модели"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26034,8 +25985,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
+msgstr "Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26264,8 +26214,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
+msgstr "Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26348,8 +26297,7 @@ msgstr "от %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
+msgstr "от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/bn_BD/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_BD/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "%s এ যুক্ত করুন"
 msgid "Add to Home Screen"
 msgstr "হোম স্ক্রিনে যোগ করুন"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "এড-অনসমূহ"
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4199,6 +4233,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4231,6 +4270,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4791,6 +4849,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4799,6 +4864,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5005,6 +5077,12 @@ msgstr "বন্ধ করুন"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5654,6 +5732,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6327,9 +6411,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7422,6 +7519,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7506,6 +7610,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9096,6 +9205,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "আরো %s জানুন %s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9614,6 +9728,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9819,6 +9939,11 @@ msgstr "মেনু"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10121,6 +10246,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "এ সম্পর্কে আরও "
@@ -10278,6 +10408,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "নিঃশব্দ লাল"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11157,6 +11292,27 @@ msgstr ""
 "ম্যাকে, %sClick Maxthon > Preferences%s, উইন্ডোজে, %s %s আইকনে ক্লিক করুন > "
 "Settings%s-এ যান"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11763,6 +11919,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11771,6 +11932,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11815,6 +11981,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12829,6 +13007,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12978,6 +13161,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13185,6 +13373,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13218,6 +13411,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13766,6 +13969,11 @@ msgstr "আপনার সেটিংসমূহ নামহীনভাব�
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14534,6 +14742,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14660,6 +14874,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14779,6 +15000,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15326,6 +15557,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16016,6 +16252,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16213,6 +16454,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16238,6 +16485,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "টেলিভিশন"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16690,6 +16942,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16758,6 +17024,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16841,6 +17112,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17356,6 +17637,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17448,6 +17734,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17647,6 +17938,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17655,6 +17951,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18034,6 +18335,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18061,6 +18367,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18827,6 +19138,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18861,6 +19179,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18885,6 +19210,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19129,6 +19461,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19591,6 +19928,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19994,6 +20338,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20160,6 +20510,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20177,6 +20542,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/bn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_IN/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1181,6 +1199,11 @@ msgstr "%s - এর সাথে জোড়া যাক"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "অতীরীক্ত কার্যকারিতা"
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4197,6 +4231,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4229,6 +4268,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4789,6 +4847,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4797,6 +4862,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5003,6 +5075,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5652,6 +5730,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6324,9 +6408,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7417,6 +7514,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7501,6 +7605,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9087,6 +9196,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9604,6 +9718,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9809,6 +9929,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10111,6 +10236,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10268,6 +10398,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "চাপা লাল"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11145,6 +11280,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11749,6 +11905,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11757,6 +11918,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11801,6 +11967,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12815,6 +12993,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12964,6 +13147,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13171,6 +13359,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13204,6 +13397,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13752,6 +13955,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14518,6 +14726,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14642,6 +14856,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14761,6 +14982,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15308,6 +15539,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15997,6 +16233,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16194,6 +16435,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16218,6 +16465,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16671,6 +16923,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16739,6 +17005,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16822,6 +17093,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17336,6 +17617,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17428,6 +17714,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17627,6 +17918,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17635,6 +17931,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18012,6 +18313,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18039,6 +18345,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18805,6 +19116,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18839,6 +19157,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18863,6 +19188,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19107,6 +19439,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19569,6 +19906,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19971,6 +20315,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20135,6 +20485,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20152,6 +20517,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/bo_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bo_CN/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr ""
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr ""
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4193,6 +4227,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4225,6 +4264,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4785,6 +4843,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4793,6 +4858,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -4999,6 +5071,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5646,6 +5724,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6308,9 +6392,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7401,6 +7498,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7485,6 +7589,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9069,6 +9178,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9586,6 +9700,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9791,6 +9911,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10093,6 +10218,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10249,6 +10379,11 @@ msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
+msgstr ""
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
 msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -11127,6 +11262,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11731,6 +11887,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11739,6 +11900,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11783,6 +11949,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12797,6 +12975,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12946,6 +13129,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13153,6 +13341,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13186,6 +13379,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13734,6 +13937,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14498,6 +14706,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14622,6 +14836,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14741,6 +14962,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15288,6 +15519,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15977,6 +16213,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16174,6 +16415,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16198,6 +16445,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16651,6 +16903,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16719,6 +16985,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16802,6 +17073,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17316,6 +17597,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17408,6 +17694,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17607,6 +17898,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17615,6 +17911,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -17992,6 +18293,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18019,6 +18325,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18785,6 +19096,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18819,6 +19137,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18843,6 +19168,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19087,6 +19419,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19549,6 +19886,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19949,6 +20293,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20113,6 +20463,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20130,6 +20495,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/br_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/br_FR/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Ouzhpennañ da %s"
 msgid "Add to Home Screen"
 msgstr "Ouzhpennañ d'ar pennskramm"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Askouezhioù"
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4205,6 +4239,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4237,6 +4276,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4797,6 +4855,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4805,6 +4870,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5011,6 +5083,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5658,6 +5736,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6321,9 +6405,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7417,6 +7514,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7501,6 +7605,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9089,6 +9198,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Deskiñ %sTraoù all%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9608,6 +9722,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9813,6 +9933,11 @@ msgstr "Lañser"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10115,6 +10240,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "muioc'h war"
@@ -10272,6 +10402,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Ruz kemmesk"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11152,6 +11287,27 @@ msgstr ""
 "War Mac, %sKlikit war Maxthon > Gwellvezioù%s, war Windows, %sklikit war an "
 "%s arlun > Arventennoù%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11758,6 +11914,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11766,6 +11927,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11810,6 +11976,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12824,6 +13002,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12973,6 +13156,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13180,6 +13368,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13213,6 +13406,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13761,6 +13964,11 @@ msgstr "Enrollit hoc'h arventennoù dizanv er c'houmoul"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14532,6 +14740,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14656,6 +14870,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14775,6 +14996,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15322,6 +15553,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16013,6 +16249,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16210,6 +16451,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16235,6 +16482,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Skinwel"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16687,6 +16939,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16755,6 +17021,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16838,6 +17109,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17354,6 +17635,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17446,6 +17732,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17645,6 +17936,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17653,6 +17949,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18037,6 +18338,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18064,6 +18370,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18830,6 +19141,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18864,6 +19182,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18888,6 +19213,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19132,6 +19464,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19596,6 +19933,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19998,6 +20342,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20164,6 +20514,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20181,6 +20546,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/bs_BA/LC_MESSAGES/duckduckgo.po
+++ b/locales/bs_BA/LC_MESSAGES/duckduckgo.po
@@ -44,6 +44,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% vakciniranih"
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -401,6 +408,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%sSaznajte kako lokaciju čuvamo privatnom%s."
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -636,6 +649,11 @@ msgstr ""
 msgctxt "Sports module"
 msgid "2nd in Group %s"
 msgstr "2. u grupi %s"
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
@@ -1190,6 +1208,11 @@ msgstr "Dodaj u %s"
 msgid "Add to Home Screen"
 msgstr "Dodaj na početni ekran"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Dodaci"
@@ -1482,6 +1505,12 @@ msgstr "Sve veličine"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Sve vrste"
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
@@ -1895,6 +1924,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4245,6 +4279,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4277,6 +4316,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4837,6 +4895,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4845,6 +4910,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5051,6 +5123,12 @@ msgstr "Sakrij"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5698,6 +5776,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6380,9 +6464,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7479,6 +7576,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7563,6 +7667,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9176,6 +9285,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "%sDetaljnije%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9696,6 +9810,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9902,6 +10022,11 @@ msgstr "Meni"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Jelovnik"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10203,6 +10328,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Više na"
@@ -10360,6 +10490,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Zagasito crvena"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11239,6 +11374,27 @@ msgstr ""
 "Na Macu: %skliknite Maxthon > Postavke%s; na Windowsu: %skliknite ikonu %s > "
 "Postavke%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11857,6 +12013,11 @@ msgstr "Prošle sedmice"
 msgid "Past year"
 msgstr "Prošle godine"
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11865,6 +12026,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11910,6 +12076,18 @@ msgstr ""
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Perzijski"
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
 msgctxt "Assistant role option label for Personal trainer"
@@ -12925,6 +13103,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13074,6 +13257,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13281,6 +13469,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13314,6 +13507,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13867,6 +14070,11 @@ msgstr "Sačuvajte svoje postavke anonimno u oblak"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14647,6 +14855,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Srpski (latinica)"
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14772,6 +14986,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14891,6 +15112,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15444,6 +15675,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16139,6 +16375,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16336,6 +16577,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16361,6 +16608,11 @@ msgstr "TBD"
 
 msgid "TV"
 msgstr "TV"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16822,6 +17074,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16891,6 +17157,11 @@ msgstr ""
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Informacija nije korisna"
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
@@ -16973,6 +17244,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17491,6 +17772,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17583,6 +17869,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17782,6 +18073,11 @@ msgstr "Turski"
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17790,6 +18086,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18175,6 +18476,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18202,6 +18508,11 @@ msgstr "Ažuriraj"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18985,6 +19296,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -19021,6 +19339,13 @@ msgstr ""
 "Vašu anonimnu lokaciju koristimo samo za prikazivanje boljih rezultata, "
 "bližih Vama. Uvijek se kasnije možete predomisliti."
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -19051,6 +19376,13 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Blokirat ćemo alate za praćenje koji pokušaju prikupiti Vaše podatke dok "
 "surfate internetom."
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
 msgctxt "noresults"
@@ -19294,6 +19626,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19760,6 +20097,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20163,6 +20507,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Preostao vam je još jedan pokušaj."
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20334,6 +20684,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Standardna s YouTubea"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Vaša historija pretraga je privatna na DuckDuckGou"
@@ -20351,6 +20716,13 @@ msgstr "Vaša stvarna lokacija ostaje privatna"
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/ca_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ca_ES/LC_MESSAGES/duckduckgo.po
@@ -43,6 +43,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% vacunats"
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -401,6 +408,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%sObteniu informació sobre com mantenim la vostra ubicació privada%s."
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -636,6 +649,11 @@ msgstr ""
 msgctxt "Sports module"
 msgid "2nd in Group %s"
 msgstr "2on del grup %s"
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
@@ -1190,6 +1208,11 @@ msgstr "Afegeix al %s"
 msgid "Add to Home Screen"
 msgstr "Afegeix a la pantalla d'inici"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Extensions"
@@ -1483,6 +1506,12 @@ msgstr "Totes les mides"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Tots els tipus"
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
@@ -1897,6 +1926,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4246,6 +4280,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4278,6 +4317,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4838,6 +4896,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4846,6 +4911,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5052,6 +5124,12 @@ msgstr "Ignora"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5700,6 +5778,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6388,9 +6472,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7485,6 +7582,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7569,6 +7673,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9189,6 +9298,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "%sMés informació%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9709,6 +9823,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9915,6 +10035,11 @@ msgstr "Menú"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menú"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10216,6 +10341,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Més a"
@@ -10373,6 +10503,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Vermell fosc"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11252,6 +11387,27 @@ msgstr ""
 "Per al Mac, %sFeu clic al Maxthon > Preferències%s, per al Windows, %sFeu "
 "clic a la icona %s > Configuració%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11870,6 +12026,11 @@ msgstr "La setmana passada"
 msgid "Past year"
 msgstr "L'any passat"
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11878,6 +12039,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11923,6 +12089,18 @@ msgstr ""
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persa"
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
 msgctxt "Assistant role option label for Personal trainer"
@@ -12939,6 +13117,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13088,6 +13271,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13296,6 +13484,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13329,6 +13522,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13880,6 +14083,11 @@ msgstr "Desa la vostra configuració anònimament al núvol"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14670,6 +14878,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Serbi (llatí)"
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14796,6 +15010,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14916,6 +15137,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15475,6 +15706,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16167,6 +16403,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16364,6 +16605,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16389,6 +16636,11 @@ msgstr "PD"
 
 msgid "TV"
 msgstr "TV"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16851,6 +17103,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16919,6 +17185,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -17002,6 +17273,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17520,6 +17801,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17613,6 +17899,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17812,6 +18103,11 @@ msgstr "Turc"
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17820,6 +18116,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18204,6 +18505,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18231,6 +18537,11 @@ msgstr "Actualitza"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -19011,6 +19322,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -19047,6 +19365,13 @@ msgstr ""
 "Només utilitzem la vostra ubicació anònima per obtenir millors resultats, "
 "més a prop vostre. Sempre podeu canviar d'opinió més endavant."
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -19079,6 +19404,13 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Blocarem els seguidors que intentin recollir les vostres dades mentre "
 "navegueu."
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
 msgctxt "noresults"
@@ -19322,6 +19654,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19786,6 +20123,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20189,6 +20533,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Us queda 1 intent."
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20360,6 +20710,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Llicència de YouTube estàndard"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "El vostre historial de cerca de DuckDuckGo és privat"
@@ -20377,6 +20742,13 @@ msgstr "La vostra ubicació real continua sent privada"
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% plně očkovaných"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% očkovaných"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -98,7 +106,8 @@ msgstr "Počet pokusů: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr "Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
+msgstr ""
+"Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -487,6 +496,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sZjisti, jak chráníme informace o poloze%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -499,7 +515,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
+msgstr ""
+"%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -511,7 +528,8 @@ msgstr "%1$sPodrž%2$s ikonu aplikace DuckDuckGo na domovské obrazovce"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
+msgstr ""
+"%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -775,6 +793,12 @@ msgid "2nd in Group %s"
 msgstr "2. místo ve skupině %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -856,7 +880,8 @@ msgstr "Byl vyčerpán 6hodinový limit využití."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -927,7 +952,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
+msgstr ""
+"Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1456,6 +1482,12 @@ msgid "Add to Home Screen"
 msgstr "Přidat na domovskou obrazovku"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Doplňky"
@@ -1566,7 +1598,8 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "Pokročilé modely můžou limity vyčerpat 2–5× rychleji než jiné modely. %1$s"
+msgstr ""
+"Pokročilé modely můžou limity vyčerpat 2–5× rychleji než jiné modely. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1816,6 +1849,13 @@ msgid "All types"
 msgstr "Všechny typy"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1850,7 +1890,8 @@ msgstr "Povolit anonymní kontrolu souborů pro tento chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
+msgstr ""
+"Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2183,7 +2224,8 @@ msgstr "Jsi tam ještě?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
+msgstr ""
+"Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2333,6 +2375,12 @@ msgstr "Zeptej se na tuhle stránku"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask anything privately"
 msgstr "Zeptej se soukromě na cokoli"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -3315,7 +3363,8 @@ msgstr "Kliknutím na „%1$s“ odsouhlasíš naše %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
+msgstr ""
+"Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3394,7 +3443,8 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
+msgstr ""
+"Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -4489,13 +4539,15 @@ msgstr "Klikni %1$ssem%2$s a stáhni si rozšíření DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
+msgstr ""
+"Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
+msgstr ""
+"V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -5275,6 +5327,12 @@ msgid "Copy"
 msgstr "Kopírovat"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5314,6 +5372,28 @@ msgstr "Zkopíruj nebo ulož tento kód"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Zkopírovat kód pro obnovení"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5701,7 +5781,8 @@ msgstr "Byl vyčerpán denní limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5995,6 +6076,14 @@ msgid "Delete recent chats?"
 msgstr "Smazat nedávné chaty?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6005,6 +6094,14 @@ msgstr "Smazat tento chat?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Smazané chaty"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6262,6 +6359,13 @@ msgid "Dismiss"
 msgstr "Skrýt"
 
 # smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
 msgctxt "duckassist"
 msgid "Dismiss"
@@ -6395,7 +6499,8 @@ msgstr "Nevidíš v seznamu DuckDuckGo?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
+msgstr ""
+"Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6764,7 +6869,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
+msgstr ""
+"Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6852,7 +6958,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
+msgstr ""
+"Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6901,7 +7008,8 @@ msgstr "Upgrade Duck.ai je hotový!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
+msgstr ""
+"Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7078,7 +7186,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
+msgstr ""
+"DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7111,6 +7220,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Prohlížeč DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7874,7 +7990,8 @@ msgstr "Rovníková Guinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
+msgstr ""
+"Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7937,10 +8054,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "Odborně vyrobené produkty pro lidi, kterým záleží na soukromí."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Platnost vypršela"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8223,7 +8355,8 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
+msgstr ""
+"Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8300,7 +8433,8 @@ msgstr "Filtry nefungují"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
+msgstr ""
+"Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8469,7 +8603,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
+msgstr ""
+"Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8580,7 +8715,8 @@ msgstr "Bezplatné a soukromé chaty, které anonymizujeme"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
+msgstr ""
+"Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9209,8 +9345,8 @@ msgstr "Stáhnout aplikaci"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Nainstaluj si bezplatný prohlížeč DuckDuckGo %1$sa blokuj reklamy na "
-"YouTube.%2$s"
+"Nainstaluj si bezplatný prohlížeč DuckDuckGo %1$sa blokuj reklamy na YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9307,6 +9443,14 @@ msgstr ""
 "Přejdi na %1$sDuck.ai Nastavení%2$s ve svém druhém prohlížeči nebo v "
 "aplikaci DuckDuckGo a jdi do %3$sChaty › Sync & Backup › Synchronizace s "
 "jiným zařízením%4$s. Nebo naskenuj QR kód ze svého PDF pro obnovení."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9419,6 +9563,12 @@ msgstr "Rozumím"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Mám to"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10221,7 +10371,8 @@ msgstr "Jak to funguje"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
+msgstr ""
+"Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10469,7 +10620,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
+msgstr ""
+"Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10478,7 +10630,8 @@ msgstr "Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatn�
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
+msgstr ""
+"Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10997,7 +11150,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
+msgstr ""
+"Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11389,6 +11543,12 @@ msgid "Learn %sMore%s"
 msgstr "%1$sVíce%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11561,7 +11721,8 @@ msgstr "Umožní ti anonymně vyhledávat pomocí DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Umožní ti přepínat mezi odesíláním vyhledávacích dotazů a promptů do Duck.ai"
+msgstr ""
+"Umožní ti přepínat mezi odesíláním vyhledávacích dotazů a promptů do Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11950,7 +12111,8 @@ msgstr "Ujisti se, že jsou všechna slova napsaná správně."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
+msgstr ""
+"Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12016,6 +12178,13 @@ msgstr "Malware"
 #. Text for generic link to send the user to a page to manage their settings.
 msgid "Manage"
 msgstr "Spravovat"
+
+# smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12267,6 +12436,12 @@ msgstr "Menu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12529,7 +12704,8 @@ msgstr "Byl vyčerpán měsíční limit"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12635,6 +12811,12 @@ msgstr "Více o !bangs"
 msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr "Více o Duck.ai"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12829,6 +13011,12 @@ msgstr "Ztlumeno"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Tlumená červená"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13388,7 +13576,8 @@ msgstr "Nebyly nalezeny žádné výsledky."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
+msgstr ""
+"Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13899,6 +14088,30 @@ msgstr ""
 "ikonu %4$s > Nastavení%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -13967,7 +14180,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
+msgstr ""
+"Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14042,7 +14256,8 @@ msgstr "Otevřít %1$sNastavení%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
+msgstr ""
+"Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14648,6 +14863,12 @@ msgid "Past year"
 msgstr "Minulý rok"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14658,6 +14879,12 @@ msgstr "Vložit"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Vložit kód Sync"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14711,6 +14938,20 @@ msgstr "Trvale zavřeno"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Perština"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15752,7 +15993,8 @@ msgstr "Upozornit"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
+msgstr ""
+"Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15794,7 +16036,8 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
+msgstr ""
+"Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15964,6 +16207,12 @@ msgstr "Čtení webové stránky"
 msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr "Čtení webové stránky..."
+
+# smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16153,6 +16402,12 @@ msgstr "Obnova"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Kód pro obnovení"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16406,6 +16661,12 @@ msgid "Remove %s"
 msgstr "Odstranit %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16446,6 +16707,18 @@ msgstr "Odstranit vybraný text"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Odstraň zbytečnou interpunkci"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16889,7 +17162,8 @@ msgstr "SV"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr "Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
+msgstr ""
+"Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -16956,7 +17230,8 @@ msgstr "Bezpečné vyhledávání zablokovalo výsledky pro %1$s."
 # smartling.placeholder_format=C
 #. A label above search results that lets the user know the safe search filter blocked some of the results from showing. The placeholder value is the user's search term.
 msgid "Safe search blocked some results for %s."
-msgstr "Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
+msgstr ""
+"Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
 
 # smartling.placeholder_format=C
 #. Safe search lets you remove adult content from results on DuckDuckGo. This string is used to invite users to select the desired level of protection (e.g., strict, moderate, off)
@@ -17104,7 +17379,8 @@ msgstr "Ukládej až 30 svých nejnovějších chatů lokálně na své zaříze
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
+msgstr ""
+"Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17135,6 +17411,12 @@ msgstr "Uložte svoje nastavení anonymně do cloudu"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Je tady Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17281,7 +17563,8 @@ msgstr "Přejdi dolů a vyhledej %1$ssvůj prohlížeč%2$s v seznamu."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
+msgstr ""
+"Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17837,13 +18120,14 @@ msgstr "V Safari zvol %1$sNastavení pro tuto webovou stránku...%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej "
-"%3$shttps://duckduckgo.com%4$s"
+"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej %3$shttps://"
+"duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
+msgstr ""
+"Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17985,7 +18269,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
+msgstr ""
+"V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18125,6 +18410,13 @@ msgid "Serbian (Latin)"
 msgstr "Srbština (latinka)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18225,7 +18517,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
+msgstr ""
+"Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18277,6 +18570,14 @@ msgid "Share"
 msgstr "Sdílet"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18318,8 +18619,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. "
-"Duck.ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
+"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. Duck."
+"ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18423,6 +18724,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Řekni nám, co si myslíš o vyhledávacím poli."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19104,6 +19417,12 @@ msgid "Something went wrong"
 msgstr "Něco se pokazilo"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19271,7 +19590,8 @@ msgstr "Vymazaný zdrojový text"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
+msgstr ""
+"Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19946,6 +20266,12 @@ msgid "Switch model"
 msgstr "Přepnout model"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20199,6 +20525,13 @@ msgid "Synced Devices"
 msgstr "Synchronizovaná zařízení"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Sýrie"
 
@@ -20229,6 +20562,12 @@ msgstr "Nedostupné"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20296,7 +20635,8 @@ msgstr "Měj osobní údaje ve svých rukou!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
+msgstr ""
+"Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20501,13 +20841,15 @@ msgstr "Děkujeme za zpětnou vazbu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr ""
+"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr ""
+"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -20567,7 +20909,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
+msgstr ""
+"Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20718,7 +21061,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
+msgstr ""
+"Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20806,6 +21150,22 @@ msgstr ""
 "urážlivé informace. Další informace najdeš tady: %4$s."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20891,6 +21251,12 @@ msgstr ""
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Tyto informace nejsou užitečné"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21008,6 +21374,18 @@ msgstr ""
 "s AI nikdy nezobrazuje."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21028,13 +21406,15 @@ msgstr "Tento překlad je špatný"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
+msgstr ""
+"Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
+msgstr ""
+"Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21250,7 +21630,8 @@ msgstr "Dnes"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "Přepnutím vyzkoušej soukromý chat s AI, nebo ho %1$svypni v nabídce %2$s.%3$s"
+msgstr ""
+"Přepnutím vyzkoušej soukromý chat s AI, nebo ho %1$svypni v nabídce %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21598,7 +21979,8 @@ msgstr "Zkus přejít na %1$s a podobné zprávy už ti nebudeme ukazovat."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
+msgstr ""
+"Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21644,6 +22026,12 @@ msgstr "Vyzkoušet zdarma"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Vyzkoušet zdarma"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21757,6 +22145,12 @@ msgstr "Vyzkoušet zdarma"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Vyzkoušet zdarma"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22004,6 +22398,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistán"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22014,6 +22414,12 @@ msgstr "Vypnout Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Vypnout Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22308,8 +22714,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: "
-"https://duckduckgo.com"
+"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22319,7 +22725,8 @@ msgstr "V nabídce %1$sNastavení vyhledávání%2$s zvol %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
+msgstr ""
+"Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -22495,6 +22902,12 @@ msgid "Unmute"
 msgstr "Zrušit ztlumení"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22528,6 +22941,12 @@ msgstr "Aktualizovat"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Aktualizovat prohlížeč"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22699,7 +23118,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
+msgstr ""
+"Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22809,7 +23229,8 @@ msgstr "Použít vyhledávač Private Search od DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
+msgstr ""
+"Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23433,7 +23854,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
+msgstr ""
+"Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23454,7 +23876,8 @@ msgstr "Nesledujeme tě. Nikdy."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
+msgstr ""
+"My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23495,13 +23918,22 @@ msgstr "Nesledujeme tě. Ani v anonymním režimu ani mimo něj."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
+msgstr ""
+"My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Chat jsme ukončili z důvodu neaktivity. Chceš to zkusit znovu?"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23550,6 +23982,14 @@ msgstr ""
 "tebe. Vždycky si to můžeš později rozmyslet."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23585,6 +24025,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Zablokujeme trackery, které se snaží shromažďovat tvoje údaje při "
 "vyhledávání na internetu."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23730,7 +24178,8 @@ msgstr "Byl vyčerpán týdenní limit využití"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23897,6 +24346,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Jaké výhody a nevýhody má anuitní splácení úvěru?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24258,7 +24713,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
+msgstr ""
+"Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24462,6 +24918,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Bez záruky „Poskytovatel nic nevidí“"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24961,6 +25425,13 @@ msgid "You have 1 attempt left."
 msgstr "Zbývá 1 pokus."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25177,6 +25648,23 @@ msgid "YouTube Standard"
 msgstr "Standard YouTube"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Tvoje historie vyhledávání DuckDuckGo je soukromá"
@@ -25198,6 +25686,14 @@ msgstr "Tvoje skutečná poloha zůstává soukromá"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Tvoje skutečná poloha zůstává soukromá."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25349,7 +25845,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
+msgstr ""
+"Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25460,7 +25957,8 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr "Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
+msgstr ""
+"Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25567,7 +26065,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
+msgstr ""
+"Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25869,7 +26368,8 @@ msgstr "oficiálních webových stránkách"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
+msgstr ""
+"nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Toto zařízení)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -106,8 +106,7 @@ msgstr "Počet pokusů: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
+msgstr "Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -500,7 +499,7 @@ msgstr "%1$sZjisti, jak chráníme informace o poloze%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sDalší informace%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -515,8 +514,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
+msgstr "%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -528,8 +526,7 @@ msgstr "%1$sPodrž%2$s ikonu aplikace DuckDuckGo na domovské obrazovce"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
+msgstr "%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -796,7 +793,7 @@ msgstr "2. místo ve skupině %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2. názor"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -880,8 +877,7 @@ msgstr "Byl vyčerpán 6hodinový limit využití."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -952,8 +948,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
+msgstr "Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1485,7 +1480,7 @@ msgstr "Přidat na domovskou obrazovku"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Přidat do mých chatů"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1598,8 +1593,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"Pokročilé modely můžou limity vyčerpat 2–5× rychleji než jiné modely. %1$s"
+msgstr "Pokročilé modely můžou limity vyčerpat 2–5× rychleji než jiné modely. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1853,7 +1847,7 @@ msgstr "Všechny typy"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Všechna tvoje zařízení jsou odpojena od synchronizace."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1890,8 +1884,7 @@ msgstr "Povolit anonymní kontrolu souborů pro tento chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
+msgstr "Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2224,8 +2217,7 @@ msgstr "Jsi tam ještě?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
+msgstr "Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2380,7 +2372,7 @@ msgstr "Zeptej se soukromě na cokoli"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Zeptej se soukromě na cokoli"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -3363,8 +3355,7 @@ msgstr "Kliknutím na „%1$s“ odsouhlasíš naše %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
+msgstr "Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3443,8 +3434,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
+msgstr "Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -4539,15 +4529,13 @@ msgstr "Klikni %1$ssem%2$s a stáhni si rozšíření DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
+msgstr "Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
+msgstr "V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -5330,7 +5318,7 @@ msgstr "Kopírovat"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopírovat"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5379,13 +5367,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Kopírovat sdílený odkaz"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Zkopíruj kód z jiného zařízení"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5394,6 +5382,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Zkopíruj kód z jiného zařízení. Přejdi do %1$sNastavení Duck.ai › Chaty › "
+"Sync & Backup › Synchronizace s jiným zařízením%2$s a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5781,8 +5771,7 @@ msgstr "Byl vyčerpán denní limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6081,7 +6070,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Smazat sdílený odkaz"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6102,6 +6091,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Odkaz po smazání přestane fungovat. Lidé, kteří konverzaci otevřeli a "
+"přidali si ji do svých chatů, si zachovají vlastní kopii."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6363,7 +6354,7 @@ msgstr "Skrýt"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Skrýt"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6499,8 +6490,7 @@ msgstr "Nevidíš v seznamu DuckDuckGo?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
+msgstr "Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6869,8 +6859,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
+msgstr "Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6958,8 +6947,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
+msgstr "Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7008,8 +6996,7 @@ msgstr "Upgrade Duck.ai je hotový!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
+msgstr "Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7186,8 +7173,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
+msgstr "DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7226,7 +7212,7 @@ msgstr "Prohlížeč DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Stránky nápovědy DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7990,8 +7976,7 @@ msgstr "Rovníková Guinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
+msgstr "Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8058,7 +8043,7 @@ msgstr "Odborně vyrobené produkty pro lidi, kterým záleží na soukromí."
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Platnost vypršela"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8072,7 +8057,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Vyprší %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8355,8 +8340,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
+msgstr "Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8433,8 +8417,7 @@ msgstr "Filtry nefungují"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
+msgstr "Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8603,8 +8586,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
+msgstr "Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8715,8 +8697,7 @@ msgstr "Bezplatné a soukromé chaty, které anonymizujeme"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
+msgstr "Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9345,8 +9326,8 @@ msgstr "Stáhnout aplikaci"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Nainstaluj si bezplatný prohlížeč DuckDuckGo %1$sa blokuj reklamy na YouTube."
-"%2$s"
+"Nainstaluj si bezplatný prohlížeč DuckDuckGo %1$sa blokuj reklamy na "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9451,6 +9432,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Přejdi do %1$sNastavení Duck.ai%2$s › %3$sChaty › Sync & Backup › "
+"Synchronizace s jiným zařízením%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9568,7 +9551,7 @@ msgstr "Mám to"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Rozumím"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10371,8 +10354,7 @@ msgstr "Jak to funguje"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
+msgstr "Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10620,8 +10602,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
+msgstr "Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10630,8 +10611,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
+msgstr "Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -11150,8 +11130,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
+msgstr "Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11546,7 +11525,7 @@ msgstr "%1$sVíce%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Více informací"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11721,8 +11700,7 @@ msgstr "Umožní ti anonymně vyhledávat pomocí DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Umožní ti přepínat mezi odesíláním vyhledávacích dotazů a promptů do Duck.ai"
+msgstr "Umožní ti přepínat mezi odesíláním vyhledávacích dotazů a promptů do Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12111,8 +12089,7 @@ msgstr "Ujisti se, že jsou všechna slova napsaná správně."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
+msgstr "Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12184,7 +12161,7 @@ msgstr "Spravovat"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Spravovat"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12441,7 +12418,7 @@ msgstr "Menu"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Zprávy od tohoto místa dál vidíš jen ty."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12704,8 +12681,7 @@ msgstr "Byl vyčerpán měsíční limit"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12816,7 +12792,7 @@ msgstr "Více o Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Další akce"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13016,7 +12992,7 @@ msgstr "Tlumená červená"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Moje zařízení"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13576,8 +13552,7 @@ msgstr "Nebyly nalezeny žádné výsledky."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
+msgstr "Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14094,6 +14069,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Na jiném zařízení přejdi na %1$sNastavení Duck.ai%2$s › %3$s Chaty › Sync & "
+"Backup › Synchronizace s jiným zařízením%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14102,6 +14079,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Na jiném zařízení přejdi do %1$sNastavení Duck.ai%2$s › %3$sChaty › Sync & "
+"Backup › Synchronizace s jiným zařízením%4$s a naskenuj tento kód:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14110,6 +14089,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Na jiném zařízení přejdi do %1$sNastavení Duck.ai%2$s › %3$sChaty › Sync & "
+"Backup › Synchronizace s jiným zařízením%4$s. Nebo naskenuj QR kód ze svého "
+"PDF pro obnovení."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14180,8 +14162,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
+msgstr "Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14256,8 +14237,7 @@ msgstr "Otevřít %1$sNastavení%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
+msgstr "Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14866,7 +14846,7 @@ msgstr "Minulý rok"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Vložit"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14884,7 +14864,7 @@ msgstr "Vložit kód Sync"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Vlož ho níže"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14943,7 +14923,7 @@ msgstr "Perština"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14952,6 +14932,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Funkce Personal Information Removal najde tvoje údaje na webech "
+"zprostředkovatelů dat, kteří je prodávají. A pak zapracujeme na jejich "
+"odstranění za tebe."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15993,8 +15976,7 @@ msgstr "Upozornit"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
+msgstr "Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16036,8 +16018,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
+msgstr "Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16212,7 +16193,7 @@ msgstr "Čtení webové stránky..."
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Těšíš se na zatmění Slunce?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16407,7 +16388,7 @@ msgstr "Kód pro obnovení"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Kód pro obnovení"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16664,7 +16645,7 @@ msgstr "Odstranit %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Smazat zařízení"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16712,13 +16693,13 @@ msgstr "Odstraň zbytečnou interpunkci"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Odstranění tvých údajů z internetu"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Odstraň své údaje online"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17162,8 +17143,7 @@ msgstr "SV"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
+msgstr "Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -17230,8 +17210,7 @@ msgstr "Bezpečné vyhledávání zablokovalo výsledky pro %1$s."
 # smartling.placeholder_format=C
 #. A label above search results that lets the user know the safe search filter blocked some of the results from showing. The placeholder value is the user's search term.
 msgid "Safe search blocked some results for %s."
-msgstr ""
-"Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
+msgstr "Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
 
 # smartling.placeholder_format=C
 #. Safe search lets you remove adult content from results on DuckDuckGo. This string is used to invite users to select the desired level of protection (e.g., strict, moderate, off)
@@ -17379,8 +17358,7 @@ msgstr "Ukládej až 30 svých nejnovějších chatů lokálně na své zaříze
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
+msgstr "Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17416,7 +17394,7 @@ msgstr "Je tady Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Je tady Duck.ai – bezplatný, soukromý AI chat od DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17563,8 +17541,7 @@ msgstr "Přejdi dolů a vyhledej %1$ssvůj prohlížeč%2$s v seznamu."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
+msgstr "Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18120,14 +18097,13 @@ msgstr "V Safari zvol %1$sNastavení pro tuto webovou stránku...%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej %3$shttps://"
-"duckduckgo.com%4$s"
+"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
+msgstr "Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18269,8 +18245,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
+msgstr "V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18414,7 +18389,7 @@ msgstr "Srbština (latinka)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Data ze serveru byla smazána"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18517,8 +18492,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
+msgstr "Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18575,7 +18549,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Sdílet"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18619,8 +18593,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. Duck."
-"ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
+"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. "
+"Duck.ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18729,13 +18703,13 @@ msgstr "Řekni nám, co si myslíš o vyhledávacím poli."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Sdílené odkazy na chat"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Sdílené odkazy na chat"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19420,7 +19394,7 @@ msgstr "Něco se pokazilo"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Při načítání tohoto sdíleného chatu se něco pokazilo."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19590,8 +19564,7 @@ msgstr "Vymazaný zdrojový text"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
+msgstr "Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20269,7 +20242,7 @@ msgstr "Přepnout model"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Přepnout model"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20529,7 +20502,7 @@ msgstr "Synchronizovaná zařízení"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Synchronizováno %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20567,7 +20540,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabulka"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20635,8 +20608,7 @@ msgstr "Měj osobní údaje ve svých rukou!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
+msgstr "Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20841,15 +20813,13 @@ msgstr "Děkujeme za zpětnou vazbu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -20909,8 +20879,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
+msgstr "Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21061,8 +21030,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
+msgstr "Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21153,7 +21121,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Tohle zařízení"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21164,6 +21132,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Tohle zařízení už nebude mít přístup k tvým synchronizovaným datům na "
+"ostatních zařízeních. Posledních %1$s chatů zůstane dál k dispozici v "
+"místním úložišti."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21256,7 +21227,7 @@ msgstr "Tyto informace nejsou užitečné"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Toto je kopie sdíleného chatu."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21377,13 +21348,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Tenhle sdílený chat nelze otevřít. Odkaz může být neúplný."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Tenhle odkaz na sdílený chat už není dostupný."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21406,15 +21377,13 @@ msgstr "Tento překlad je špatný"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
+msgstr "Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
+msgstr "Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21630,8 +21599,7 @@ msgstr "Dnes"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"Přepnutím vyzkoušej soukromý chat s AI, nebo ho %1$svypni v nabídce %2$s.%3$s"
+msgstr "Přepnutím vyzkoušej soukromý chat s AI, nebo ho %1$svypni v nabídce %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21979,8 +21947,7 @@ msgstr "Zkus přejít na %1$s a podobné zprávy už ti nebudeme ukazovat."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
+msgstr "Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22031,7 +21998,7 @@ msgstr "Vyzkoušet zdarma"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Vyzkoušet zdarma!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22150,7 +22117,7 @@ msgstr "Vyzkoušet zdarma"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Vyzkoušej to zdarma!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22401,7 +22368,7 @@ msgstr "Turkmenistán"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Vypnout"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22419,7 +22386,7 @@ msgstr "Vypnout Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Vypnout Sync & Backup a smazat data na serveru?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22714,8 +22681,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: https://duckduckgo."
-"com"
+"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22725,8 +22692,7 @@ msgstr "V nabídce %1$sNastavení vyhledávání%2$s zvol %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
+msgstr "Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -22905,7 +22871,7 @@ msgstr "Zrušit ztlumení"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Chat bez názvu"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22946,7 +22912,7 @@ msgstr "Aktualizovat prohlížeč"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Pro zobrazení tohoto sdíleného chatu aktualizuj Duck.ai."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23118,8 +23084,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
+msgstr "Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23229,8 +23194,7 @@ msgstr "Použít vyhledávač Private Search od DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
+msgstr "Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23854,8 +23818,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
+msgstr "Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23876,8 +23839,7 @@ msgstr "Nesledujeme tě. Nikdy."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
+msgstr "My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23918,8 +23880,7 @@ msgstr "Nesledujeme tě. Ani v anonymním režimu ani mimo něj."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
+msgstr "My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23934,6 +23895,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Najdeme a odstraníme tvoje osobní údaje z webů zprostředkovatelů dat. Navíc "
+"získáš VPN a další výhody."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23988,6 +23951,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Pravidelně na webech zprostředkovatelů dat hledáme tvé osobní údaje a o svém "
+"pokroku tě informujeme na snadno použitelném ovládacím panelu."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24033,6 +23998,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Na webech zprostředkovatelů dat vyhledáme tvůj e-mail, jméno, adresu a další "
+"údaje a zapracujeme na odstranění všeho, co o tobě najdeme."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24178,8 +24145,7 @@ msgstr "Byl vyčerpán týdenní limit využití"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24351,7 +24317,7 @@ msgstr "Jaké výhody a nevýhody má anuitní splácení úvěru?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Jaké jsou výhody Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24713,8 +24679,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
+msgstr "Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24926,6 +24891,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Funguje přímo z tvého zařízení a odstraňuje tvůj e-mail, jméno, adresu a "
+"další údaje z webů zprostředkovatelů dat."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25429,7 +25396,7 @@ msgstr "Zbývá 1 pokus."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Nemáš žádné sdílené odkazy na chat."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25656,13 +25623,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Tvých %1$s nejnovějších chatů bude k dispozici v místním úložišti těchto "
+"prohlížečů:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Tvoje chaty Duck.ai se synchronizují se šifrováním end-to-end."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25694,6 +25663,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Tvoje záloha se smaže ze serveru DuckDuckGo. Všechna zařízení se odpojí od "
+"synchronizace."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25845,8 +25816,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
+msgstr "Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25957,8 +25927,7 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr ""
-"Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
+msgstr "Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26065,8 +26034,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
+msgstr "Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26368,8 +26336,7 @@ msgstr "oficiálních webových stránkách"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
+msgstr "nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/cy_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/cy_GB/LC_MESSAGES/duckduckgo.po
@@ -45,6 +45,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -401,6 +408,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%sDysgwch sut ydyn ni'n cadw eich lleoliad yn breifat yma%s."
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -635,6 +648,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1188,6 +1206,11 @@ msgstr "Ychwanegu i %s"
 msgid "Add to Home Screen"
 msgstr "Ychwanegu i Sgrin Gartref"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Ategolion"
@@ -1479,6 +1502,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1889,6 +1918,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4220,6 +4254,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4252,6 +4291,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4813,6 +4871,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4821,6 +4886,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5027,6 +5099,12 @@ msgstr "Diswyddo"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5675,6 +5753,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6337,9 +6421,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7438,6 +7535,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7522,6 +7626,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9118,6 +9227,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Dysgu %smwy%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9637,6 +9751,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9844,6 +9964,11 @@ msgstr "Dewislen"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Dewislen"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 #, fuzzy
 msgctxt "settingsvalue"
@@ -10148,6 +10273,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Mwy ar"
@@ -10306,6 +10436,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Coch tawel"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11187,6 +11322,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11802,6 +11958,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11810,6 +11971,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11854,6 +12020,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12872,6 +13050,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13021,6 +13204,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13228,6 +13416,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13261,6 +13454,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13810,6 +14013,11 @@ msgstr "Arbed eich gosodiadau yn anhysbys i'r cwmwl"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14578,6 +14786,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14704,6 +14918,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14824,6 +15045,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15371,6 +15602,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16064,6 +16300,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16261,6 +16502,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16286,6 +16533,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Teledu"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16738,6 +16990,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16806,6 +17072,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16889,6 +17160,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17403,6 +17684,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17495,6 +17781,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17694,6 +17985,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17702,6 +17998,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18083,6 +18384,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18110,6 +18416,11 @@ msgstr "Diweddaru"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18888,6 +19199,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18922,6 +19240,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18946,6 +19271,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19191,6 +19523,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19655,6 +19992,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20058,6 +20402,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20227,6 +20577,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Safon YouTube"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20244,6 +20609,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: da_DK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Denne enhed)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -308,8 +308,7 @@ msgstr "Rangeringer for %1$s er endnu ikke tilgængelige"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s når brugsgrænserne 2-5 gange hurtigere end grundlæggende modeller. %2$s"
+msgstr "%1$s når brugsgrænserne 2-5 gange hurtigere end grundlæggende modeller. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -445,8 +444,7 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
+msgstr "%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -501,15 +499,14 @@ msgstr "%1$sSe, hvordan vi holder din placering hemmelig%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sLæs mere%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
+msgstr "%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -794,7 +791,7 @@ msgstr "2. i gruppe %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2. vurdering"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -878,8 +875,7 @@ msgstr "Grænsen på 6 timers brug er nået."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
+msgstr "Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -950,16 +946,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
+msgstr "En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
+msgstr "En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1484,7 +1478,7 @@ msgstr "Føj til startskærm"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Føj til mine chats"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1812,8 +1806,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
+msgstr "Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1854,7 +1847,7 @@ msgstr "Alle typer"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Alle dine enheder er afbrudt fra Sync."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2126,8 +2119,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. f."
-"eks. Fortæl mig altid fakta om ænder"
+"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. "
+"f.eks. Fortæl mig altid fakta om ænder"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2226,8 +2219,7 @@ msgstr "Er du der stadig?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
+msgstr "Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2239,8 +2231,7 @@ msgstr "Er du sikker på, at du vil rydde denne samtale og starte en ny?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
+msgstr "Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2384,7 +2375,7 @@ msgstr "Spørg om hvad som helst privat"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Spørg om hvad som helst privat"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2447,8 +2438,8 @@ msgstr ""
 "skal vises: Aldrig (fjerner Assist UI fra søgeresultaterne), On-demand "
 "(viser kun AI-assisterede svar, hvis du klikker på knappen Assist), Nogle "
 "gange (viser kun AI-assisterede svar, når det er yderst relevant) eller Ofte "
-"(vises oftere på en bredere række af søgninger). Indtil videre er AI-"
-"assisterede svar kun tilgængelige i USA (engelsk)."
+"(vises oftere på en bredere række af søgninger). Indtil videre er "
+"AI-assisterede svar kun tilgængelige i USA (engelsk)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2992,8 +2983,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"Blokér skadelige hjemmesider, skjul din IP-adresse, og få mere premium-"
-"beskyttelse med vores abonnement."
+"Blokér skadelige hjemmesider, skjul din IP-adresse, og få mere "
+"premium-beskyttelse med vores abonnement."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3741,8 +3732,7 @@ msgstr "Ændrer den måde, URL-resultaterne vises på"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
+msgstr "Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4072,8 +4062,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i Duck."
-"ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
+"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i "
+"Duck.ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4206,8 +4196,7 @@ msgstr "Vælg mellem flere AI-modeller, herunder %1$s og %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
+msgstr "Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4657,8 +4646,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
 "Klik eller tryk på %1$sSlet mine oplysninger%2$s. Dette fjerner "
-"oplysningerne fra skyen, men de forbliver i din browser, indtil du klikker/"
-"trykker på %3$sNulstil alle indstillinger%4$s."
+"oplysningerne fra skyen, men de forbliver i din browser, indtil du "
+"klikker/trykker på %3$sNulstil alle indstillinger%4$s."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -5317,7 +5306,7 @@ msgstr "Kopi"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopiér"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5366,13 +5355,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Kopiér delt link"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Kopiér koden fra en anden enhed"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5381,6 +5370,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Kopiér koden fra en anden enhed. Gå til %1$sDuck.ai-indstillinger › Chats › "
+"Sync & Backup › Synkroniser med en anden enhed%2$s, og prøv igen."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6051,8 +6042,7 @@ msgstr "Vil du slette de ældste chats for at frigøre lagerplads?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
+msgstr "Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6066,7 +6056,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Slet delt link"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6087,6 +6077,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Hvis du sletter et link, stopper det med at fungere. Personer, der har åbnet "
+"det og føjet samtalen til deres chats, beholder deres egen kopi."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6182,8 +6174,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr "Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6347,7 +6338,7 @@ msgstr "Afvis"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Afvis"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6521,8 +6512,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen AI-"
-"funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen "
+"AI-funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6531,8 +6522,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden AI-"
-"funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden "
+"AI-funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6931,11 +6922,12 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai giver dig mulighed for at have anonyme samtaler med tredjeparts-AI-"
-"chatmodeller, herunder modeller fra OpenAI, Anthropic og andre. Hvis du "
-"deaktiverer denne indstilling, vil Duck.ai-knapper og -links blive skjult på "
-"DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, når denne "
-"indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s direkte."
+"Duck.ai giver dig mulighed for at have anonyme samtaler med "
+"tredjeparts-AI-chatmodeller, herunder modeller fra OpenAI, Anthropic og "
+"andre. Hvis du deaktiverer denne indstilling, vil Duck.ai-knapper og -links "
+"blive skjult på DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, "
+"når denne indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s "
+"direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7001,8 +6993,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privat AI-chatbot, gratis AI-chat, anonym AI-chat, "
-"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source AI-"
-"modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
+"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source "
+"AI-modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
 "konto"
 
 # smartling.placeholder_format=C
@@ -7165,8 +7157,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
+msgstr "DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7205,7 +7196,7 @@ msgstr "DuckDuckGo-browser %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo-hjælpesider"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7708,8 +7699,7 @@ msgstr "Aktivér diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
+msgstr "Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7819,8 +7809,7 @@ msgstr "Kan du lide Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
+msgstr "Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8041,7 +8030,7 @@ msgstr "Ekspertfremstillede produkter til folk, der prioriterer privatliv."
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Udløbet"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8055,7 +8044,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Udløber %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8080,8 +8069,7 @@ msgstr "Forklar det accepterede svar i simple termer."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
+msgstr "Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8319,8 +8307,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
-"forbedringer."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og "
+"-forbedringer."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8329,8 +8317,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
-"forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og "
+"-forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8422,8 +8410,7 @@ msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
+msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8723,8 +8710,7 @@ msgstr "Gratis at dele og bruge kommercielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
+msgstr "Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9258,8 +9244,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Få vores hurtige VPN uden logfiler, valgfri adgang til avancerede AI-"
-"modeller med højere chatgrænser og flere premium-beskyttelser."
+"Få vores hurtige VPN uden logfiler, valgfri adgang til avancerede "
+"AI-modeller med højere chatgrænser og flere premium-beskyttelser."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9322,8 +9308,8 @@ msgstr "Hent appen"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Hent den gratis DuckDuckGo-browser %1$sfor at blokere annoncer på YouTube."
-"%2$s"
+"Hent den gratis DuckDuckGo-browser %1$sfor at blokere annoncer på "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9382,9 +9368,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden enhed "
-"› Kopiér tekstkode%4$s"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed › Kopiér tekstkode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9393,9 +9379,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
-"enhed%4$s"
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9405,9 +9391,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
-"enhed%4$s, og scan denne kode:"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed%4$s, og scan denne kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9417,9 +9403,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
-"enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9428,6 +9414,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Gå til %1$sDuck.ai-indstillinger%2$s › %3$sChats › Sync & Backup › "
+"Synkroniser med en anden enhed%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9543,7 +9531,7 @@ msgstr "Forstået"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Forstået"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10352,8 +10340,7 @@ msgstr "Hvor tit vil du have, at AI-assisterede svar skal dukke op?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
+msgstr "Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10794,8 +10781,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr ""
-"Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
+msgstr "Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11524,7 +11510,7 @@ msgstr "Få %1$sMere%2$s at vide"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Mere info"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11699,8 +11685,7 @@ msgstr "Lader dig søge anonymt på internettet med DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Lader dig skifte mellem at indsende søgeforespørgsler og prompter til Duck.ai"
+msgstr "Lader dig skifte mellem at indsende søgeforespørgsler og prompter til Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11905,8 +11890,7 @@ msgstr "Indlæser flere billedresultater, mens du scroller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
+msgstr "Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12164,7 +12148,7 @@ msgstr "Administrer"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Administrer"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12421,7 +12405,7 @@ msgstr "Menu"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Beskeder efter dette punkt er kun synlige for dig."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12793,7 +12777,7 @@ msgstr "Mere om Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Flere handlinger"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12993,7 +12977,7 @@ msgstr "Dæmpet rød"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Mine enheder"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13235,10 +13219,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nye prompter og svar krypteres og gemmes midlertidigt på en DuckDuckGo-"
-"server efter afsendelse for at hjælpe med at gendanne en chat, hvis du "
-"mister din internetforbindelse. Deaktivering af chathistorikken sletter "
-"fastgjorte chats og deaktiverer midlertidig lagring af nye prompter og svar."
+"Nye prompter og svar krypteres og gemmes midlertidigt på en "
+"DuckDuckGo-server efter afsendelse for at hjælpe med at gendanne en chat, "
+"hvis du mister din internetforbindelse. Deaktivering af chathistorikken "
+"sletter fastgjorte chats og deaktiverer midlertidig lagring af nye prompter "
+"og svar."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14070,6 +14055,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"På en anden enhed skal du gå til %1$sDuck.ai-indstillinger%2$s › %3$sChats › "
+"Sync & Backup › Synkroniser med en anden enhed%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14078,6 +14065,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Gå til %1$sDuck.ai-indstillinger%2$s › %3$sChats › Sync & Backup › "
+"Synkroniser med en anden enhed%4$s på en anden enhed, og scan denne kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14086,6 +14075,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Gå til %1$sDuck.ai-indstillinger%2$s › %3$sChats › Sync & Backup › "
+"Synkroniser med en anden enhed%4$s på en anden enhed. Eller scan QR-koden på "
+"din gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14481,8 +14473,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"Andre søgemaskiner sporer dine søgninger, selv når du er i privat browsing-"
-"tilstand. Vi sporer dig ikke – punktum."
+"Andre søgemaskiner sporer dine søgninger, selv når du er i privat "
+"browsing-tilstand. Vi sporer dig ikke – punktum."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14840,7 +14832,7 @@ msgstr "Seneste år"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Indsæt"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14858,7 +14850,7 @@ msgstr "Indsæt synkroniseringskode"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Indsæt nedenfor"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14917,7 +14909,7 @@ msgstr "Persisk"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14926,6 +14918,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal finder dine oplysninger på datamæglerwebsteder, "
+"der sælger dem. Derefter arbejder vi på at få dem fjernet for dig."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -16194,7 +16188,7 @@ msgstr "Læser websted…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Klar til solformørkelsen?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16393,7 +16387,7 @@ msgstr "Gendannelseskode"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Gendannelseskode"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16650,7 +16644,7 @@ msgstr "Fjern %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Fjern enhed"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16698,13 +16692,13 @@ msgstr "Fjern unødvendig tegnsætning"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Fjern dine oplysninger fra internettet"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Fjern dine oplysninger online"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17397,7 +17391,7 @@ msgstr "Sig hej til Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Sig hej til Duck.ai – gratis, privat AI-chat af DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17550,8 +17544,7 @@ msgstr "Rul ned til %1$sDuckDuckGo%2$s, og lad den bruge din placering."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
+msgstr "Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17781,8 +17774,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge POST-"
-"anmodninger)"
+"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge "
+"POST-anmodninger)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18247,8 +18240,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
+msgstr "Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18393,7 +18385,7 @@ msgstr "Serbisk (latin)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Serverdata er slettet"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18555,7 +18547,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Del"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18572,8 +18564,7 @@ msgstr "Del"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
+msgstr "Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18710,13 +18701,13 @@ msgstr "Del dine tanker om søgefeltet."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Delte chatlinks"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Delte chatlinks"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19106,8 +19097,7 @@ msgstr "Viser vandrette linjer ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
+msgstr "Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19128,8 +19118,7 @@ msgstr "Viser lejlighedsvise påmindelser om at føje DuckDuckGo til din browser
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
+msgstr "Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19147,8 +19136,7 @@ msgstr "Vis sidenumre ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
+msgstr "Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19246,8 +19234,7 @@ msgstr "Navne på websteder"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
+msgstr "Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19399,7 +19386,7 @@ msgstr "Noget gik galt"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Noget gik galt under indlæsning af denne delte chat."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19569,8 +19556,7 @@ msgstr "Kildetekst ryddet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
+msgstr "Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19739,8 +19725,7 @@ msgstr "Start med et billede"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
+msgstr "Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -19776,8 +19761,7 @@ msgstr "Bliv på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
+msgstr "Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20256,7 +20240,7 @@ msgstr "Skift model"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Skift model"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20519,7 +20503,7 @@ msgstr "Synkroniserede enheder"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Synkroniseret den %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20557,7 +20541,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabel"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20870,15 +20854,13 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
+msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
+msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -20916,8 +20898,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
+msgstr "Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21069,8 +21050,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
+msgstr "Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21145,7 +21125,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Denne enhed"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21156,6 +21136,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Denne enhed vil ikke længere have adgang til dine synkroniserede data på "
+"andre enheder. De seneste %1$s chats vil stadig være tilgængelige i lokal "
+"lagring."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21226,16 +21209,14 @@ msgstr "Dette billede kunne ikke oprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
+msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
+msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21246,7 +21227,7 @@ msgstr "Disse oplysninger er ikke nyttige"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Dette er en kopi af en delt chat."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21314,8 +21295,7 @@ msgstr "Denne side kræver JavaScript for at kunne fungere."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
+msgstr "Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21365,13 +21345,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Denne delte chat kunne ikke åbnes. Linket kan være ufuldstændigt."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Dette delte chatlink er ikke længere tilgængeligt."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21394,8 +21374,7 @@ msgstr "Denne oversættelse er forkert"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
+msgstr "Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -22019,7 +21998,7 @@ msgstr "Prøv gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Prøv gratis!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22101,8 +22080,7 @@ msgstr "Prøv andre nøgleord."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
+msgstr "Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22139,7 +22117,7 @@ msgstr "Prøv gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Prøv gratis!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22388,7 +22366,7 @@ msgstr "Turkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Slå fra"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22406,7 +22384,7 @@ msgstr "Slå Sync & Backup fra"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Slå Sync & Backup fra, og slet serverdata?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22688,8 +22666,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: https://"
-"duckduckgo.com"
+"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22716,15 +22694,14 @@ msgstr "Under %1$sSøg i adressefeltet med%2$s vælger du %3$sTilføj ny%4$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner ..."
-"%4$s"
+"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner "
+"...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
+msgstr "Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22831,8 +22808,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås op for avancerede AI-modeller og højere grænser med et DuckDuckGo-"
-"abonnement"
+"Lås op for avancerede AI-modeller og højere grænser med et "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22871,8 +22848,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
+msgstr "Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -22890,7 +22866,7 @@ msgstr "Slå lyd til"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Chat uden titel"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22931,7 +22907,7 @@ msgstr "Opdater browser"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Opdater Duck.ai for at se denne delte chat."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23103,8 +23079,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
+msgstr "Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23214,8 +23189,7 @@ msgstr "Brug DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
+msgstr "Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23513,9 +23487,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn Duck.ai-"
-"indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg \"Synkroniser "
-"med en anden enhed\". Eller scan QR-koden på din gendannelses-PDF."
+"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn "
+"Duck.ai-indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg "
+"\"Synkroniser med en anden enhed\". Eller scan QR-koden på din "
+"gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23567,8 +23542,7 @@ msgstr "Stemmesamtale afsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr "Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23793,8 +23767,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
+msgstr "Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23917,6 +23890,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Vi finder og fjerner dine personlige oplysninger fra datamæglerwebsteder. "
+"Plus få en VPN og mere."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23971,6 +23946,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Vi scanner regelmæssigt datamæglerwebsteder for dine personlige oplysninger, "
+"og vi deler vores fremskridt med dig i et brugervenligt dashboard."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24006,8 +23983,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
+msgstr "Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24016,6 +23992,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Vi scanner datamæglerwebsteder for din e-mailadresse, dit navn, din adresse "
+"og mere og arbejder på at få alt, hvad vi finder om dig, fjernet."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24049,8 +24027,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
+msgstr "Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24213,8 +24190,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
+msgstr "Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24305,15 +24281,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
+msgstr "Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
+msgstr "Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24335,7 +24309,7 @@ msgstr "Hvad er nogle fordele og ulemper ved livrenter?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Hvad er fordelene ved Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24350,9 +24324,10 @@ msgid ""
 msgstr ""
 "Hvad er fordelene ved at downloade DuckDuckGo-browseren, hvis du er "
 "interesseret i at bruge Duck.ai? Referer kun officielle DuckDuckGo-kilder. "
-"Opdel svaret i klare sektioner med titler, med fokus på Duck.ai-"
-"integrationer og beskyttelse af privatlivet. Hold det kort, enkelt og "
-"letforståeligt for folk med eller uden betydelig AI- eller teknisk erfaring."
+"Opdel svaret i klare sektioner med titler, med fokus på "
+"Duck.ai-integrationer og beskyttelse af privatlivet. Hold det kort, enkelt "
+"og letforståeligt for folk med eller uden betydelig AI- eller teknisk "
+"erfaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24437,8 +24412,7 @@ msgstr "Hvilke retter bør man prøve her?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
+msgstr "Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24580,8 +24554,7 @@ msgstr "Hvilke informationer bliver gemt?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
-"Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
+msgstr "Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -24698,8 +24671,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
+msgstr "Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24915,6 +24887,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Arbejder direkte fra din enhed for at fjerne din e-mail, dit navn, din "
+"adresse og meget mere fra datamæglerwebsteder."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25183,8 +25157,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
+msgstr "Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25419,7 +25392,7 @@ msgstr "Du har 1 forsøg tilbage."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Du har ingen delte chatlinks."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25480,8 +25453,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
+msgstr "Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25576,16 +25548,14 @@ msgstr "Du har nået det maksimale antal beskeder for nu. Prøv igen senere."
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Du har nået den maksimale varighed af stemmechat for en enkelt session."
+msgstr "Du har nået den maksimale varighed af stemmechat for en enkelt session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
+msgstr "Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25650,13 +25620,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Dine %1$s seneste chats vil være tilgængelige i lokal lagring i disse "
+"browsere:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Dine Duck.ai-chats synkroniseres med end-to-end-kryptering."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25688,6 +25660,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Din sikkerhedskopiering blver slettet fra DuckDuckGos server. Alle enheder "
+"bliver afbrudt fra synkronisering."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25768,8 +25742,7 @@ msgstr "Dine chats bliver nu gemt."
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr ""
-"Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
+msgstr "Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25783,8 +25756,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
-"modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25792,8 +25765,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
-"modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25911,8 +25884,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure Hash-"
-"algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
+"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure "
+"Hash-algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
 "indstillingsfil forlader din browser. Vi gemmer indstillingsfilen ved at "
 "bruge nøglen som navnet. DuckDuckGo får aldrig dit adgangsudtryk at vide."
 

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: da_DK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% fuldt vaccineret"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% vaccineret"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -300,7 +308,8 @@ msgstr "Rangeringer for %1$s er endnu ikke tilgængelige"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s når brugsgrænserne 2-5 gange hurtigere end grundlæggende modeller. %2$s"
+msgstr ""
+"%1$s når brugsgrænserne 2-5 gange hurtigere end grundlæggende modeller. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -436,7 +445,8 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
+msgstr ""
+"%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -487,11 +497,19 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sSe, hvordan vi holder din placering hemmelig%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
+msgstr ""
+"%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -773,6 +791,12 @@ msgid "2nd in Group %s"
 msgstr "2. i gruppe %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -854,7 +878,8 @@ msgstr "Grænsen på 6 timers brug er nået."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
+msgstr ""
+"Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -925,14 +950,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
+msgstr ""
+"En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
+msgstr ""
+"En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1454,6 +1481,12 @@ msgid "Add to Home Screen"
 msgstr "Føj til startskærm"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Tilføjelser"
@@ -1779,7 +1812,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
+msgstr ""
+"Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1814,6 +1848,13 @@ msgstr "Alle størrelser"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Alle typer"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2085,8 +2126,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. "
-"f.eks. Fortæl mig altid fakta om ænder"
+"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. f."
+"eks. Fortæl mig altid fakta om ænder"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2185,7 +2226,8 @@ msgstr "Er du der stadig?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
+msgstr ""
+"Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2197,7 +2239,8 @@ msgstr "Er du sikker på, at du vil rydde denne samtale og starte en ny?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
+msgstr ""
+"Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2338,6 +2381,12 @@ msgid "Ask anything privately"
 msgstr "Spørg om hvad som helst privat"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2398,8 +2447,8 @@ msgstr ""
 "skal vises: Aldrig (fjerner Assist UI fra søgeresultaterne), On-demand "
 "(viser kun AI-assisterede svar, hvis du klikker på knappen Assist), Nogle "
 "gange (viser kun AI-assisterede svar, når det er yderst relevant) eller Ofte "
-"(vises oftere på en bredere række af søgninger). Indtil videre er "
-"AI-assisterede svar kun tilgængelige i USA (engelsk)."
+"(vises oftere på en bredere række af søgninger). Indtil videre er AI-"
+"assisterede svar kun tilgængelige i USA (engelsk)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2943,8 +2992,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"Blokér skadelige hjemmesider, skjul din IP-adresse, og få mere "
-"premium-beskyttelse med vores abonnement."
+"Blokér skadelige hjemmesider, skjul din IP-adresse, og få mere premium-"
+"beskyttelse med vores abonnement."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3692,7 +3741,8 @@ msgstr "Ændrer den måde, URL-resultaterne vises på"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
+msgstr ""
+"Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4022,8 +4072,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i "
-"Duck.ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
+"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i Duck."
+"ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4156,7 +4206,8 @@ msgstr "Vælg mellem flere AI-modeller, herunder %1$s og %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
+msgstr ""
+"Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4606,8 +4657,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
 "Klik eller tryk på %1$sSlet mine oplysninger%2$s. Dette fjerner "
-"oplysningerne fra skyen, men de forbliver i din browser, indtil du "
-"klikker/trykker på %3$sNulstil alle indstillinger%4$s."
+"oplysningerne fra skyen, men de forbliver i din browser, indtil du klikker/"
+"trykker på %3$sNulstil alle indstillinger%4$s."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -5263,6 +5314,12 @@ msgid "Copy"
 msgstr "Kopi"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5302,6 +5359,28 @@ msgstr "Kopiér eller gem denne kode"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Kopiér gendannelseskode"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5972,13 +6051,22 @@ msgstr "Vil du slette de ældste chats for at frigøre lagerplads?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
+msgstr ""
+"Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
 msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr "Slet seneste chats?"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -5991,6 +6079,14 @@ msgstr "Slet denne chat?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Slettede chats"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6086,7 +6182,8 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr ""
+"Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6244,6 +6341,13 @@ msgstr "Afvis"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Afvis"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6417,8 +6521,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen "
-"AI-funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen AI-"
+"funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6427,8 +6531,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden "
-"AI-funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden AI-"
+"funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6827,12 +6931,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai giver dig mulighed for at have anonyme samtaler med "
-"tredjeparts-AI-chatmodeller, herunder modeller fra OpenAI, Anthropic og "
-"andre. Hvis du deaktiverer denne indstilling, vil Duck.ai-knapper og -links "
-"blive skjult på DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, "
-"når denne indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s "
-"direkte."
+"Duck.ai giver dig mulighed for at have anonyme samtaler med tredjeparts-AI-"
+"chatmodeller, herunder modeller fra OpenAI, Anthropic og andre. Hvis du "
+"deaktiverer denne indstilling, vil Duck.ai-knapper og -links blive skjult på "
+"DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, når denne "
+"indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6898,8 +7001,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privat AI-chatbot, gratis AI-chat, anonym AI-chat, "
-"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source "
-"AI-modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
+"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source AI-"
+"modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
 "konto"
 
 # smartling.placeholder_format=C
@@ -7062,7 +7165,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
+msgstr ""
+"DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7095,6 +7199,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo-browser %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7597,7 +7708,8 @@ msgstr "Aktivér diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
+msgstr ""
+"Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7707,7 +7819,8 @@ msgstr "Kan du lide Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
+msgstr ""
+"Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7924,10 +8037,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "Ekspertfremstillede produkter til folk, der prioriterer privatliv."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Udløbet"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7952,7 +8080,8 @@ msgstr "Forklar det accepterede svar i simple termer."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
+msgstr ""
+"Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8190,8 +8319,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og "
-"-forbedringer."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
+"forbedringer."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8200,8 +8329,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og "
-"-forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
+"forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8293,7 +8422,8 @@ msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
+msgstr ""
+"Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8593,7 +8723,8 @@ msgstr "Gratis at dele og bruge kommercielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
+msgstr ""
+"Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9127,8 +9258,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Få vores hurtige VPN uden logfiler, valgfri adgang til avancerede "
-"AI-modeller med højere chatgrænser og flere premium-beskyttelser."
+"Få vores hurtige VPN uden logfiler, valgfri adgang til avancerede AI-"
+"modeller med højere chatgrænser og flere premium-beskyttelser."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9191,8 +9322,8 @@ msgstr "Hent appen"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Hent den gratis DuckDuckGo-browser %1$sfor at blokere annoncer på "
-"YouTube.%2$s"
+"Hent den gratis DuckDuckGo-browser %1$sfor at blokere annoncer på YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9251,9 +9382,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
-"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
-"anden enhed › Kopiér tekstkode%4$s"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
+"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden enhed "
+"› Kopiér tekstkode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9262,9 +9393,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller "
-"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
-"anden enhed%4$s"
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller DuckDuckGo-"
+"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
+"enhed%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9274,9 +9405,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
-"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
-"anden enhed%4$s, og scan denne kode:"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
+"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
+"enhed%4$s, og scan denne kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9286,9 +9417,17 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller "
-"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
-"anden enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller DuckDuckGo-"
+"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
+"enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9399,6 +9538,12 @@ msgstr "Forstået"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Forstået"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10207,7 +10352,8 @@ msgstr "Hvor tit vil du have, at AI-assisterede svar skal dukke op?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
+msgstr ""
+"Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10648,7 +10794,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr "Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
+msgstr ""
+"Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11374,6 +11521,12 @@ msgid "Learn %sMore%s"
 msgstr "Få %1$sMere%2$s at vide"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11546,7 +11699,8 @@ msgstr "Lader dig søge anonymt på internettet med DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Lader dig skifte mellem at indsende søgeforespørgsler og prompter til Duck.ai"
+msgstr ""
+"Lader dig skifte mellem at indsende søgeforespørgsler og prompter til Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11751,7 +11905,8 @@ msgstr "Indlæser flere billedresultater, mens du scroller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
+msgstr ""
+"Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12005,6 +12160,13 @@ msgid "Manage"
 msgstr "Administrer"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12254,6 +12416,12 @@ msgstr "Menu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12622,6 +12790,12 @@ msgid "More about Duck.ai"
 msgstr "Mere om Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Mere på"
@@ -12814,6 +12988,12 @@ msgstr "Mikrofon slået fra"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Dæmpet rød"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13055,11 +13235,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nye prompter og svar krypteres og gemmes midlertidigt på en "
-"DuckDuckGo-server efter afsendelse for at hjælpe med at gendanne en chat, "
-"hvis du mister din internetforbindelse. Deaktivering af chathistorikken "
-"sletter fastgjorte chats og deaktiverer midlertidig lagring af nye prompter "
-"og svar."
+"Nye prompter og svar krypteres og gemmes midlertidigt på en DuckDuckGo-"
+"server efter afsendelse for at hjælpe med at gendanne en chat, hvis du "
+"mister din internetforbindelse. Deaktivering af chathistorikken sletter "
+"fastgjorte chats og deaktiverer midlertidig lagring af nye prompter og svar."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13885,6 +14064,30 @@ msgstr ""
 "%4$s-ikonet > Indstillinger%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14278,8 +14481,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"Andre søgemaskiner sporer dine søgninger, selv når du er i privat "
-"browsing-tilstand. Vi sporer dig ikke – punktum."
+"Andre søgemaskiner sporer dine søgninger, selv når du er i privat browsing-"
+"tilstand. Vi sporer dig ikke – punktum."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14634,6 +14837,12 @@ msgid "Past year"
 msgstr "Seneste år"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14644,6 +14853,12 @@ msgstr "Indsæt"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Indsæt synkroniseringskode"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14697,6 +14912,20 @@ msgstr "Permanent lukket"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persisk"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15962,6 +16191,12 @@ msgid "Reading website…"
 msgstr "Læser websted…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16153,6 +16388,12 @@ msgstr "Gendannelse"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Gendannelseskode"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16406,6 +16647,12 @@ msgid "Remove %s"
 msgstr "Fjern %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16446,6 +16693,18 @@ msgstr "Fjern det markerede tekstområde"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Fjern unødvendig tegnsætning"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17135,6 +17394,12 @@ msgid "Say hello to Duck.ai"
 msgstr "Sig hej til Duck.ai"
 
 # smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai!"
@@ -17285,7 +17550,8 @@ msgstr "Rul ned til %1$sDuckDuckGo%2$s, og lad den bruge din placering."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
+msgstr ""
+"Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17515,8 +17781,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge "
-"POST-anmodninger)"
+"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge POST-"
+"anmodninger)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17981,7 +18247,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
+msgstr ""
+"Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18120,6 +18387,13 @@ msgstr "Serbisk (kyrillisk)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Serbisk (latin)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18276,6 +18550,14 @@ msgid "Share"
 msgstr "Del"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18290,7 +18572,8 @@ msgstr "Del"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
+msgstr ""
+"Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18422,6 +18705,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Del dine tanker om søgefeltet."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18811,7 +19106,8 @@ msgstr "Viser vandrette linjer ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
+msgstr ""
+"Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18832,7 +19128,8 @@ msgstr "Viser lejlighedsvise påmindelser om at føje DuckDuckGo til din browser
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
+msgstr ""
+"Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18850,7 +19147,8 @@ msgstr "Vis sidenumre ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
+msgstr ""
+"Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18948,7 +19246,8 @@ msgstr "Navne på websteder"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
+msgstr ""
+"Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19095,6 +19394,12 @@ msgstr "Noget andet"
 msgctxt "duckai_migration"
 msgid "Something went wrong"
 msgstr "Noget gik galt"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19264,7 +19569,8 @@ msgstr "Kildetekst ryddet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
+msgstr ""
+"Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19433,7 +19739,8 @@ msgstr "Start med et billede"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr "Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
+msgstr ""
+"Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -19469,7 +19776,8 @@ msgstr "Bliv på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
+msgstr ""
+"Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19945,6 +20253,12 @@ msgid "Switch model"
 msgstr "Skift model"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20201,6 +20515,13 @@ msgid "Synced Devices"
 msgstr "Synkroniserede enheder"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Syrien"
 
@@ -20231,6 +20552,12 @@ msgstr "Ikke fastlagt"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20543,13 +20870,15 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
+msgstr ""
+"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
+msgstr ""
+"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -20587,7 +20916,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
+msgstr ""
+"Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20739,7 +21069,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
+msgstr ""
+"Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20811,6 +21142,22 @@ msgstr ""
 "(se %4$s for mere info)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20879,19 +21226,27 @@ msgstr "Dette billede kunne ikke oprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
+msgstr ""
+"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
+msgstr ""
+"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Disse oplysninger er ikke nyttige"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -20959,7 +21314,8 @@ msgstr "Denne side kræver JavaScript for at kunne fungere."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
+msgstr ""
+"Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21006,6 +21362,18 @@ msgstr ""
 "har dog også en startside, der aldrig viser AI-assisterede svar på %1$s."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21026,7 +21394,8 @@ msgstr "Denne oversættelse er forkert"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
+msgstr ""
+"Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21647,6 +22016,12 @@ msgid "Try Free"
 msgstr "Prøv gratis"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21726,7 +22101,8 @@ msgstr "Prøv andre nøgleord."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
+msgstr ""
+"Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21758,6 +22134,12 @@ msgstr "Prøv gratis"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Prøv gratis"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22003,6 +22385,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22013,6 +22401,12 @@ msgstr "Slå Sync & Backup fra"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Slå Sync & Backup fra"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22294,8 +22688,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: "
-"https://duckduckgo.com"
+"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22322,14 +22716,15 @@ msgstr "Under %1$sSøg i adressefeltet med%2$s vælger du %3$sTilføj ny%4$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner "
-"...%4$s"
+"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner ..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
+msgstr ""
+"Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22436,8 +22831,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås op for avancerede AI-modeller og højere grænser med et "
-"DuckDuckGo-abonnement"
+"Lås op for avancerede AI-modeller og højere grænser med et DuckDuckGo-"
+"abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22476,7 +22871,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
+msgstr ""
+"Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -22489,6 +22885,12 @@ msgstr "Lås op for premium-beskyttelser"
 msgctxt "voice chat"
 msgid "Unmute"
 msgstr "Slå lyd til"
+
+# smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22524,6 +22926,12 @@ msgstr "Opdater"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Opdater browser"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22695,7 +23103,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
+msgstr ""
+"Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22805,7 +23214,8 @@ msgstr "Brug DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
+msgstr ""
+"Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23103,10 +23513,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn "
-"Duck.ai-indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg "
-"\"Synkroniser med en anden enhed\". Eller scan QR-koden på din "
-"gendannelses-PDF."
+"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn Duck.ai-"
+"indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg \"Synkroniser "
+"med en anden enhed\". Eller scan QR-koden på din gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23158,7 +23567,8 @@ msgstr "Stemmesamtale afsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr ""
+"Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23383,7 +23793,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
+msgstr ""
+"Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23500,6 +23911,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Vi afsluttede chatten på grund af inaktivitet. Vil du prøve igen?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23546,6 +23965,14 @@ msgstr ""
 "på dig. Du kan altid skifte mening senere."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23579,7 +24006,16 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
+msgstr ""
+"Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23613,7 +24049,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
+msgstr ""
+"Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23776,7 +24213,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
+msgstr ""
+"Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23867,13 +24305,15 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
+msgstr ""
+"Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
+msgstr ""
+"Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23892,6 +24332,12 @@ msgid "What are some pros and cons of annuities?"
 msgstr "Hvad er nogle fordele og ulemper ved livrenter?"
 
 # smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
 msgctxt "User prompt seeded by Learn More CTA"
 msgid ""
@@ -23904,10 +24350,9 @@ msgid ""
 msgstr ""
 "Hvad er fordelene ved at downloade DuckDuckGo-browseren, hvis du er "
 "interesseret i at bruge Duck.ai? Referer kun officielle DuckDuckGo-kilder. "
-"Opdel svaret i klare sektioner med titler, med fokus på "
-"Duck.ai-integrationer og beskyttelse af privatlivet. Hold det kort, enkelt "
-"og letforståeligt for folk med eller uden betydelig AI- eller teknisk "
-"erfaring."
+"Opdel svaret i klare sektioner med titler, med fokus på Duck.ai-"
+"integrationer og beskyttelse af privatlivet. Hold det kort, enkelt og "
+"letforståeligt for folk med eller uden betydelig AI- eller teknisk erfaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23992,7 +24437,8 @@ msgstr "Hvilke retter bør man prøve her?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
+msgstr ""
+"Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24134,7 +24580,8 @@ msgstr "Hvilke informationer bliver gemt?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr "Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
+msgstr ""
+"Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -24251,7 +24698,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
+msgstr ""
+"Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24459,6 +24907,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Uden nul udbydersynlighed"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24727,7 +25183,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
+msgstr ""
+"Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24958,6 +25415,13 @@ msgid "You have 1 attempt left."
 msgstr "Du har 1 forsøg tilbage."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25016,7 +25480,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
+msgstr ""
+"Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25111,14 +25576,16 @@ msgstr "Du har nået det maksimale antal beskeder for nu. Prøv igen senere."
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Du har nået den maksimale varighed af stemmechat for en enkelt session."
+msgstr ""
+"Du har nået den maksimale varighed af stemmechat for en enkelt session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
+msgstr ""
+"Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25175,6 +25642,23 @@ msgid "YouTube Standard"
 msgstr "YouTube-standard"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Din DuckDuckGo-søgehistorik er privat"
@@ -25196,6 +25680,14 @@ msgstr "Din faktiske placering forbliver privat"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Din faktiske placering forbliver privat."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25276,7 +25768,8 @@ msgstr "Dine chats bliver nu gemt."
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr "Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
+msgstr ""
+"Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25290,8 +25783,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
-"AI-modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25299,8 +25792,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
-"AI-modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25418,8 +25911,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure "
-"Hash-algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
+"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure Hash-"
+"algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
 "indstillingsfil forlader din browser. Vi gemmer indstillingsfilen ved at "
 "bruge nøglen som navnet. DuckDuckGo får aldrig dit adgangsudtryk at vide."
 

--- a/locales/de_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_CH/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -396,6 +403,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -630,6 +643,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1185,6 +1203,11 @@ msgstr "Zu %s hinzufügen"
 msgid "Add to Home Screen"
 msgstr "Zu Homescreen hinzufügen"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Erweiterungen"
@@ -1477,6 +1500,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1889,6 +1918,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4226,6 +4260,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4259,6 +4298,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4819,6 +4877,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4827,6 +4892,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5033,6 +5105,12 @@ msgstr "Ablehnen"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5680,6 +5758,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6343,9 +6427,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7441,6 +7538,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7525,6 +7629,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9122,6 +9231,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Mehr %serfahren%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9641,6 +9755,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9847,6 +9967,11 @@ msgstr "Menü"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10148,6 +10273,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Mehr Informationen unter "
@@ -10305,6 +10435,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "mattes Rot"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11184,6 +11319,27 @@ msgstr ""
 "Auf Mac, %sklicke auf Maxthon > Einstellungen%s, auf Windows, %sklicke auf "
 "das %sIcon > Einstellungen%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11797,6 +11953,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11805,6 +11966,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11849,6 +12015,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12863,6 +13041,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13012,6 +13195,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13219,6 +13407,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13252,6 +13445,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13800,6 +14003,11 @@ msgstr "Sichere deine Einstellungen anonym in der Cloud"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14579,6 +14787,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14705,6 +14919,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14826,6 +15047,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15373,6 +15604,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16064,6 +16300,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16261,6 +16502,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16286,6 +16533,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Fernsehen"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16746,6 +16998,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16814,6 +17080,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16897,6 +17168,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17415,6 +17696,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17507,6 +17793,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17706,6 +17997,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17714,6 +18010,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18100,6 +18401,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18127,6 +18433,11 @@ msgstr "Aktualisieren"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18907,6 +19218,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18941,6 +19259,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18965,6 +19290,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19209,6 +19541,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19671,6 +20008,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20076,6 +20420,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20246,6 +20596,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube Standard"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20263,6 +20628,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% vollständig geimpft"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% geimpft"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -488,6 +496,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sHier erfährst du, wie wir deinen Standort privat halten%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -778,6 +793,12 @@ msgstr "2. Aufschlag Punkte gewonnen"
 msgctxt "Sports module"
 msgid "2nd in Group %s"
 msgstr "2. in Gruppe %1$s"
+
+# smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1296,7 +1317,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr "Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
+msgstr ""
+"Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1468,6 +1490,12 @@ msgstr "Zu %1$s hinzufügen"
 #. Button that creates a shortcut to the current page on the home screen of the user's phone.
 msgid "Add to Home Screen"
 msgstr "Zum Startbildschirm hinzufügen"
+
+# smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1835,6 +1863,13 @@ msgid "All types"
 msgstr "Alle Arten"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1869,7 +1904,8 @@ msgstr "Anonyme Dateiüberprüfung für diesen Chat erlauben?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
+msgstr ""
+"Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2211,7 +2247,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
+msgstr ""
+"Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2360,6 +2397,12 @@ msgid "Ask anything privately"
 msgstr "Alles privat fragen"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2417,13 +2460,13 @@ msgid ""
 msgstr ""
 "Assist kann anonym KI-gestützte Antworten auf einige Suchanfragen "
 "generieren, die auf der Zusammenfassung relevanter Webinhalte basieren. Du "
-"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die "
-"Assist-Benutzeroberfläche wird vollständig aus den Suchergebnissen "
-"entfernt), Bei Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du "
-"auf die Assist-Schaltfläche klickst), Manchmal (KI-gestützte Antworten "
-"werden nur bei hoher Relevanz angezeigt) oder Oft (werden häufiger bei einer "
-"größeren Anzahl von Suchanfragen angezeigt). Derzeit sind KI-gestützte "
-"Antworten nur in den USA (Englisch) verfügbar."
+"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die Assist-"
+"Benutzeroberfläche wird vollständig aus den Suchergebnissen entfernt), Bei "
+"Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du auf die Assist-"
+"Schaltfläche klickst), Manchmal (KI-gestützte Antworten werden nur bei hoher "
+"Relevanz angezeigt) oder Oft (werden häufiger bei einer größeren Anzahl von "
+"Suchanfragen angezeigt). Derzeit sind KI-gestützte Antworten nur in den USA "
+"(Englisch) verfügbar."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2435,8 +2478,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym "
-"KI-gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
+"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym KI-"
+"gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
 "das Internet nach relevanten Inhalten und verwendet dann KI-gestützte "
 "natürliche Sprachtechnologie, um eine kurze Antwort auf der Grundlage der "
 "gefundenen relevanten Informationen zu generieren. Es ist wichtig, zu "
@@ -2604,7 +2647,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr "Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
+msgstr ""
+"Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2678,7 +2722,8 @@ msgstr "Durchschn. Vol."
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr "Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
+msgstr ""
+"Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2984,7 +3029,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
+msgstr ""
+"Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3000,7 +3046,8 @@ msgstr "Diese Seite in allen Ergebnissen blockieren"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
+msgstr ""
+"Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3258,9 +3305,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, "
-"Tracker-Blockade, und Website-Verschlüsselung – alles in einem Download, für "
-"%1$sdie wichtigsten Browser%2$s."
+"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, Tracker-"
+"Blockade, und Website-Verschlüsselung – alles in einem Download, für %1$sdie "
+"wichtigsten Browser%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3346,7 +3393,8 @@ msgstr "Indem du auf „%1$s“ klickst, akzeptierst du unsere %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
+msgstr ""
+"Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3367,11 +3415,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"Normalerweise werden die Einstellungen in nicht personenbezogenen "
-"Browser-Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save "
-"lassen sich Einstellungen dauerhafter sichern (auf einem Remote-Server in "
-"der Cloud). Es werden dabei keine personenbezogenen Daten in der Cloud "
-"gespeichert und die Passphrase verlässt nie den eigenen Browser."
+"Normalerweise werden die Einstellungen in nicht personenbezogenen Browser-"
+"Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save lassen sich "
+"Einstellungen dauerhafter sichern (auf einem Remote-Server in der Cloud). Es "
+"werden dabei keine personenbezogenen Daten in der Cloud gespeichert und die "
+"Passphrase verlässt nie den eigenen Browser."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3427,7 +3475,8 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
+msgstr ""
+"Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3755,7 +3804,8 @@ msgstr ""
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
+msgstr ""
+"Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3886,8 +3936,8 @@ msgstr ""
 "KI-Chatmodellen von Drittanbietern zu führen, etwa OpenAI oder Anthropic. "
 "Wenn du diese Einstellung deaktivierst, werden Chat-Schaltflächen und -Links "
 "in DuckDuckGo Search ausgeblendet. Du kannst jedoch auch dann auf den Chat "
-"zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
-"%1$shttps://duck.ai%2$s direkt besuchst."
+"zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://duck."
+"ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4022,9 +4072,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf "
-"DuckDuckGo-Servern oder Remote-Servern. Wenn du den Chatverlauf "
-"deaktivierst, werden angeheftete Chats gelöscht."
+"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf DuckDuckGo-"
+"Servern oder Remote-Servern. Wenn du den Chatverlauf deaktivierst, werden "
+"angeheftete Chats gelöscht."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4037,11 +4087,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "Chats werden lokal auf deinem Gerät gespeichert. Neue Prompts und Antworten "
-"werden verschlüsselt und nach dem Senden vorübergehend auf einem "
-"DuckDuckGo-Server gespeichert, damit du einen Chat wiederherstellen kannst, "
-"falls deine Internetverbindung unterbrochen wird. Wenn du den Chatverlauf "
-"deaktivierst, werden angeheftete Chats gelöscht und die vorübergehende "
-"Speicherung neuer Aufforderungen und Antworten deaktiviert."
+"werden verschlüsselt und nach dem Senden vorübergehend auf einem DuckDuckGo-"
+"Server gespeichert, damit du einen Chat wiederherstellen kannst, falls deine "
+"Internetverbindung unterbrochen wird. Wenn du den Chatverlauf deaktivierst, "
+"werden angeheftete Chats gelöscht und die vorübergehende Speicherung neuer "
+"Aufforderungen und Antworten deaktiviert."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4064,8 +4114,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in "
-"Duck.ai hochgeladenen Dateien werden anonym von einem Anbieter für "
+"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in Duck."
+"ai hochgeladenen Dateien werden anonym von einem Anbieter für "
 "Inhaltsmoderation auf %2$s überprüft."
 
 # smartling.placeholder_format=C
@@ -4199,7 +4249,8 @@ msgstr "Auswahl von KI-Modellen, darunter %1$s und %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
+msgstr ""
+"Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -5312,6 +5363,12 @@ msgid "Copy"
 msgstr "Kopieren"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5353,6 +5410,28 @@ msgstr "Diesen Code kopieren oder speichern"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Wiederherstellungscode kopieren"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5740,7 +5819,8 @@ msgstr "Tageslimit erreicht"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
+msgstr ""
+"Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6034,6 +6114,14 @@ msgid "Delete recent chats?"
 msgstr "Aktuelle Chats löschen?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6046,10 +6134,19 @@ msgid "Deleted chats"
 msgstr "Gelöschte Chats"
 
 # smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr "Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
+msgstr ""
+"Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6071,7 +6168,8 @@ msgstr "Beschreibe die Änderungen basierend auf dem Bild"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
+msgstr ""
+"Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6140,8 +6238,8 @@ msgstr "Diktierfunktion in Duck.ai"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von "
-"KI-Modellen verwendet."
+"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von KI-"
+"Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6299,6 +6397,13 @@ msgstr "Verwerfen"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Verwerfen"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6484,8 +6589,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne "
-"KI-Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
+"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne KI-"
+"Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
 "erfahren%4$s"
 
 # smartling.placeholder_format=C
@@ -6893,10 +6998,10 @@ msgid ""
 msgstr ""
 "Mit Duck.ai kannst du anonyme Unterhaltungen mit KI-Chatmodellen von "
 "Drittanbietern führen, darunter Modelle von OpenAI, Anthropic und anderen. "
-"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und "
-"-Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf "
-"Duck.ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
-"%1$shttps://duck.ai%2$s direkt besuchst."
+"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und -"
+"Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf Duck."
+"ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://"
+"duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7090,8 +7195,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die "
-"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die Chat-"
+"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7100,8 +7205,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die "
-"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die Chat-"
+"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7166,6 +7271,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo-Browser %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7820,7 +7932,8 @@ msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist"
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure location access is %sallowed%s."
-msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
+msgstr ""
+"Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7946,7 +8059,8 @@ msgstr "Äquatorialguinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
+msgstr ""
+"Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8011,10 +8125,25 @@ msgstr ""
 "Privatsphäre geben."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Abgelaufen"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8039,7 +8168,8 @@ msgstr "Erkläre die akzeptierte Antwort in einfachen Worten."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
+msgstr ""
+"Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8547,7 +8677,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
+msgstr ""
+"Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8658,7 +8789,8 @@ msgstr "Kostenlose und private Chats, von uns anonymisiert"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
+msgstr ""
+"Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8771,9 +8903,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Wähle in der Menüleiste der Anwendung auf dem Mac "
-"<strong>DuckDuckGo</strong> &gt; <strong>Nach Updates suchen ...</strong> "
-"und dann <strong>Update installieren</strong>."
+"Wähle in der Menüleiste der Anwendung auf dem Mac <strong>DuckDuckGo</"
+"strong> &gt; <strong>Nach Updates suchen ...</strong> und dann "
+"<strong>Update installieren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9135,7 +9267,8 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections. Try it for free!"
-msgstr "Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
+msgstr ""
+"Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market.
@@ -9171,8 +9304,8 @@ msgid ""
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
 "Erhalte Zugang zu den fortschrittlichen KI-Modellen in Duck.ai, indem du "
-"DuckDuckGo abonnierst, was auch unser VPN und andere "
-"Premium-Datenschutzmaßnahmen beinhaltet."
+"DuckDuckGo abonnierst, was auch unser VPN und andere Premium-"
+"Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9183,9 +9316,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen "
-"KI-Modellen in Duck.ai, das auch unser VPN und andere "
-"Premium-Datenschutzmaßnahmen beinhaltet."
+"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen KI-"
+"Modellen in Duck.ai, das auch unser VPN und andere Premium-"
+"Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9388,10 +9521,18 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu "
-"%1$sDuck.ai-Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit "
-"einem anderen Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
+"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu %1$sDuck.ai-"
+"Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit einem anderen "
+"Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
 "Wiederherstellungs-PDF."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9502,6 +9643,12 @@ msgstr "Verstanden"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Verstanden"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9921,13 +10068,15 @@ msgstr "Hilf uns zu verstehen, was wir falsch gemacht haben"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr "Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
+msgstr ""
+"Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
+msgstr ""
+"Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9939,7 +10088,8 @@ msgstr "Hilfreich"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr "Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
+msgstr ""
+"Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -10145,8 +10295,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"Achtung! Wenn du die Einstellung zurücksetzt, wird die "
-"DuckDuckGo-Erweiterung deaktiviert und du verlierst unseren Datenschutz."
+"Achtung! Wenn du die Einstellung zurücksetzt, wird die DuckDuckGo-"
+"Erweiterung deaktiviert und du verlierst unseren Datenschutz."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10466,8 +10616,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Ich mag das Buch „Der Name des Windes“. Welche anderen guten "
-"Bücher/Buchreihen ähneln diesem am meisten und warum?"
+"Ich mag das Buch „Der Name des Windes“. Welche anderen guten Bücher/"
+"Buchreihen ähneln diesem am meisten und warum?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10542,9 +10692,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten "
-"Chat-Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an "
-"%1$s und %2$s wenden."
+"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten Chat-"
+"Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an %1$s "
+"und %2$s wenden."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10582,8 +10732,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue Tabs« "
-"(öffnen mit) aus."
+"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue "
+"Tabs« (öffnen mit) aus."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -11112,7 +11262,8 @@ msgstr "Lohnt es sich, das anzuschauen?"
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr "Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
+msgstr ""
+"Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11484,6 +11635,12 @@ msgstr "%1$sMehr%2$s erfahren"
 msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "%1$sMehr%2$s erfahren"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -12123,6 +12280,13 @@ msgid "Manage"
 msgstr "Verwalten"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12372,6 +12536,12 @@ msgstr "Menü"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menü"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12744,6 +12914,12 @@ msgid "More about Duck.ai"
 msgstr "Mehr über Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Mehr unter"
@@ -12938,6 +13114,12 @@ msgid "Muted red"
 msgstr "Gedecktes Rot"
 
 # smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
 msgid "My name"
@@ -13091,7 +13273,8 @@ msgstr "Niederlande"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a network error occurs during dictation upload.
 msgid "Network error. Please check your connection and try again."
-msgstr "Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
+msgstr ""
+"Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
 
 # smartling.placeholder_format=C
 #. The title of the 'Never' option in the assist settings modal.
@@ -13497,7 +13680,8 @@ msgstr "Keine Ergebnisse gefunden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
+msgstr ""
+"Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14008,6 +14192,30 @@ msgstr ""
 "%4$s-Symbol anklicken → Einstellungen%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14153,7 +14361,8 @@ msgstr "%1$sEinstellungen%2$s öffnen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
+msgstr ""
+"Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14302,7 +14511,8 @@ msgstr "Öffne das Bedienfeld „So funktioniert Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
+msgstr ""
+"Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14760,6 +14970,12 @@ msgid "Past year"
 msgstr "Letztes Jahr"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14770,6 +14986,12 @@ msgstr "Einfügen"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Sync-Code einfügen"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14823,6 +15045,20 @@ msgstr "Dauerhaft geschlossen"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persisch"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14895,8 +15131,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als vollständigen Fragesatz formulierst, ist es "
 "wahrscheinlicher, dass KI-gestützte Antworten automatisch erscheinen, und du "
-"erhältst oft bessere Antworten. Um sie auszuschalten und die "
-"Assist-Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
+"erhältst oft bessere Antworten. Um sie auszuschalten und die Assist-"
+"Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14920,8 +15156,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als Frage und in einem vollständigen Satz formulierst, "
 "ist es wahrscheinlicher, dass DuckAssist automatisch erscheint, und du "
-"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die "
-"Assist-Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
+"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die Assist-"
+"Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -16096,6 +16332,12 @@ msgid "Reading website…"
 msgstr "Website wird gelesen …"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16288,6 +16530,12 @@ msgstr "Wiederherstellung"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Wiederherstellungscode"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16508,7 +16756,8 @@ msgstr "Meine Auswahl merken"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
+msgstr ""
+"Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16539,6 +16788,12 @@ msgstr "%1$s entfernen"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "Entferne %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16581,6 +16836,18 @@ msgstr "Textauswahl entfernen"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Unnötige Interpunktion entfernen"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17245,8 +17512,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit "
-"Ende-zu-Ende-Verschlüsselung."
+"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit Ende-zu-Ende-"
+"Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17277,6 +17544,12 @@ msgstr "Deine Einstellungen anonym in der Cloud speichern"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Sag Hallo zu Duck.ai!"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17386,7 +17659,8 @@ msgstr "Scrolle herunter und wähle %1$sErweiterte Einstellungen%2$s aus"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
+msgstr ""
+"Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17663,8 +17937,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die "
-"POST-Methode verwendet)"
+"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die POST-"
+"Methode verwendet)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17774,7 +18048,8 @@ msgstr "Zweite Meinung"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
+msgstr ""
+"Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17783,8 +18058,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
+"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17793,8 +18068,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
+"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17803,9 +18078,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen synchronisierten "
-"Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
+"zu-Ende-Verschlüsselung und greife von all deinen synchronisierten Geräten "
+"darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17814,16 +18089,16 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Speichere deine Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere deine Chats sicher auf unserem Server mit Ende-zu-Ende-"
+"Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit "
-"End-to-End-Verschlüsselung."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
+"Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17832,9 +18107,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit "
-"End-to-End-Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht "
-"einmal wir."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
+"Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht einmal wir."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -17951,7 +18225,8 @@ msgstr "Entdecke einige unserer neuesten Updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
+msgstr ""
+"Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17978,7 +18253,8 @@ msgstr "%1$s%2$s%3$s auswählen, dann %4$sSuchmaschine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
+msgstr ""
+"Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18004,13 +18280,15 @@ msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
+msgstr ""
+"Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
+msgstr ""
+"Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18282,6 +18560,13 @@ msgid "Serbian (Latin)"
 msgstr "Serbisch (Lateinische Schrift)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18436,6 +18721,14 @@ msgid "Share"
 msgstr "Teilen"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18450,7 +18743,8 @@ msgstr "Teilen"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
+msgstr ""
+"Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18478,8 +18772,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Teile den Standort in Form der Stadt mit KI-Modellen, um die Relevanz zu "
-"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder "
-"KI-Modelle weiter."
+"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder KI-"
+"Modelle weiter."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18583,6 +18877,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Teile uns deine Gedanken über das Suchfeld mit."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18712,7 +19018,8 @@ msgstr "DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
+msgstr ""
+"DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18897,7 +19204,8 @@ msgstr "Seitenleiste anzeigen"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Schritt-für-Schritt-Tipps anzeigen, um das Beste aus Duck.ai herauszuholen."
+msgstr ""
+"Schritt-für-Schritt-Tipps anzeigen, um das Beste aus Duck.ai herauszuholen."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19045,7 +19353,8 @@ msgstr "Begrüßung oben auf der Suchergebnisseite anzeigen"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
+msgstr ""
+"Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19124,7 +19433,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
+msgstr ""
+"Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19268,6 +19578,12 @@ msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19338,7 +19654,8 @@ msgstr "Entschuldigung, ein unerwarteter Fehler ist aufgetreten."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr "Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
+msgstr ""
+"Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -19614,7 +19931,8 @@ msgstr "Beginne mit einem Bild"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr "Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
+msgstr ""
+"Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -19651,8 +19969,8 @@ msgstr "Bleib auf DuckDuckGo"
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
 msgstr ""
-"Bleibe gut geschützt und gut informiert – mit unseren "
-"Privatsphäre-Newslettern."
+"Bleibe gut geschützt und gut informiert – mit unseren Privatsphäre-"
+"Newslettern."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19707,7 +20025,8 @@ msgstr "Versteckte Tracker stoppen, die auf anderen Websites lauern."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
+msgstr ""
+"Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19929,7 +20248,8 @@ msgstr "Q&As zusammenfassen"
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr "Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
+msgstr ""
+"Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
@@ -20122,6 +20442,12 @@ msgstr "Modell wechseln"
 msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr "Modell wechseln"
+
+# smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20384,6 +20710,13 @@ msgid "Synced Devices"
 msgstr "Synchronisierte Geräte"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Syrien"
 
@@ -20414,6 +20747,12 @@ msgstr "TBD"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20733,7 +21072,8 @@ msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s 
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
+msgstr ""
+"Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -20765,7 +21105,8 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr "Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
+msgstr ""
+"Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20932,7 +21273,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
+msgstr ""
+"Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20965,8 +21307,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des "
-"%3$s-Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
+"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des %3$s-"
+"Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
 "anstößige Informationen an (weitere Informationen siehe %4$s)."
 
 # smartling.placeholder_format=C
@@ -21003,6 +21345,22 @@ msgstr ""
 "Diese Konversation wurde mit DuckDuckGo AI Chat (%1$s) unter Verwendung des "
 "%3$s-Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
 "anstößige Informationen an (weitere Informationen siehe %4$s)."
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21090,6 +21448,12 @@ msgstr ""
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Diese Informationen sind nicht hilfreich"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21190,8 +21554,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
-"KI-gestützte Antworten."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
+"gestützte Antworten."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21202,9 +21566,21 @@ msgid ""
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
-"KI-gestützte Antworten. Allerdings haben wir auch eine Startseite unter "
-"%1$s, auf der niemals KI-gestützte Antworten angezeigt werden."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
+"gestützte Antworten. Allerdings haben wir auch eine Startseite unter %1$s, "
+"auf der niemals KI-gestützte Antworten angezeigt werden."
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21235,7 +21611,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
+msgstr ""
+"Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21353,7 +21730,8 @@ msgstr "Tipps"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
+msgstr ""
+"Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21809,7 +22187,8 @@ msgstr "Versuche, %1$s, um solche Nachrichten nicht mehr zu sehen."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
+msgstr ""
+"Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21855,6 +22234,12 @@ msgstr "Kostenlos testen"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Kostenlos testen"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21974,6 +22359,12 @@ msgid "Try for Free"
 msgstr "Kostenlos testen"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
 msgctxt ""
 "Link text shown to unauthenticated users in the subscription promo card to "
@@ -21999,7 +22390,8 @@ msgstr "Gratis testen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
+msgstr ""
+"Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22073,7 +22465,8 @@ msgstr "Versuche deinen Standort manuell einzustellen."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
+msgstr ""
+"Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22119,7 +22512,8 @@ msgstr "Probiere den neuen privaten Echtzeit-Sprachchat aus!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr "Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
+msgstr ""
+"Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -22143,7 +22537,8 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr "Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
+msgstr ""
+"Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -22180,9 +22575,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No "
-"AI%2$s-Sucherweiterung, damit deine Einstellungen gespeichert bleiben. "
-"%3$sMehr erfahren%4$s"
+"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No AI%2$s-"
+"Sucherweiterung, damit deine Einstellungen gespeichert bleiben. %3$sMehr "
+"erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22221,6 +22616,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22231,6 +22632,12 @@ msgstr "Sync & Backup deaktivieren"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Sync & Backup deaktivieren"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22296,7 +22703,8 @@ msgstr "Abschalten:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
+msgstr ""
+"Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -22319,7 +22727,8 @@ msgstr "Aktiviere „Präziser Standort“, um genauere Ergebnisse zu erhalten."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
+msgstr ""
+"Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22516,8 +22925,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s "
-"https://duckduckgo.com eingeben"
+"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s https://"
+"duckduckgo.com eingeben"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22549,7 +22958,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
+msgstr ""
+"Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22666,8 +23076,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem "
-"DuckDuckGo-Abo frei"
+"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem DuckDuckGo-"
+"Abo frei"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22706,7 +23116,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
+msgstr ""
+"Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -22719,6 +23130,12 @@ msgstr "Premium-Schutzmaßnahmen freischalten"
 msgctxt "voice chat"
 msgid "Unmute"
 msgstr "Stummschaltung aufheben"
+
+# smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22756,6 +23173,12 @@ msgstr "Aktualisieren"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Browser aktualisieren"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23100,7 +23523,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
+msgstr ""
+"Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23401,8 +23825,8 @@ msgstr "Sprachchat beendet"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von "
-"KI-Modellen verwendet."
+"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von KI-"
+"Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23547,8 +23971,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Benutze den Duck Player, um personalisierte Werbung auf YouTube zu "
-"blockieren und zu verhindern, dass deine Aktivitäten die "
-"YouTube-Empfehlungen beeinflussen."
+"blockieren und zu verhindern, dass deine Aktivitäten die YouTube-"
+"Empfehlungen beeinflussen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23695,7 +24119,8 @@ msgstr "Wir tracken dich nicht. Niemals."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
+msgstr ""
+"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23736,7 +24161,8 @@ msgstr "Wir tracken dich nicht, ob im privaten oder normalen Modus."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
+msgstr ""
+"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23745,6 +24171,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 "Wir haben den Chat aufgrund von Inaktivität beendet. Möchtest du es erneut "
 "versuchen?"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23766,7 +24200,8 @@ msgstr "Wir halten deinen Suchverlauf privat"
 #. Displayed when the voice chat connection is lost and the session ends.
 msgctxt "voice chat error"
 msgid "We lost the connection, please try again later."
-msgstr "Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
+msgstr ""
+"Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
 
 # smartling.placeholder_format=C
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
@@ -23797,6 +24232,14 @@ msgstr ""
 "rückgängig gemacht werden."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23807,7 +24250,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
+msgstr ""
+"Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23831,6 +24275,14 @@ msgstr ""
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr "Wir blockieren Tracker, die während des Surfens deine Daten abgreifen."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24151,6 +24603,12 @@ msgid "What are some pros and cons of annuities?"
 msgstr "Was sind Vor- und Nachteile von Annuitäten?"
 
 # smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
 msgctxt "User prompt seeded by Learn More CTA"
 msgid ""
@@ -24162,11 +24620,11 @@ msgid ""
 "experience."
 msgstr ""
 "Welche Vorteile bietet das Herunterladen des DuckDuckGo-Browsers für "
-"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle "
-"DuckDuckGo-Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit "
-"Titeln auf, wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem "
-"Datenschutz liegt. Halte es sehr kurz, einfach und leicht verständlich für "
-"Menschen mit oder ohne viel KI- oder technische Erfahrung."
+"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle DuckDuckGo-"
+"Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit Titeln auf, "
+"wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem Datenschutz "
+"liegt. Halte es sehr kurz, einfach und leicht verständlich für Menschen mit "
+"oder ohne viel KI- oder technische Erfahrung."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24251,7 +24709,8 @@ msgstr "Was muss man hier unbedingt probieren?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
+msgstr ""
+"Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24724,6 +25183,14 @@ msgid "Without zero provider visibility"
 msgstr "Mit Sichtbarkeit auf Anbieterseite"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -25068,7 +25535,8 @@ msgstr "Du kannst dies jederzeit in den %1$sSucheinstellungen%2$s ändern"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
+msgstr ""
+"Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25229,6 +25697,13 @@ msgid "You have 1 attempt left."
 msgstr "Du hast noch 1 Versuch."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25372,7 +25847,8 @@ msgstr "Du hast das Limit für die Erstellung von Bildern erreicht."
 #. Title shown when a user has reached their image generation edit limit.
 msgctxt "Title for image generation edit limit reached message"
 msgid "You've reached the maximum number of edits for this image"
-msgstr "Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
+msgstr ""
+"Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum number of messages for a given moment, and should try again later when they might be able to send more messages again.
@@ -25458,6 +25934,23 @@ msgid "YouTube Standard"
 msgstr "YouTube-Vorgabe"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Dein DuckDuckGo-Suchverlauf ist privat"
@@ -25479,6 +25972,14 @@ msgstr "Dein tatsächlicher Standort bleibt privat"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Dein tatsächlicher Standort bleibt privat."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25679,7 +26180,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
+msgstr ""
+"Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25777,8 +26279,8 @@ msgid ""
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 "Deine Einstellungen sind gespeichert, aber durch das Löschen der Cookies "
-"werden sie zurückgesetzt. Aktiviere die %1$sDuckDuckGo No "
-"AI%2$s-Erweiterung, um sie dauerhaft zu aktivieren."
+"werden sie zurückgesetzt. Aktiviere die %1$sDuckDuckGo No AI%2$s-"
+"Erweiterung, um sie dauerhaft zu aktivieren."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25788,14 +26290,15 @@ msgid ""
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
 "Deine Einstellungen sind gespeichert, aber durch das Löschen der Cookies "
-"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No "
-"AI%2$s-Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
+"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No AI%2$s-"
+"Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr "Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
+msgstr ""
+"Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Dieses Gerät)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -500,7 +500,7 @@ msgstr "%1$sHier erfährst du, wie wir deinen Standort privat halten%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sMehr erfahren%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -798,7 +798,7 @@ msgstr "2. in Gruppe %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2. Meinung"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1317,8 +1317,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr ""
-"Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
+msgstr "Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1495,7 +1494,7 @@ msgstr "Zum Startbildschirm hinzufügen"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Zu „Meine Chats“ hinzufügen"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1867,7 +1866,7 @@ msgstr "Alle Arten"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Alle deine Geräte sind von Sync getrennt."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1904,8 +1903,7 @@ msgstr "Anonyme Dateiüberprüfung für diesen Chat erlauben?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
+msgstr "Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2247,8 +2245,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
+msgstr "Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2400,7 +2397,7 @@ msgstr "Alles privat fragen"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Alles privat fragen"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2460,13 +2457,13 @@ msgid ""
 msgstr ""
 "Assist kann anonym KI-gestützte Antworten auf einige Suchanfragen "
 "generieren, die auf der Zusammenfassung relevanter Webinhalte basieren. Du "
-"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die Assist-"
-"Benutzeroberfläche wird vollständig aus den Suchergebnissen entfernt), Bei "
-"Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du auf die Assist-"
-"Schaltfläche klickst), Manchmal (KI-gestützte Antworten werden nur bei hoher "
-"Relevanz angezeigt) oder Oft (werden häufiger bei einer größeren Anzahl von "
-"Suchanfragen angezeigt). Derzeit sind KI-gestützte Antworten nur in den USA "
-"(Englisch) verfügbar."
+"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die "
+"Assist-Benutzeroberfläche wird vollständig aus den Suchergebnissen "
+"entfernt), Bei Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du "
+"auf die Assist-Schaltfläche klickst), Manchmal (KI-gestützte Antworten "
+"werden nur bei hoher Relevanz angezeigt) oder Oft (werden häufiger bei einer "
+"größeren Anzahl von Suchanfragen angezeigt). Derzeit sind KI-gestützte "
+"Antworten nur in den USA (Englisch) verfügbar."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2478,8 +2475,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym KI-"
-"gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
+"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym "
+"KI-gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
 "das Internet nach relevanten Inhalten und verwendet dann KI-gestützte "
 "natürliche Sprachtechnologie, um eine kurze Antwort auf der Grundlage der "
 "gefundenen relevanten Informationen zu generieren. Es ist wichtig, zu "
@@ -2647,8 +2644,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
+msgstr "Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2722,8 +2718,7 @@ msgstr "Durchschn. Vol."
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr ""
-"Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
+msgstr "Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -3029,8 +3024,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
+msgstr "Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3046,8 +3040,7 @@ msgstr "Diese Seite in allen Ergebnissen blockieren"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
+msgstr "Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3305,9 +3298,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, Tracker-"
-"Blockade, und Website-Verschlüsselung – alles in einem Download, für %1$sdie "
-"wichtigsten Browser%2$s."
+"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, "
+"Tracker-Blockade, und Website-Verschlüsselung – alles in einem Download, für "
+"%1$sdie wichtigsten Browser%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3393,8 +3386,7 @@ msgstr "Indem du auf „%1$s“ klickst, akzeptierst du unsere %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
+msgstr "Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3415,11 +3407,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"Normalerweise werden die Einstellungen in nicht personenbezogenen Browser-"
-"Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save lassen sich "
-"Einstellungen dauerhafter sichern (auf einem Remote-Server in der Cloud). Es "
-"werden dabei keine personenbezogenen Daten in der Cloud gespeichert und die "
-"Passphrase verlässt nie den eigenen Browser."
+"Normalerweise werden die Einstellungen in nicht personenbezogenen "
+"Browser-Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save "
+"lassen sich Einstellungen dauerhafter sichern (auf einem Remote-Server in "
+"der Cloud). Es werden dabei keine personenbezogenen Daten in der Cloud "
+"gespeichert und die Passphrase verlässt nie den eigenen Browser."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3475,8 +3467,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
+msgstr "Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3804,8 +3795,7 @@ msgstr ""
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
+msgstr "Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3936,8 +3926,8 @@ msgstr ""
 "KI-Chatmodellen von Drittanbietern zu führen, etwa OpenAI oder Anthropic. "
 "Wenn du diese Einstellung deaktivierst, werden Chat-Schaltflächen und -Links "
 "in DuckDuckGo Search ausgeblendet. Du kannst jedoch auch dann auf den Chat "
-"zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://duck."
-"ai%2$s direkt besuchst."
+"zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
+"%1$shttps://duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4072,9 +4062,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf DuckDuckGo-"
-"Servern oder Remote-Servern. Wenn du den Chatverlauf deaktivierst, werden "
-"angeheftete Chats gelöscht."
+"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf "
+"DuckDuckGo-Servern oder Remote-Servern. Wenn du den Chatverlauf "
+"deaktivierst, werden angeheftete Chats gelöscht."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4087,11 +4077,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "Chats werden lokal auf deinem Gerät gespeichert. Neue Prompts und Antworten "
-"werden verschlüsselt und nach dem Senden vorübergehend auf einem DuckDuckGo-"
-"Server gespeichert, damit du einen Chat wiederherstellen kannst, falls deine "
-"Internetverbindung unterbrochen wird. Wenn du den Chatverlauf deaktivierst, "
-"werden angeheftete Chats gelöscht und die vorübergehende Speicherung neuer "
-"Aufforderungen und Antworten deaktiviert."
+"werden verschlüsselt und nach dem Senden vorübergehend auf einem "
+"DuckDuckGo-Server gespeichert, damit du einen Chat wiederherstellen kannst, "
+"falls deine Internetverbindung unterbrochen wird. Wenn du den Chatverlauf "
+"deaktivierst, werden angeheftete Chats gelöscht und die vorübergehende "
+"Speicherung neuer Aufforderungen und Antworten deaktiviert."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4114,8 +4104,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in Duck."
-"ai hochgeladenen Dateien werden anonym von einem Anbieter für "
+"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in "
+"Duck.ai hochgeladenen Dateien werden anonym von einem Anbieter für "
 "Inhaltsmoderation auf %2$s überprüft."
 
 # smartling.placeholder_format=C
@@ -4249,8 +4239,7 @@ msgstr "Auswahl von KI-Modellen, darunter %1$s und %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
+msgstr "Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -5366,7 +5355,7 @@ msgstr "Kopieren"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopieren"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5417,13 +5406,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Geteilten Link kopieren"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Kopiere den Code von einem anderen Gerät"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5432,6 +5421,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Kopiere den Code von einem anderen Gerät. Gehe zu %1$sDuck.ai-Einstellungen "
+"› Chats › Sync & Backup › Mit einem anderen Gerät synchronisieren%2$s und "
+"versuche es erneut."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5819,8 +5811,7 @@ msgstr "Tageslimit erreicht"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
+msgstr "Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6119,7 +6110,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Geteilten Link löschen"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6140,13 +6131,15 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Das Löschen eines Links führt dazu, dass er nicht mehr funktioniert. "
+"Personen, die ihn geöffnet und die Unterhaltung zu ihren Chats hinzugefügt "
+"haben, behalten ihre eigene Kopie."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
+msgstr "Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6168,8 +6161,7 @@ msgstr "Beschreibe die Änderungen basierend auf dem Bild"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
+msgstr "Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6238,8 +6230,8 @@ msgstr "Diktierfunktion in Duck.ai"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von KI-"
-"Modellen verwendet."
+"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von "
+"KI-Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6403,7 +6395,7 @@ msgstr "Verwerfen"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Verwerfen"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6589,8 +6581,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne KI-"
-"Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
+"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne "
+"KI-Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
 "erfahren%4$s"
 
 # smartling.placeholder_format=C
@@ -6998,10 +6990,10 @@ msgid ""
 msgstr ""
 "Mit Duck.ai kannst du anonyme Unterhaltungen mit KI-Chatmodellen von "
 "Drittanbietern führen, darunter Modelle von OpenAI, Anthropic und anderen. "
-"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und -"
-"Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf Duck."
-"ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://"
-"duck.ai%2$s direkt besuchst."
+"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und "
+"-Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf "
+"Duck.ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
+"%1$shttps://duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7195,8 +7187,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die Chat-"
-"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die "
+"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7205,8 +7197,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die Chat-"
-"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die "
+"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7277,7 +7269,7 @@ msgstr "DuckDuckGo-Browser %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo-Hilfeseiten"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7932,8 +7924,7 @@ msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist"
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure location access is %sallowed%s."
-msgstr ""
-"Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
+msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8059,8 +8050,7 @@ msgstr "Äquatorialguinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
+msgstr "Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8129,7 +8119,7 @@ msgstr ""
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Abgelaufen"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8143,7 +8133,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Läuft am %1$s ab"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8168,8 +8158,7 @@ msgstr "Erkläre die akzeptierte Antwort in einfachen Worten."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
+msgstr "Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8677,8 +8666,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
+msgstr "Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8789,8 +8777,7 @@ msgstr "Kostenlose und private Chats, von uns anonymisiert"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
+msgstr "Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8903,9 +8890,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Wähle in der Menüleiste der Anwendung auf dem Mac <strong>DuckDuckGo</"
-"strong> &gt; <strong>Nach Updates suchen ...</strong> und dann "
-"<strong>Update installieren</strong>."
+"Wähle in der Menüleiste der Anwendung auf dem Mac "
+"<strong>DuckDuckGo</strong> &gt; <strong>Nach Updates suchen ...</strong> "
+"und dann <strong>Update installieren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9267,8 +9254,7 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections. Try it for free!"
-msgstr ""
-"Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
+msgstr "Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market.
@@ -9304,8 +9290,8 @@ msgid ""
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
 "Erhalte Zugang zu den fortschrittlichen KI-Modellen in Duck.ai, indem du "
-"DuckDuckGo abonnierst, was auch unser VPN und andere Premium-"
-"Datenschutzmaßnahmen beinhaltet."
+"DuckDuckGo abonnierst, was auch unser VPN und andere "
+"Premium-Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9316,9 +9302,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen KI-"
-"Modellen in Duck.ai, das auch unser VPN und andere Premium-"
-"Datenschutzmaßnahmen beinhaltet."
+"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen "
+"KI-Modellen in Duck.ai, das auch unser VPN und andere "
+"Premium-Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9521,9 +9507,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu %1$sDuck.ai-"
-"Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit einem anderen "
-"Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
+"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu "
+"%1$sDuck.ai-Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit "
+"einem anderen Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
 "Wiederherstellungs-PDF."
 
 # smartling.placeholder_format=C
@@ -9533,6 +9519,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Gehe zu %1$sDuck.ai-Einstellungen%2$s › %3$sChats › Sync & Backup › Mit "
+"einem anderen Gerät synchronisieren%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9648,7 +9636,7 @@ msgstr "Verstanden"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Verstanden"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10068,15 +10056,13 @@ msgstr "Hilf uns zu verstehen, was wir falsch gemacht haben"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
+msgstr "Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
+msgstr "Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10088,8 +10074,7 @@ msgstr "Hilfreich"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr ""
-"Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
+msgstr "Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -10295,8 +10280,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"Achtung! Wenn du die Einstellung zurücksetzt, wird die DuckDuckGo-"
-"Erweiterung deaktiviert und du verlierst unseren Datenschutz."
+"Achtung! Wenn du die Einstellung zurücksetzt, wird die "
+"DuckDuckGo-Erweiterung deaktiviert und du verlierst unseren Datenschutz."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10616,8 +10601,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Ich mag das Buch „Der Name des Windes“. Welche anderen guten Bücher/"
-"Buchreihen ähneln diesem am meisten und warum?"
+"Ich mag das Buch „Der Name des Windes“. Welche anderen guten "
+"Bücher/Buchreihen ähneln diesem am meisten und warum?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10692,9 +10677,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten Chat-"
-"Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an %1$s "
-"und %2$s wenden."
+"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten "
+"Chat-Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an "
+"%1$s und %2$s wenden."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10732,8 +10717,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue "
-"Tabs« (öffnen mit) aus."
+"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue Tabs« "
+"(öffnen mit) aus."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -11262,8 +11247,7 @@ msgstr "Lohnt es sich, das anzuschauen?"
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
-"Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
+msgstr "Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11640,7 +11624,7 @@ msgstr "%1$sMehr%2$s erfahren"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Mehr erfahren"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -12284,7 +12268,7 @@ msgstr "Verwalten"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Verwalten"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12541,7 +12525,7 @@ msgstr "Menü"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Nachrichten ab diesem Punkt sind nur für dich sichtbar."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12917,7 +12901,7 @@ msgstr "Mehr über Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Mehr Aktionen"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13117,7 +13101,7 @@ msgstr "Gedecktes Rot"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Meine Geräte"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13273,8 +13257,7 @@ msgstr "Niederlande"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a network error occurs during dictation upload.
 msgid "Network error. Please check your connection and try again."
-msgstr ""
-"Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
+msgstr "Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
 
 # smartling.placeholder_format=C
 #. The title of the 'Never' option in the assist settings modal.
@@ -13680,8 +13663,7 @@ msgstr "Keine Ergebnisse gefunden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
+msgstr "Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14198,6 +14180,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Gehe auf einem anderen Gerät zu %1$sDuck.ai-Einstellungen%2$s › %3$sChats › "
+"Sync & Backup › Mit einem anderen Gerät synchronisieren%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14206,6 +14190,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Gehe auf einem anderen Gerät zu %1$sDuck.ai-Einstellungen%2$s › %3$sChats › "
+"Sync & Backup › Mit einem anderen Gerät synchronisieren%4$s und scanne "
+"diesen Code:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14214,6 +14201,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Gehe auf einem anderen Gerät zu %1$sDuck.ai-Einstellungen%2$s › %3$sChats › "
+"Sync & Backup › Mit einem anderen Gerät synchronisieren%4$s. Oder scanne den "
+"QR-Code auf deinem Wiederherstellungs-PDF."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14361,8 +14351,7 @@ msgstr "%1$sEinstellungen%2$s öffnen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
+msgstr "Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14511,8 +14500,7 @@ msgstr "Öffne das Bedienfeld „So funktioniert Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
+msgstr "Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14973,7 +14961,7 @@ msgstr "Letztes Jahr"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Einfügen"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14991,7 +14979,7 @@ msgstr "Sync-Code einfügen"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Füge ihn unten ein"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -15050,7 +15038,7 @@ msgstr "Persisch"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -15059,6 +15047,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal findet deine Daten auf Datenbroker-Websites, "
+"die diese verkaufen. Dann arbeiten wir daran, sie für dich entfernen zu "
+"lassen."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15131,8 +15122,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als vollständigen Fragesatz formulierst, ist es "
 "wahrscheinlicher, dass KI-gestützte Antworten automatisch erscheinen, und du "
-"erhältst oft bessere Antworten. Um sie auszuschalten und die Assist-"
-"Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
+"erhältst oft bessere Antworten. Um sie auszuschalten und die "
+"Assist-Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15156,8 +15147,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als Frage und in einem vollständigen Satz formulierst, "
 "ist es wahrscheinlicher, dass DuckAssist automatisch erscheint, und du "
-"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die Assist-"
-"Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
+"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die "
+"Assist-Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -16335,7 +16326,7 @@ msgstr "Website wird gelesen …"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Bereit für die Sonnenfinsternis?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16535,7 +16526,7 @@ msgstr "Wiederherstellungscode"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Wiederherstellungscode"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16756,8 +16747,7 @@ msgstr "Meine Auswahl merken"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
+msgstr "Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16793,7 +16783,7 @@ msgstr "Entferne %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Gerät entfernen"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16841,13 +16831,13 @@ msgstr "Unnötige Interpunktion entfernen"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Entferne deine Daten aus dem Internet"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Entferne deine Daten online"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17512,8 +17502,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit Ende-zu-Ende-"
-"Verschlüsselung."
+"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit "
+"Ende-zu-Ende-Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17549,7 +17539,7 @@ msgstr "Sag Hallo zu Duck.ai!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Sag Hallo zu Duck.ai – dem kostenlosen, privaten KI-Chat von DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17659,8 +17649,7 @@ msgstr "Scrolle herunter und wähle %1$sErweiterte Einstellungen%2$s aus"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
+msgstr "Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17937,8 +17926,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die POST-"
-"Methode verwendet)"
+"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die "
+"POST-Methode verwendet)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18048,8 +18037,7 @@ msgstr "Zweite Meinung"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
+msgstr "Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18058,8 +18046,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18068,8 +18056,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18078,9 +18066,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen synchronisierten Geräten "
-"darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen synchronisierten "
+"Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18089,16 +18077,16 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Speichere deine Chats sicher auf unserem Server mit Ende-zu-Ende-"
-"Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere deine Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
-"Verschlüsselung."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit "
+"End-to-End-Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18107,8 +18095,9 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
-"Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht einmal wir."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit "
+"End-to-End-Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht "
+"einmal wir."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18225,8 +18214,7 @@ msgstr "Entdecke einige unserer neuesten Updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
+msgstr "Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18253,8 +18241,7 @@ msgstr "%1$s%2$s%3$s auswählen, dann %4$sSuchmaschine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
+msgstr "Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18280,15 +18267,13 @@ msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
+msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
+msgstr "Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18564,7 +18549,7 @@ msgstr "Serbisch (Lateinische Schrift)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Serverdaten gelöscht"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18726,7 +18711,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Teilen"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18743,8 +18728,7 @@ msgstr "Teilen"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
+msgstr "Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18772,8 +18756,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Teile den Standort in Form der Stadt mit KI-Modellen, um die Relevanz zu "
-"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder KI-"
-"Modelle weiter."
+"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder "
+"KI-Modelle weiter."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18882,13 +18866,13 @@ msgstr "Teile uns deine Gedanken über das Suchfeld mit."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Geteilte Chat-Links"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Geteilte Chat-Links"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19018,8 +19002,7 @@ msgstr "DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
+msgstr "DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19204,8 +19187,7 @@ msgstr "Seitenleiste anzeigen"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Schritt-für-Schritt-Tipps anzeigen, um das Beste aus Duck.ai herauszuholen."
+msgstr "Schritt-für-Schritt-Tipps anzeigen, um das Beste aus Duck.ai herauszuholen."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19353,8 +19335,7 @@ msgstr "Begrüßung oben auf der Suchergebnisseite anzeigen"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
+msgstr "Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19433,8 +19414,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
+msgstr "Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19581,7 +19561,7 @@ msgstr "Etwas ist schiefgelaufen"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Beim Laden dieses geteilten Chats ist ein Fehler aufgetreten."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19654,8 +19634,7 @@ msgstr "Entschuldigung, ein unerwarteter Fehler ist aufgetreten."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
+msgstr "Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -19931,8 +19910,7 @@ msgstr "Beginne mit einem Bild"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
+msgstr "Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -19969,8 +19947,8 @@ msgstr "Bleib auf DuckDuckGo"
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
 msgstr ""
-"Bleibe gut geschützt und gut informiert – mit unseren Privatsphäre-"
-"Newslettern."
+"Bleibe gut geschützt und gut informiert – mit unseren "
+"Privatsphäre-Newslettern."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20025,8 +20003,7 @@ msgstr "Versteckte Tracker stoppen, die auf anderen Websites lauern."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
+msgstr "Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20248,8 +20225,7 @@ msgstr "Q&As zusammenfassen"
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
-"Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
+msgstr "Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
@@ -20447,7 +20423,7 @@ msgstr "Modell wechseln"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Modell wechseln"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20714,7 +20690,7 @@ msgstr "Synchronisierte Geräte"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Synchronisiert am %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20752,7 +20728,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabelle"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -21072,8 +21048,7 @@ msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s 
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
+msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21105,8 +21080,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
+msgstr "Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21273,8 +21247,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
+msgstr "Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21307,8 +21280,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des %3$s-"
-"Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
+"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des "
+"%3$s-Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
 "anstößige Informationen an (weitere Informationen siehe %4$s)."
 
 # smartling.placeholder_format=C
@@ -21350,7 +21323,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Dieses Gerät"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21361,6 +21334,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Dieses Gerät kann nicht mehr auf deine synchronisierten Daten auf anderen "
+"Geräten zugreifen. Die letzten %1$s Chats bleiben weiterhin im lokalen "
+"Speicher verfügbar."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21453,7 +21429,7 @@ msgstr "Diese Informationen sind nicht hilfreich"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Dies ist eine Kopie eines geteilten Chats."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21554,8 +21530,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
-"gestützte Antworten."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
+"KI-gestützte Antworten."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21566,21 +21542,23 @@ msgid ""
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
-"gestützte Antworten. Allerdings haben wir auch eine Startseite unter %1$s, "
-"auf der niemals KI-gestützte Antworten angezeigt werden."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
+"KI-gestützte Antworten. Allerdings haben wir auch eine Startseite unter "
+"%1$s, auf der niemals KI-gestützte Antworten angezeigt werden."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
 msgstr ""
+"Dieser geteilte Chat konnte nicht geöffnet werden. Der Link ist "
+"möglicherweise unvollständig."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Dieser geteilte Chat-Link ist nicht mehr verfügbar."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21611,8 +21589,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
+msgstr "Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21730,8 +21707,7 @@ msgstr "Tipps"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
+msgstr "Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22187,8 +22163,7 @@ msgstr "Versuche, %1$s, um solche Nachrichten nicht mehr zu sehen."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
+msgstr "Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22239,7 +22214,7 @@ msgstr "Kostenlos testen"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Kostenlos testen!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22362,7 +22337,7 @@ msgstr "Kostenlos testen"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Kostenlos testen!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22390,8 +22365,7 @@ msgstr "Gratis testen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
+msgstr "Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22465,8 +22439,7 @@ msgstr "Versuche deinen Standort manuell einzustellen."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
+msgstr "Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22512,8 +22485,7 @@ msgstr "Probiere den neuen privaten Echtzeit-Sprachchat aus!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
+msgstr "Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -22537,8 +22509,7 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr ""
-"Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
+msgstr "Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -22575,9 +22546,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No AI%2$s-"
-"Sucherweiterung, damit deine Einstellungen gespeichert bleiben. %3$sMehr "
-"erfahren%4$s"
+"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No "
+"AI%2$s-Sucherweiterung, damit deine Einstellungen gespeichert bleiben. "
+"%3$sMehr erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22619,7 +22590,7 @@ msgstr "Turkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Ausschalten"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22637,7 +22608,7 @@ msgstr "Sync & Backup deaktivieren"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Sync & Backup deaktivieren und Serverdaten löschen?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22703,8 +22674,7 @@ msgstr "Abschalten:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
+msgstr "Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -22727,8 +22697,7 @@ msgstr "Aktiviere „Präziser Standort“, um genauere Ergebnisse zu erhalten."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
+msgstr "Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22925,8 +22894,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s https://"
-"duckduckgo.com eingeben"
+"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s "
+"https://duckduckgo.com eingeben"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22958,8 +22927,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
+msgstr "Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23076,8 +23044,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem DuckDuckGo-"
-"Abo frei"
+"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem "
+"DuckDuckGo-Abo frei"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23116,8 +23084,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
+msgstr "Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23135,7 +23102,7 @@ msgstr "Stummschaltung aufheben"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Chat ohne Titel"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23178,7 +23145,7 @@ msgstr "Browser aktualisieren"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Aktualisiere Duck.ai, um diesen geteilten Chat anzusehen."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23523,8 +23490,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
+msgstr "Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23825,8 +23791,8 @@ msgstr "Sprachchat beendet"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von KI-"
-"Modellen verwendet."
+"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von "
+"KI-Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23971,8 +23937,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Benutze den Duck Player, um personalisierte Werbung auf YouTube zu "
-"blockieren und zu verhindern, dass deine Aktivitäten die YouTube-"
-"Empfehlungen beeinflussen."
+"blockieren und zu verhindern, dass deine Aktivitäten die "
+"YouTube-Empfehlungen beeinflussen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24119,8 +24085,7 @@ msgstr "Wir tracken dich nicht. Niemals."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
+msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24161,8 +24126,7 @@ msgstr "Wir tracken dich nicht, ob im privaten oder normalen Modus."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
+msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24179,6 +24143,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Wir finden und entfernen deine personenbezogenen Daten von "
+"Datenbroker-Websites. Hol dir zusätzlich ein VPN und mehr."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24200,8 +24166,7 @@ msgstr "Wir halten deinen Suchverlauf privat"
 #. Displayed when the voice chat connection is lost and the session ends.
 msgctxt "voice chat error"
 msgid "We lost the connection, please try again later."
-msgstr ""
-"Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
+msgstr "Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
 
 # smartling.placeholder_format=C
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
@@ -24238,6 +24203,9 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Wir durchsuchen Datenbroker-Websites regelmäßig nach deinen "
+"personenbezogenen Daten und teilen unseren Fortschritt mit dir in einem "
+"benutzerfreundlichen Dashboard."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24250,8 +24218,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
+msgstr "Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24283,6 +24250,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Wir durchsuchen Datenbroker-Websites nach deiner E-Mail-Adresse, deinem "
+"Namen, deiner Adresse und mehr und arbeiten daran, alles, was wir über dich "
+"finden, entfernen zu lassen."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24606,7 +24576,7 @@ msgstr "Was sind Vor- und Nachteile von Annuitäten?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Welche Vorteile bietet Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24620,11 +24590,11 @@ msgid ""
 "experience."
 msgstr ""
 "Welche Vorteile bietet das Herunterladen des DuckDuckGo-Browsers für "
-"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle DuckDuckGo-"
-"Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit Titeln auf, "
-"wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem Datenschutz "
-"liegt. Halte es sehr kurz, einfach und leicht verständlich für Menschen mit "
-"oder ohne viel KI- oder technische Erfahrung."
+"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle "
+"DuckDuckGo-Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit "
+"Titeln auf, wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem "
+"Datenschutz liegt. Halte es sehr kurz, einfach und leicht verständlich für "
+"Menschen mit oder ohne viel KI- oder technische Erfahrung."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24709,8 +24679,7 @@ msgstr "Was muss man hier unbedingt probieren?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
+msgstr "Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25189,6 +25158,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Funktioniert direkt von deinem Gerät aus, um deine E-Mail-Adresse, deinen "
+"Namen, deine Adresse und mehr von Datenbroker-Seiten zu entfernen."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25535,8 +25506,7 @@ msgstr "Du kannst dies jederzeit in den %1$sSucheinstellungen%2$s ändern"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
+msgstr "Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25701,7 +25671,7 @@ msgstr "Du hast noch 1 Versuch."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Du hast keine geteilten Chat-Links."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25847,8 +25817,7 @@ msgstr "Du hast das Limit für die Erstellung von Bildern erreicht."
 #. Title shown when a user has reached their image generation edit limit.
 msgctxt "Title for image generation edit limit reached message"
 msgid "You've reached the maximum number of edits for this image"
-msgstr ""
-"Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
+msgstr "Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum number of messages for a given moment, and should try again later when they might be able to send more messages again.
@@ -25941,14 +25910,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
+msgstr "Deine %1$s letzten Chats sind im lokalen Speicher dieser Browser verfügbar:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Deine Duck.ai-Chats werden mit Ende-zu-Ende-Verschlüsselung synchronisiert."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25980,6 +25949,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Dein Backup wird vom Server von DuckDuckGo gelöscht. Alle Geräte werden von "
+"der Synchronisation abgekoppelt."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26180,8 +26151,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
+msgstr "Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26279,8 +26249,8 @@ msgid ""
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 "Deine Einstellungen sind gespeichert, aber durch das Löschen der Cookies "
-"werden sie zurückgesetzt. Aktiviere die %1$sDuckDuckGo No AI%2$s-"
-"Erweiterung, um sie dauerhaft zu aktivieren."
+"werden sie zurückgesetzt. Aktiviere die %1$sDuckDuckGo No "
+"AI%2$s-Erweiterung, um sie dauerhaft zu aktivieren."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26290,15 +26260,14 @@ msgid ""
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
 "Deine Einstellungen sind gespeichert, aber durch das Löschen der Cookies "
-"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No AI%2$s-"
-"Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
+"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No "
+"AI%2$s-Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
+msgstr "Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -43,6 +43,14 @@ msgstr "% πλήρως εμβολιασμένος"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% εμβολιασμένοι"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -102,7 +110,8 @@ msgstr "%1$s απόπειρες"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr "Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr ""
+"Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -304,7 +313,8 @@ msgstr "Οι κατατάξεις %1$s δεν είναι ακόμη διαθέσ
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "Το %1$s φτάνει στα όρια χρήσης 2-5x νωρίτερα από τα βασικά μοντέλα. %2$s"
+msgstr ""
+"Το %1$s φτάνει στα όρια χρήσης 2-5x νωρίτερα από τα βασικά μοντέλα. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -375,7 +385,8 @@ msgstr "%1$s χρησιμοποιήθηκε"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "Το %1$s χρησιμοποιεί τα όρια έως και 2-5x ταχύτερα από τα βασικά μοντέλα %2$s"
+msgstr ""
+"Το %1$s χρησιμοποιεί τα όρια έως και 2-5x ταχύτερα από τα βασικά μοντέλα %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -495,6 +506,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sΜάθε πώς διατηρούμε την τοποθεσία σου απόρρητη%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -523,7 +541,8 @@ msgstr ""
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
+msgstr ""
+"%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -623,7 +642,8 @@ msgstr "1 προσπάθεια"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when only one exists.
 msgid "1 attempt blocked by DuckDuckGo in the last 24 hours"
-msgstr "Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr ""
+"Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -785,6 +805,12 @@ msgstr "Κερδισμένοι πόντοι 2ου σερβίς"
 msgctxt "Sports module"
 msgid "2nd in Group %s"
 msgstr "2η στον όμιλο %1$s"
+
+# smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1035,7 +1061,8 @@ msgstr ""
 #. Disclaimer text displayed at the bottom of the voice chat dialog informing the user that the AI (Artificial Intelligence) may provide inaccurate or offensive information.
 msgctxt "voice chat"
 msgid "AI may provide inaccurate or offensive information."
-msgstr "Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr ""
+"Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Label for the input field where user can specify how the AI assistant should refer to itself. Example: 'AI nickname (is): Fred'
@@ -1484,6 +1511,12 @@ msgid "Add to Home Screen"
 msgstr "Προσθήκη στην αρχική οθόνη"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Πρόσθετα"
@@ -1761,7 +1794,8 @@ msgstr "Όλες οι συνομιλίες είναι %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr "Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
+msgstr ""
+"Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -1847,6 +1881,13 @@ msgstr "Όλα τα μεγέθη"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Όλα τα είδη"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2228,7 +2269,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
+msgstr ""
+"Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2376,6 +2418,12 @@ msgstr "Ρωτήστε γι' αυτήν τη σελίδα"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask anything privately"
 msgstr "Ρώτα οτιδήποτε ιδιωτικά"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2818,7 +2866,8 @@ msgstr "Γραμμοκώδικας"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr "Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
+msgstr ""
+"Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2990,7 +3039,8 @@ msgstr "Αποκλεισμός ενοχλητικών αναδυόμενων π�
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr "Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
+msgstr ""
+"Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -3005,7 +3055,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
+msgstr ""
+"Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3088,7 +3139,8 @@ msgstr "Αποκλεισμένα:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr "Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
+msgstr ""
+"Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -3372,7 +3424,8 @@ msgstr "Κάνοντας κλικ στο «%1$s» συμφωνείτε με το
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
+msgstr ""
+"Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3758,7 +3811,8 @@ msgstr "Αλλάζει την εμφάνιση των διευθύνσεων URL
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
+msgstr ""
+"Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4484,8 +4538,8 @@ msgid ""
 msgstr ""
 "Η εκκαθάριση των δεδομένων του προγράμματος περιήγησης διαγράφει τις "
 "πρόσφατες συνομιλίες. Οι πρόσφατες συνομιλίες μπορεί να αποθηκευτούν επ' "
-"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του "
-"Duck.ai., ανάλογα με το πρόγραμμα περιήγησής σας."
+"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του Duck."
+"ai., ανάλογα με το πρόγραμμα περιήγησής σας."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4605,7 +4659,8 @@ msgstr "Κάνε κλικ στις %1$sΡυθμίσεις%2$s στο αναπτ�
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
+msgstr ""
+"Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4643,7 +4698,8 @@ msgstr "Κάνε κλικ στο %1$sΠρόγραμμα περιήγησης%2$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr "Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
+msgstr ""
+"Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4723,13 +4779,15 @@ msgstr "Κάνε κλικ στην καρτέλα %1$sΓενικά%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr "Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
+msgstr ""
+"Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr "Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
+msgstr ""
+"Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -5258,7 +5316,8 @@ msgstr "Συνεχίστε να μπλοκάρετε διαφημίσεις"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "Συνέχισε τις πρόσφατες συνομιλίες εδώ. Ή διάγραψέ τες με το Fire Button."
+msgstr ""
+"Συνέχισε τις πρόσφατες συνομιλίες εδώ. Ή διάγραψέ τες με το Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5362,6 +5421,12 @@ msgid "Copy"
 msgstr "Αντιγραφή"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5403,6 +5468,28 @@ msgstr "Αντιγραφή ή αποθήκευση αυτού του κώδικ�
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Αντιγραφή κωδικού ανάκτησης"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6088,6 +6175,14 @@ msgid "Delete recent chats?"
 msgstr "Διαγραφή πρόσφατων συνομιλιών;"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6098,6 +6193,14 @@ msgstr "Διαγραφή αυτής της συνομιλίας;"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Διαγραμμένες συνομιλίες"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6125,7 +6228,8 @@ msgstr "Περιγράψτε τις αλλαγές με βάση την εικό
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
+msgstr ""
+"Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6295,7 +6399,8 @@ msgstr "Απενεργοποίηση και αποσύνδεση"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
+msgstr ""
+"Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6356,6 +6461,13 @@ msgid "Dismiss"
 msgstr "Απόρριψη"
 
 # smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
 msgctxt "duckassist"
 msgid "Dismiss"
@@ -6406,7 +6518,8 @@ msgstr "Γλώσσα οθόνης"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr "Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
+msgstr ""
+"Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6489,7 +6602,8 @@ msgstr "Δεν βλέπεις το DuckDuckGo στη λίστα;"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
+msgstr ""
+"Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6538,10 +6652,9 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το "
-"%1$snoai.duckduckgo.com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής "
-"νοημοσύνης και με φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε "
-"περισσότερα%4$s"
+"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το %1$snoai.duckduckgo."
+"com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής νοημοσύνης και με "
+"φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε περισσότερα%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6818,7 +6931,8 @@ msgstr "Όρους χρήσης υπηρεσίας του Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
+msgstr ""
+"Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6896,8 +7010,8 @@ msgid ""
 "remember home on the web: https://duck.ai"
 msgstr ""
 "Το Duck.ai εξακολουθεί να αποτελεί προϊόν της DuckDuckGo, ωστόσο πλέον θα "
-"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: "
-"https://duck.ai"
+"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: https://duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6938,8 +7052,8 @@ msgid ""
 msgstr ""
 "Το Duck.ai σάς επιτρέπει να συνομιλείτε ιδιωτικά με δημοφιλή μοντέλα "
 "τεχνητής νοημοσύνης. Η απενεργοποίησή του αποκρύπτει τα κουμπιά και τους "
-"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το "
-"%1$sduck.ai%2$s απευθείας."
+"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το %1$sduck."
+"ai%2$s απευθείας."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6962,7 +7076,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr ""
+"Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6978,7 +7093,8 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr "Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
+msgstr ""
+"Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7011,7 +7127,8 @@ msgstr "Το Duck.ai αναβαθμίστηκε!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
+msgstr ""
+"Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7205,7 +7322,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
+msgstr ""
+"Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7232,6 +7350,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Πρόγραμμα περιήγησης DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7460,7 +7585,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
+msgstr ""
+"Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7638,7 +7764,8 @@ msgstr "Δώστε έμφαση σε σημαντικές πληροφορίες
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr "Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
+msgstr ""
+"Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7650,7 +7777,8 @@ msgstr "Ενεργοποίηση λειτουργιών τεχνητής νοη�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
+msgstr ""
+"Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7857,19 +7985,22 @@ msgstr "Βεβαιώσου ότι έχεις επιλέξει %1$sΑποδοχή
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
+msgstr ""
+"Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
+msgstr ""
+"Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
+msgstr ""
+"Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7992,7 +8123,8 @@ msgstr "Καταχώρισε τη διεύθυνση email σου."
 #. A prompt asking users to enter their passphrase.
 msgctxt "cloudsave"
 msgid "Enter your passphrase to load your settings."
-msgstr "Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
+msgstr ""
+"Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an entertainment guide in its responses.
@@ -8076,13 +8208,29 @@ msgstr "Ανάπτυξη χάρτη"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
+msgstr ""
+"Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
+
+# smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Έληξε"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8494,7 +8642,8 @@ msgstr "Οικονομικός σύμβουλος"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
+msgstr ""
+"Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -9473,10 +9622,19 @@ msgstr ""
 "Συγχρονισμός με άλλη συσκευή%4$s. Ή σάρωσε τον κωδικό QR στο PDF ανάκτησης."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
+msgstr ""
+"Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9582,6 +9740,12 @@ msgstr "Το κατάλαβα"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Το κατάλαβα"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9935,7 +10099,8 @@ msgstr "Βοηθήστε με να προετοιμαστώ για τη συνέ
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr "Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
+msgstr ""
+"Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9947,7 +10112,8 @@ msgstr "Βοηθήστε μας να βελτιώσουμε το DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
+msgstr ""
+"Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9999,7 +10165,8 @@ msgstr "Βοηθήστε μας να καταλάβουμε πώς δεν πετ
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr "Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
+msgstr ""
+"Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -10304,7 +10471,8 @@ msgstr "Οι ώρες λείπουν"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr "Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
+msgstr ""
+"Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10411,7 +10579,8 @@ msgstr "Πόσο συχνά θέλετε να βλέπετε τις απαντή
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr "Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
+msgstr ""
+"Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10646,7 +10815,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
+msgstr ""
+"Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11231,7 +11401,8 @@ msgstr ""
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
+msgstr ""
+"Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11574,6 +11745,12 @@ msgstr "Μάθε %1$sπερισσότερα%2$s"
 msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Μάθε %1$sπερισσότερα%2$s"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -12217,6 +12394,13 @@ msgid "Manage"
 msgstr "Διαχείριση"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12466,6 +12650,12 @@ msgstr "Μενού"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Μενού"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12838,6 +13028,12 @@ msgid "More about Duck.ai"
 msgstr "Περισσότερα για το Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Περισσότερα στην πηγή"
@@ -13030,6 +13226,12 @@ msgstr "Σε σίγαση"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Μουντό κόκκινο"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13591,7 +13793,8 @@ msgstr "Δεν βρέθηκαν αποτελέσματα."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
+msgstr ""
+"Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13615,13 +13818,15 @@ msgstr "Δεν αποκλείστηκαν εφαρμογές παρακολού�
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
+msgstr ""
+"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
+msgstr ""
+"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -14102,6 +14307,30 @@ msgstr ""
 "Windows, %3$sκάνε κλικ στο εικονίδιο %4$s > Ρυθμίσεις %5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14399,8 +14628,8 @@ msgstr "Άνοιγμα του πίνακα «Πώς λειτουργεί το Du
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
 msgstr ""
-"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το "
-"DuckDuckGo...%2$s"
+"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το DuckDuckGo..."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14861,6 +15090,12 @@ msgid "Past year"
 msgstr "Τελευταίο έτος"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14871,6 +15106,12 @@ msgstr "Επικόλληση"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Επικόλληση κωδικού συγχρονισμού"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14924,6 +15165,20 @@ msgstr "Οριστικά κλειστό"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Περσικά"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15994,7 +16249,8 @@ msgstr "Προστατέψτε τα εισερχόμενά σας"
 #. DuckDuckGo's browser app has features to protect your data by keeping it private
 msgctxt "SERP footer content"
 msgid "Protect your data as you search and browse."
-msgstr "Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
+msgstr ""
+"Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
 
 # smartling.placeholder_format=C
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
@@ -16200,6 +16456,12 @@ msgid "Reading website…"
 msgstr "Ανάγνωση ιστότοπου..."
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16233,7 +16495,8 @@ msgstr "Συλλογιστική τεχνητή νοημοσύνη με μέτρ
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr "Η συλλογιστική μπορεί να δώσει καλύτερες απαντήσεις σε σύνθετες ερωτήσεις."
+msgstr ""
+"Η συλλογιστική μπορεί να δώσει καλύτερες απαντήσεις σε σύνθετες ερωτήσεις."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16392,6 +16655,12 @@ msgstr "Ανάκτηση"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Κωδικός ανάκτησης"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16619,7 +16888,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr "Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
+msgstr ""
+"Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -16645,6 +16915,12 @@ msgstr "Αφαίρεση %1$s"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "Αφαίρεση %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16687,6 +16963,18 @@ msgstr "Αφαίρεση επιλεγμένου κειμένου"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Αφαίρεσε περιττά σημεία στίξης"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17058,7 +17346,8 @@ msgstr "Κριτικές"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr "Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
+msgstr ""
+"Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17135,7 +17424,8 @@ msgstr "ΝΑ"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr "Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
+msgstr ""
+"Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -17390,6 +17680,12 @@ msgid "Say hello to Duck.ai"
 msgstr "Πείτε γεια στο Duck.ai"
 
 # smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai!"
@@ -17491,13 +17787,15 @@ msgstr "Σκωτία"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr ""
+"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr ""
+"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17709,7 +18007,8 @@ msgstr "Ορατότητα αναζήτησης"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr "Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
+msgstr ""
+"Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -18117,8 +18416,8 @@ msgstr "Επιλέξτε %1$sΡύθμιση για αυτόν τον ιστότ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε "
-"%3$shttps://duckduckgo.com%4$s στο πεδίο εισαγωγής"
+"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε %3$shttps://duckduckgo."
+"com%4$s στο πεδίο εισαγωγής"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18130,13 +18429,15 @@ msgstr ""
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
+msgstr ""
+"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
+msgstr ""
+"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18177,7 +18478,8 @@ msgstr "Διάλεξε %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
+msgstr ""
+"Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18251,7 +18553,8 @@ msgstr "Διάλεξε %1$sΡυθμίσεις%2$s και έπειτα %3$sΣύν
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
+msgstr ""
+"Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18312,7 +18615,8 @@ msgstr "Διάλεξε όλα τα τετράγωνα που περιέχουν 
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr "Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
+msgstr ""
+"Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -18416,6 +18720,13 @@ msgstr "Σερβικά (Κυριλλικά)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Σερβικά (λατινικά)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18572,6 +18883,14 @@ msgid "Share"
 msgstr "Κοινοποίηση"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18702,7 +19021,8 @@ msgstr "Κοινοποίησε αυτή τη συνομιλία στο DuckDuckG
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr "Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
+msgstr ""
+"Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -18721,6 +19041,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Μοιραστείτε τις σκέψεις σας στο πεδίο αναζήτησης."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19038,7 +19370,8 @@ msgstr "Εμφάνιση πλαϊνής γραμμής"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Εμφάνιση συμβουλών βήμα προς βήμα για να αξιοποιήσεις στο έπακρο το Duck.ai."
+msgstr ""
+"Εμφάνιση συμβουλών βήμα προς βήμα για να αξιοποιήσεις στο έπακρο το Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19421,6 +19754,12 @@ msgid "Something went wrong"
 msgstr "Κάτι πήγε λάθος"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19430,7 +19769,8 @@ msgstr "Κάτι πήγε στραβά κατά την αποθήκευση στ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
+msgstr ""
+"Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19763,7 +20103,8 @@ msgstr "Αρχίστε με μια εικόνα"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr "Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
+msgstr ""
+"Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -20037,7 +20378,8 @@ msgstr "Πρότεινε έναν τίτλο για μια ανάρτηση σε
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
+msgstr ""
+"Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20277,6 +20619,12 @@ msgstr "Αλλαγή μοντέλου"
 msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr "Αλλαγή μοντέλου"
+
+# smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20541,6 +20889,13 @@ msgid "Synced Devices"
 msgstr "Συγχρονισμένες συσκευές"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Συρία"
 
@@ -20571,6 +20926,12 @@ msgstr "Θα ανακοινωθεί"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "Τηλεόραση"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20845,13 +21206,15 @@ msgstr "Ευχαριστούμε για τα σχόλιά σας!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
+msgstr ""
+"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
+msgstr ""
+"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -21016,7 +21379,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
+msgstr ""
+"Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21090,7 +21454,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
+msgstr ""
+"Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21114,7 +21479,8 @@ msgstr "Αυτή την εβδομάδα"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr "Αυτή η συνομιλία παραμένει στο Duck.ai και παραμένει ιδιωτική για σένα."
+msgstr ""
+"Αυτή η συνομιλία παραμένει στο Duck.ai και παραμένει ιδιωτική για σένα."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21166,16 +21532,34 @@ msgstr ""
 "περισσότερες πληροφορίες)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
+msgstr ""
+"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
+msgstr ""
+"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21234,19 +21618,27 @@ msgstr "Δεν ήταν δυνατή η δημιουργία αυτής της �
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
+msgstr ""
+"Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
+msgstr ""
+"Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Αυτές οι πληροφορίες δεν είναι χρήσιμες"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21317,7 +21709,8 @@ msgstr "Αυτή η σελίδα απαιτεί Javascript για να λειτ�
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
+msgstr ""
+"Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21368,6 +21761,18 @@ msgstr ""
 "υποστήριξη τεχνητής νοημοσύνης στο %1$s."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21396,7 +21801,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
+msgstr ""
+"Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21425,7 +21831,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
+msgstr ""
+"Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21513,7 +21920,8 @@ msgstr "Συμβουλές"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
+msgstr ""
+"Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21546,8 +21954,8 @@ msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
 msgstr ""
-"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του "
-"Duck.ai"
+"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του Duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -21788,7 +22196,8 @@ msgstr "Εφαρμογές παρακολούθησης που αποκλείσ�
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr "Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
+msgstr ""
+"Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21974,7 +22383,8 @@ msgstr "Δοκιμάστε το %1$s για να σταματήσετε να β�
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
+msgstr ""
+"Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22022,6 +22432,12 @@ msgstr "Δοκιμάστε το δωρεάν"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Δοκιμάστε το δωρεάν"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22094,7 +22510,8 @@ msgstr ""
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
 msgctxt "noresults"
 msgid "Try clearing your filters and searching again."
-msgstr "Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
+msgstr ""
+"Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words.
@@ -22113,7 +22530,8 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
+msgstr ""
+"Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22141,6 +22559,12 @@ msgstr "Δοκιμάστε το δωρεάν"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Δοκιμάστε το δωρεάν"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22181,7 +22605,8 @@ msgstr "Δοκίμασε δωρεάν για 7 ημέρες"
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
 msgid "Try generating an AI-assisted answer"
-msgstr "Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
+msgstr ""
+"Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask duckassist (an instant answer based on generative AI) for an answer
@@ -22209,7 +22634,8 @@ msgstr "Δοκιμάστε το πρόγραμμα περιήγησής μας"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
+msgstr ""
+"Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22394,6 +22820,12 @@ msgid "Turkmenistan"
 msgstr "Τουρκμενιστάν"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22404,6 +22836,12 @@ msgstr "Απενεργοποίηση Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Απενεργοποίηση Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22496,7 +22934,8 @@ msgstr "Ενεργοποιήστε την «Ακριβή τοποθεσία» γ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
+msgstr ""
+"Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22648,7 +23087,8 @@ msgstr "Δεν είναι δυνατή η αποστολή σχολίων"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
+msgstr ""
+"Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -22702,7 +23142,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
+msgstr ""
+"Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22721,8 +23162,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών "
-"αναζήτησης…%4$s"
+"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών αναζήτησης…"
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22823,7 +23264,8 @@ msgstr ""
 #. Title for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Unlock VPN + Advanced AI"
-msgstr "Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
+msgstr ""
+"Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Text for the button that allows the user to unlock an AI model with a DuckDuckGo subscription when clicked.
@@ -22853,7 +23295,8 @@ msgstr "Ξεκλειδώστε προηγμένα μοντέλα τεχνητή�
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr "Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
+msgstr ""
+"Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -22898,6 +23341,12 @@ msgid "Unmute"
 msgstr "Κατάργηση σίγασης"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22933,6 +23382,12 @@ msgstr "Ενημέρωση"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Ενημέρωση προγράμματος περιήγησης"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23216,7 +23671,8 @@ msgstr "Χρήση της ιδιωτικής αναζήτησης του DuckDuc
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
+msgstr ""
+"Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23250,7 +23706,8 @@ msgstr "Χρησιμοποιείτε δημόσιο Wi-Fi; Χρησιμοποι�
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr "Χρησιμοποίησε το Fire Button για να διαγράψεις μια συνομιλία από το ιστορικό."
+msgstr ""
+"Χρησιμοποίησε το Fire Button για να διαγράψεις μια συνομιλία από το ιστορικό."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23414,7 +23871,8 @@ msgstr "Δείτε τιμές για τη διαμονή σας"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
+msgstr ""
+"Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23874,7 +24332,8 @@ msgstr "Δεν σε παρακολουθούμε, ποτέ μα ποτέ."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
+msgstr ""
+"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23917,13 +24376,22 @@ msgstr ""
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
+msgstr ""
+"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Τερματίσαμε τη συνομιλία λόγω αδράνειας. Θέλετε να προσπαθήσετε ξανά;"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23974,6 +24442,14 @@ msgstr ""
 "γνώμη ανά πάσα στιγμή αργότερα."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -24012,6 +24488,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Θα αποκλείουμε εφαρμογές παρακολούθησης που προσπαθούν να συλλέξουν τα "
 "δεδομένα σου κατά την περιήγηση."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24224,7 +24708,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
+msgstr ""
+"Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24286,14 +24771,15 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του "
-"Duck.ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
+"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του Duck."
+"ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What AI model would you like us to add? (optional)"
-msgstr "Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
+msgstr ""
+"Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for providing arguments, counter-arguments, and rebuttals to the concept of a plant-based diet.
@@ -24336,6 +24822,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Ποια είναι μερικά πλεονεκτήματα και μειονεκτήματα των προσόδων;"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24914,6 +25406,14 @@ msgid "Without zero provider visibility"
 msgstr "Χωρίς μηδενική ορατότητα από τον πάροχο"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -25198,7 +25698,8 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr "Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
+msgstr ""
+"Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -25260,7 +25761,8 @@ msgstr ""
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
+msgstr ""
+"Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25297,7 +25799,8 @@ msgstr ""
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can keep chatting by using your monthly limit."
-msgstr "Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
+msgstr ""
+"Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
 
 # smartling.placeholder_format=C
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
@@ -25408,7 +25911,8 @@ msgstr "Μπορείς να ξεκινήσεις από την αρχή σε α�
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
+msgstr ""
+"Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -25421,6 +25925,13 @@ msgstr "Σου απομένουν %1$s απόπειρες."
 msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Σου απομένει 1 απόπειρα."
+
+# smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25584,14 +26095,16 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
+msgstr ""
+"Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
+msgstr ""
+"Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25617,9 +26130,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες "
-"Duck.ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να "
-"συνεχίσετε τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
+"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες Duck."
+"ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να συνεχίσετε "
+"τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25649,6 +26162,23 @@ msgid "YouTube Standard"
 msgstr "Βασική άδεια YouTube"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Το ιστορικό αναζήτησής σου στο DuckDuckGo είναι ιδιωτικό"
@@ -25670,6 +26200,14 @@ msgstr "Η πραγματική τοποθεσία σου δεν αποκαλύ�
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Η πραγματική τοποθεσία σας παραμένει ιδιωτική."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,7 +50,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Αυτή η συσκευή)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -110,8 +110,7 @@ msgstr "%1$s απόπειρες"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr "Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -313,8 +312,7 @@ msgstr "Οι κατατάξεις %1$s δεν είναι ακόμη διαθέσ
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"Το %1$s φτάνει στα όρια χρήσης 2-5x νωρίτερα από τα βασικά μοντέλα. %2$s"
+msgstr "Το %1$s φτάνει στα όρια χρήσης 2-5x νωρίτερα από τα βασικά μοντέλα. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -385,8 +383,7 @@ msgstr "%1$s χρησιμοποιήθηκε"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"Το %1$s χρησιμοποιεί τα όρια έως και 2-5x ταχύτερα από τα βασικά μοντέλα %2$s"
+msgstr "Το %1$s χρησιμοποιεί τα όρια έως και 2-5x ταχύτερα από τα βασικά μοντέλα %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -510,7 +507,7 @@ msgstr "%1$sΜάθε πώς διατηρούμε την τοποθεσία σο�
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sΜάθετε περισσότερα%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -541,8 +538,7 @@ msgstr ""
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
+msgstr "%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -642,8 +638,7 @@ msgstr "1 προσπάθεια"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when only one exists.
 msgid "1 attempt blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr "Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -810,7 +805,7 @@ msgstr "2η στον όμιλο %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2η γνώμη"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1061,8 +1056,7 @@ msgstr ""
 #. Disclaimer text displayed at the bottom of the voice chat dialog informing the user that the AI (Artificial Intelligence) may provide inaccurate or offensive information.
 msgctxt "voice chat"
 msgid "AI may provide inaccurate or offensive information."
-msgstr ""
-"Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr "Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Label for the input field where user can specify how the AI assistant should refer to itself. Example: 'AI nickname (is): Fred'
@@ -1514,7 +1508,7 @@ msgstr "Προσθήκη στην αρχική οθόνη"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Προσθήκη στο Οι συνομιλίες μου"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1794,8 +1788,7 @@ msgstr "Όλες οι συνομιλίες είναι %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr ""
-"Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
+msgstr "Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -1887,7 +1880,7 @@ msgstr "Όλα τα είδη"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Όλες οι συσκευές σας έχουν αποσυνδεθεί από το Sync."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2269,8 +2262,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
+msgstr "Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2423,7 +2415,7 @@ msgstr "Ρώτα οτιδήποτε ιδιωτικά"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Ρώτα οτιδήποτε ιδιωτικά"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2866,8 +2858,7 @@ msgstr "Γραμμοκώδικας"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
-"Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
+msgstr "Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -3039,8 +3030,7 @@ msgstr "Αποκλεισμός ενοχλητικών αναδυόμενων π�
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr ""
-"Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
+msgstr "Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -3055,8 +3045,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
+msgstr "Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3139,8 +3128,7 @@ msgstr "Αποκλεισμένα:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr ""
-"Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
+msgstr "Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -3424,8 +3412,7 @@ msgstr "Κάνοντας κλικ στο «%1$s» συμφωνείτε με το
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
+msgstr "Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3811,8 +3798,7 @@ msgstr "Αλλάζει την εμφάνιση των διευθύνσεων URL
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
+msgstr "Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4538,8 +4524,8 @@ msgid ""
 msgstr ""
 "Η εκκαθάριση των δεδομένων του προγράμματος περιήγησης διαγράφει τις "
 "πρόσφατες συνομιλίες. Οι πρόσφατες συνομιλίες μπορεί να αποθηκευτούν επ' "
-"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του Duck."
-"ai., ανάλογα με το πρόγραμμα περιήγησής σας."
+"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του "
+"Duck.ai., ανάλογα με το πρόγραμμα περιήγησής σας."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4659,8 +4645,7 @@ msgstr "Κάνε κλικ στις %1$sΡυθμίσεις%2$s στο αναπτ�
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
+msgstr "Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4698,8 +4683,7 @@ msgstr "Κάνε κλικ στο %1$sΠρόγραμμα περιήγησης%2$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
+msgstr "Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4779,15 +4763,13 @@ msgstr "Κάνε κλικ στην καρτέλα %1$sΓενικά%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr ""
-"Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
+msgstr "Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr ""
-"Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
+msgstr "Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -5316,8 +5298,7 @@ msgstr "Συνεχίστε να μπλοκάρετε διαφημίσεις"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Συνέχισε τις πρόσφατες συνομιλίες εδώ. Ή διάγραψέ τες με το Fire Button."
+msgstr "Συνέχισε τις πρόσφατες συνομιλίες εδώ. Ή διάγραψέ τες με το Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5424,7 +5405,7 @@ msgstr "Αντιγραφή"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Αντιγραφή"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5475,13 +5456,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Αντιγραφή κοινόχρηστου συνδέσμου"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Αντίγραψε τον κωδικό από άλλη συσκευή"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5490,6 +5471,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Αντίγραψε τον κωδικό από άλλη συσκευή. Μεταβείτε στις %1$sΡυθμίσεις Duck.ai "
+"› Συνομιλίες › Sync & Backup › Συγχρονισμός με άλλη συσκευή%2$s και "
+"προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6180,7 +6164,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Διαγραφή κοινόχρηστου συνδέσμου"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6201,6 +6185,9 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Η διαγραφή ενός συνδέσμου σταματά τη λειτουργία του. Τα άτομα που τον έχουν "
+"ανοίξει και έχουν προσθέσει τη συνομιλία στις συνομιλίες τους θα διατηρήσουν "
+"το δικό τους αντίγραφο."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6228,8 +6215,7 @@ msgstr "Περιγράψτε τις αλλαγές με βάση την εικό
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
+msgstr "Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6399,8 +6385,7 @@ msgstr "Απενεργοποίηση και αποσύνδεση"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
+msgstr "Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6465,7 +6450,7 @@ msgstr "Απόρριψη"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Απόρριψη"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6518,8 +6503,7 @@ msgstr "Γλώσσα οθόνης"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
+msgstr "Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6602,8 +6586,7 @@ msgstr "Δεν βλέπεις το DuckDuckGo στη λίστα;"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
+msgstr "Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6652,9 +6635,10 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το %1$snoai.duckduckgo."
-"com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής νοημοσύνης και με "
-"φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε περισσότερα%4$s"
+"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το "
+"%1$snoai.duckduckgo.com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής "
+"νοημοσύνης και με φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε "
+"περισσότερα%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6931,8 +6915,7 @@ msgstr "Όρους χρήσης υπηρεσίας του Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
+msgstr "Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7010,8 +6993,8 @@ msgid ""
 "remember home on the web: https://duck.ai"
 msgstr ""
 "Το Duck.ai εξακολουθεί να αποτελεί προϊόν της DuckDuckGo, ωστόσο πλέον θα "
-"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: https://duck."
-"ai"
+"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: "
+"https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7052,8 +7035,8 @@ msgid ""
 msgstr ""
 "Το Duck.ai σάς επιτρέπει να συνομιλείτε ιδιωτικά με δημοφιλή μοντέλα "
 "τεχνητής νοημοσύνης. Η απενεργοποίησή του αποκρύπτει τα κουμπιά και τους "
-"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το %1$sduck."
-"ai%2$s απευθείας."
+"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το "
+"%1$sduck.ai%2$s απευθείας."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7076,8 +7059,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr "Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7093,8 +7075,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
+msgstr "Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7127,8 +7108,7 @@ msgstr "Το Duck.ai αναβαθμίστηκε!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
+msgstr "Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7322,8 +7302,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
+msgstr "Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7356,7 +7335,7 @@ msgstr "Πρόγραμμα περιήγησης DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Σελίδες βοήθειας DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7585,8 +7564,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
+msgstr "Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7764,8 +7742,7 @@ msgstr "Δώστε έμφαση σε σημαντικές πληροφορίες
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr ""
-"Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
+msgstr "Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7777,8 +7754,7 @@ msgstr "Ενεργοποίηση λειτουργιών τεχνητής νοη�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
+msgstr "Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7985,22 +7961,19 @@ msgstr "Βεβαιώσου ότι έχεις επιλέξει %1$sΑποδοχή
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
+msgstr "Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
+msgstr "Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
+msgstr "Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8123,8 +8096,7 @@ msgstr "Καταχώρισε τη διεύθυνση email σου."
 #. A prompt asking users to enter their passphrase.
 msgctxt "cloudsave"
 msgid "Enter your passphrase to load your settings."
-msgstr ""
-"Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
+msgstr "Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an entertainment guide in its responses.
@@ -8208,15 +8180,14 @@ msgstr "Ανάπτυξη χάρτη"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
+msgstr "Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Έληξε"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8230,7 +8201,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Λήγει %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8642,8 +8613,7 @@ msgstr "Οικονομικός σύμβουλος"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
+msgstr "Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -9628,13 +9598,14 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Μεταβείτε στις %1$sΡυθμίσεις Duck.ai%2$s › %3$sΣυνομιλίες › Sync & Backup › "
+"Συγχρονισμός με άλλη συσκευή%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
+msgstr "Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9745,7 +9716,7 @@ msgstr "Το κατάλαβα"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Το κατάλαβα"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10099,8 +10070,7 @@ msgstr "Βοηθήστε με να προετοιμαστώ για τη συνέ
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
-"Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
+msgstr "Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -10112,8 +10082,7 @@ msgstr "Βοηθήστε μας να βελτιώσουμε το DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
+msgstr "Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10165,8 +10134,7 @@ msgstr "Βοηθήστε μας να καταλάβουμε πώς δεν πετ
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
+msgstr "Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -10471,8 +10439,7 @@ msgstr "Οι ώρες λείπουν"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
+msgstr "Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10579,8 +10546,7 @@ msgstr "Πόσο συχνά θέλετε να βλέπετε τις απαντή
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
+msgstr "Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10815,8 +10781,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
+msgstr "Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11401,8 +11366,7 @@ msgstr ""
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
+msgstr "Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11750,7 +11714,7 @@ msgstr "Μάθε %1$sπερισσότερα%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Μάθετε περισσότερα"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -12398,7 +12362,7 @@ msgstr "Διαχείριση"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Διαχείριση"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12655,7 +12619,7 @@ msgstr "Μενού"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Τα μηνύματα από αυτό το σημείο και έπειτα είναι ορατά μόνο σε εσάς."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -13031,7 +12995,7 @@ msgstr "Περισσότερα για το Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Περισσότερες ενέργειες"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13231,7 +13195,7 @@ msgstr "Μουντό κόκκινο"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Οι συσκευές μου"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13793,8 +13757,7 @@ msgstr "Δεν βρέθηκαν αποτελέσματα."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
+msgstr "Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13818,15 +13781,13 @@ msgstr "Δεν αποκλείστηκαν εφαρμογές παρακολού�
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr ""
-"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
+msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
+msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -14313,6 +14274,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Σε άλλη συσκευή μεταβείτε στις %1$sΡυθμίσεις Duck.ai%2$s › %3$sΣυνομιλίες › "
+"Sync & Backup › Συγχρονισμός με άλλη συσκευή%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14321,6 +14284,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Σε άλλη συσκευή μεταβείτε στις %1$sΡυθμίσεις Duck.ai%2$s › %3$sΣυνομιλίες › "
+"Sync & Backup › Συγχρονισμός με άλλη συσκευή%4$s και σαρώστε αυτόν τον "
+"κωδικό:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14329,6 +14295,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Σε μια άλλη συσκευή μεταβείτε στις %1$sΡυθμίσεις Duck.ai%2$s › "
+"%3$sΣυνομιλίες › Sync & Backup › Συγχρονισμός με άλλη συσκευή%4$s. Ή σαρώστε "
+"τον κωδικό QR στο PDF ανάκτησης."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14628,8 +14597,8 @@ msgstr "Άνοιγμα του πίνακα «Πώς λειτουργεί το Du
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
 msgstr ""
-"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το DuckDuckGo..."
-"%2$s"
+"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το "
+"DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15093,7 +15062,7 @@ msgstr "Τελευταίο έτος"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Επικόλληση"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -15111,7 +15080,7 @@ msgstr "Επικόλληση κωδικού συγχρονισμού"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Επικολλήστε το παρακάτω"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -15170,7 +15139,7 @@ msgstr "Περσικά"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -15179,6 +15148,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Η λειτουργία Personal Information Removal εντοπίζει τις πληροφορίες σας σε "
+"ιστότοπους διαμεσολαβητών δεδομένων που τις πωλούν. Στη συνέχεια, "
+"εργαζόμαστε για να τις αφαιρέσουμε για εσάς."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -16249,8 +16221,7 @@ msgstr "Προστατέψτε τα εισερχόμενά σας"
 #. DuckDuckGo's browser app has features to protect your data by keeping it private
 msgctxt "SERP footer content"
 msgid "Protect your data as you search and browse."
-msgstr ""
-"Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
+msgstr "Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
 
 # smartling.placeholder_format=C
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
@@ -16459,7 +16430,7 @@ msgstr "Ανάγνωση ιστότοπου..."
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Έτοιμοι για την έκλειψη ηλίου;"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16495,8 +16466,7 @@ msgstr "Συλλογιστική τεχνητή νοημοσύνη με μέτρ
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
-"Η συλλογιστική μπορεί να δώσει καλύτερες απαντήσεις σε σύνθετες ερωτήσεις."
+msgstr "Η συλλογιστική μπορεί να δώσει καλύτερες απαντήσεις σε σύνθετες ερωτήσεις."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16660,7 +16630,7 @@ msgstr "Κωδικός ανάκτησης"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Κωδικός ανάκτησης"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16888,8 +16858,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr ""
-"Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
+msgstr "Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -16920,7 +16889,7 @@ msgstr "Αφαίρεση %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Αφαίρεση συσκευής"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16968,13 +16937,13 @@ msgstr "Αφαίρεσε περιττά σημεία στίξης"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Αφαιρέστε τις πληροφορίες σας από το διαδίκτυο"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Αφαιρέστε τις πληροφορίες σας ηλεκτρονικά"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17346,8 +17315,7 @@ msgstr "Κριτικές"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
+msgstr "Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17424,8 +17392,7 @@ msgstr "ΝΑ"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
+msgstr "Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -17684,6 +17651,8 @@ msgstr "Πείτε γεια στο Duck.ai"
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
+"Πες γεια στο Duck.ai – δωρεάν, ιδιωτική συνομιλία με τεχνητή νοημοσύνη από "
+"το DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17787,15 +17756,13 @@ msgstr "Σκωτία"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18007,8 +17974,7 @@ msgstr "Ορατότητα αναζήτησης"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
+msgstr "Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -18416,8 +18382,8 @@ msgstr "Επιλέξτε %1$sΡύθμιση για αυτόν τον ιστότ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε %3$shttps://duckduckgo."
-"com%4$s στο πεδίο εισαγωγής"
+"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε "
+"%3$shttps://duckduckgo.com%4$s στο πεδίο εισαγωγής"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18429,15 +18395,13 @@ msgstr ""
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
+msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
+msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18478,8 +18442,7 @@ msgstr "Διάλεξε %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
+msgstr "Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18553,8 +18516,7 @@ msgstr "Διάλεξε %1$sΡυθμίσεις%2$s και έπειτα %3$sΣύν
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
+msgstr "Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18615,8 +18577,7 @@ msgstr "Διάλεξε όλα τα τετράγωνα που περιέχουν 
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr ""
-"Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
+msgstr "Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -18726,7 +18687,7 @@ msgstr "Σερβικά (λατινικά)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Τα δεδομένα διακομιστή διαγράφηκαν"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18888,7 +18849,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Κοινοποίηση"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -19021,8 +18982,7 @@ msgstr "Κοινοποίησε αυτή τη συνομιλία στο DuckDuckG
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr ""
-"Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
+msgstr "Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -19046,13 +19006,13 @@ msgstr "Μοιραστείτε τις σκέψεις σας στο πεδίο α
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Σύνδεσμοι κοινοποιημένων συνομιλιών"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Σύνδεσμοι κοινοποιημένων συνομιλιών"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19370,8 +19330,7 @@ msgstr "Εμφάνιση πλαϊνής γραμμής"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Εμφάνιση συμβουλών βήμα προς βήμα για να αξιοποιήσεις στο έπακρο το Duck.ai."
+msgstr "Εμφάνιση συμβουλών βήμα προς βήμα για να αξιοποιήσεις στο έπακρο το Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19757,7 +19716,7 @@ msgstr "Κάτι πήγε λάθος"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Κάτι πήγε λάθος κατά τη φόρτωση αυτής της κοινόχρηστης συνομιλίας."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19769,8 +19728,7 @@ msgstr "Κάτι πήγε στραβά κατά την αποθήκευση στ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
+msgstr "Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -20103,8 +20061,7 @@ msgstr "Αρχίστε με μια εικόνα"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
+msgstr "Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -20378,8 +20335,7 @@ msgstr "Πρότεινε έναν τίτλο για μια ανάρτηση σε
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
+msgstr "Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20624,7 +20580,7 @@ msgstr "Αλλαγή μοντέλου"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Αλλαγή μοντέλου"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20893,7 +20849,7 @@ msgstr "Συγχρονισμένες συσκευές"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Συγχρονίστηκε %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20931,7 +20887,7 @@ msgstr "Τηλεόραση"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Πίνακας"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -21206,15 +21162,13 @@ msgstr "Ευχαριστούμε για τα σχόλιά σας!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
+msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
+msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -21379,8 +21333,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
+msgstr "Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21454,8 +21407,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
+msgstr "Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21479,8 +21431,7 @@ msgstr "Αυτή την εβδομάδα"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
-"Αυτή η συνομιλία παραμένει στο Duck.ai και παραμένει ιδιωτική για σένα."
+msgstr "Αυτή η συνομιλία παραμένει στο Duck.ai και παραμένει ιδιωτική για σένα."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21535,7 +21486,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Αυτή η συσκευή"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21546,20 +21497,21 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Αυτή η συσκευή δεν θα μπορεί πλέον να έχει πρόσβαση στα συγχρονισμένα "
+"δεδομένα σας σε άλλες συσκευές. Οι τελευταίες %1$s συνομιλίες θα παραμείνουν "
+"διαθέσιμες στον τοπικό χώρο αποθήκευσης."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
+msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
+msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21618,16 +21570,14 @@ msgstr "Δεν ήταν δυνατή η δημιουργία αυτής της �
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
+msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
+msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21638,7 +21588,7 @@ msgstr "Αυτές οι πληροφορίες δεν είναι χρήσιμε�
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Αυτό είναι ένα αντίγραφο μιας κοινοποιημένης συνομιλίας."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21709,8 +21659,7 @@ msgstr "Αυτή η σελίδα απαιτεί Javascript για να λειτ�
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
+msgstr "Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21765,12 +21714,14 @@ msgstr ""
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
 msgstr ""
+"Δεν ήταν δυνατό το άνοιγμα αυτής της κοινόχρηστης συνομιλίας. Ο σύνδεσμος "
+"μπορεί να μην είναι πλήρης."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Αυτός ο κοινόχρηστος σύνδεσμος συνομιλίας δεν είναι πλέον διαθέσιμος."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21801,8 +21752,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
+msgstr "Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21831,8 +21781,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
+msgstr "Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21920,8 +21869,7 @@ msgstr "Συμβουλές"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
+msgstr "Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21954,8 +21902,8 @@ msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
 msgstr ""
-"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του Duck."
-"ai"
+"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -22196,8 +22144,7 @@ msgstr "Εφαρμογές παρακολούθησης που αποκλείσ�
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
+msgstr "Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22383,8 +22330,7 @@ msgstr "Δοκιμάστε το %1$s για να σταματήσετε να β�
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
+msgstr "Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22437,7 +22383,7 @@ msgstr "Δοκιμάστε το δωρεάν"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Δοκιμάστε το δωρεάν!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22510,8 +22456,7 @@ msgstr ""
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
 msgctxt "noresults"
 msgid "Try clearing your filters and searching again."
-msgstr ""
-"Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
+msgstr "Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words.
@@ -22530,8 +22475,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
+msgstr "Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22564,7 +22508,7 @@ msgstr "Δοκιμάστε το δωρεάν"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Δοκιμάστε δωρεάν!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22605,8 +22549,7 @@ msgstr "Δοκίμασε δωρεάν για 7 ημέρες"
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
 msgid "Try generating an AI-assisted answer"
-msgstr ""
-"Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
+msgstr "Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask duckassist (an instant answer based on generative AI) for an answer
@@ -22634,8 +22577,7 @@ msgstr "Δοκιμάστε το πρόγραμμα περιήγησής μας"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
+msgstr "Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22823,7 +22765,7 @@ msgstr "Τουρκμενιστάν"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Απενεργοποίηση"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22841,7 +22783,7 @@ msgstr "Απενεργοποίηση Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Απενεργοποίηση του Sync & Backup και διαγραφή των δεδομένων διακομιστή;"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22934,8 +22876,7 @@ msgstr "Ενεργοποιήστε την «Ακριβή τοποθεσία» γ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
+msgstr "Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23087,8 +23028,7 @@ msgstr "Δεν είναι δυνατή η αποστολή σχολίων"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
+msgstr "Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -23142,8 +23082,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
+msgstr "Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23162,8 +23101,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών αναζήτησης…"
-"%4$s"
+"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών "
+"αναζήτησης…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23264,8 +23203,7 @@ msgstr ""
 #. Title for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Unlock VPN + Advanced AI"
-msgstr ""
-"Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
+msgstr "Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Text for the button that allows the user to unlock an AI model with a DuckDuckGo subscription when clicked.
@@ -23295,8 +23233,7 @@ msgstr "Ξεκλειδώστε προηγμένα μοντέλα τεχνητή�
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
+msgstr "Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -23344,7 +23281,7 @@ msgstr "Κατάργηση σίγασης"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Συνομιλία χωρίς τίτλο"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23387,7 +23324,7 @@ msgstr "Ενημέρωση προγράμματος περιήγησης"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Ενημερώστε το Duck.ai για να δείτε αυτήν την κοινόχρηστη συνομιλία."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23671,8 +23608,7 @@ msgstr "Χρήση της ιδιωτικής αναζήτησης του DuckDuc
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
+msgstr "Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23706,8 +23642,7 @@ msgstr "Χρησιμοποιείτε δημόσιο Wi-Fi; Χρησιμοποι�
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
-"Χρησιμοποίησε το Fire Button για να διαγράψεις μια συνομιλία από το ιστορικό."
+msgstr "Χρησιμοποίησε το Fire Button για να διαγράψεις μια συνομιλία από το ιστορικό."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23871,8 +23806,7 @@ msgstr "Δείτε τιμές για τη διαμονή σας"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
+msgstr "Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -24332,8 +24266,7 @@ msgstr "Δεν σε παρακολουθούμε, ποτέ μα ποτέ."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
+msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24376,8 +24309,7 @@ msgstr ""
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
+msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24392,6 +24324,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Βρίσκουμε και αφαιρούμε τις προσωπικές πληροφορίες σας από ιστότοπους "
+"διαμεσολαβητών δεδομένων. Επιπλέον, αποκτήστε ένα VPN και πολλά άλλα."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24448,6 +24382,9 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Σαρώνουμε τακτικά ιστότοπους διαμεσολαβητών δεδομένων για τα προσωπικά "
+"στοιχεία σας και κοινοποιούμε την πρόοδό μας μαζί σας σε έναν εύχρηστο "
+"πίνακα εργαλείων."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24496,6 +24433,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Θα σαρώσουμε ιστότοπους διαμεσολαβητών δεδομένων για το email, το όνομα, τη "
+"διεύθυνσή σας και άλλα, και θα εργαστούμε για να αφαιρέσουμε ό,τι βρούμε για "
+"εσάς."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24708,8 +24648,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
+msgstr "Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24771,15 +24710,14 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του Duck."
-"ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
+"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του "
+"Duck.ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What AI model would you like us to add? (optional)"
-msgstr ""
-"Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
+msgstr "Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for providing arguments, counter-arguments, and rebuttals to the concept of a plant-based diet.
@@ -24827,7 +24765,7 @@ msgstr "Ποια είναι μερικά πλεονεκτήματα και με�
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Ποια είναι τα πλεονεκτήματα του Duck.ai;"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -25412,6 +25350,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Λειτουργεί απευθείας από τη συσκευή σας για να αφαιρέσει το email, το όνομα, "
+"τη διεύθυνσή σας και άλλα από ιστότοπους διαμεσολαβητών δεδομένων."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25698,8 +25638,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
+msgstr "Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -25761,8 +25700,7 @@ msgstr ""
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
+msgstr "Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25799,8 +25737,7 @@ msgstr ""
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can keep chatting by using your monthly limit."
-msgstr ""
-"Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
+msgstr "Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
 
 # smartling.placeholder_format=C
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
@@ -25911,8 +25848,7 @@ msgstr "Μπορείς να ξεκινήσεις από την αρχή σε α�
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
+msgstr "Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -25931,7 +25867,7 @@ msgstr "Σου απομένει 1 απόπειρα."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Δεν έχεις κοινοποιημένους συνδέσμους συνομιλίας."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -26095,16 +26031,14 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
+msgstr "Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
+msgstr "Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26130,9 +26064,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες Duck."
-"ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να συνεχίσετε "
-"τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
+"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες "
+"Duck.ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να "
+"συνεχίσετε τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -26170,6 +26104,8 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Οι %1$s πιο πρόσφατες συνομιλίες σας θα είναι διαθέσιμες στον τοπικό χώρο "
+"αποθήκευσης σε αυτά τα προγράμματα περιήγησης:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -26177,6 +26113,8 @@ msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
 msgstr ""
+"Οι συνομιλίες σας στο Duck.ai συγχρονίζονται με κρυπτογράφηση από άκρο σε "
+"άκρο."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26208,6 +26146,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Το αντίγραφο ασφαλείας σας θα διαγραφεί από τον διακομιστή του DuckDuckGo. "
+"Όλες οι συσκευές θα αποσυνδεθούν από τον συγχρονισμό."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/en_AU/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_AU/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -394,6 +401,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -628,6 +641,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1181,6 +1199,11 @@ msgstr "Add to %s"
 msgid "Add to Home Screen"
 msgstr "Add to Home Screen"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Add-ons"
@@ -1472,6 +1495,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1884,6 +1913,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4205,6 +4239,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4237,6 +4276,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4797,6 +4855,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4805,6 +4870,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5011,6 +5083,12 @@ msgstr "Dismiss"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5658,6 +5736,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6321,9 +6405,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7416,6 +7513,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7500,6 +7604,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9092,6 +9201,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Learn %sMore%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9609,6 +9723,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9815,6 +9935,11 @@ msgstr "Menu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10116,6 +10241,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "More here->"
@@ -10273,6 +10403,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Muted red"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11152,6 +11287,27 @@ msgstr ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11762,6 +11918,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11770,6 +11931,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11814,6 +11980,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12828,6 +13006,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12977,6 +13160,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13184,6 +13372,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13217,6 +13410,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13765,6 +13968,11 @@ msgstr "Save your settings anonymously to the cloud"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14537,6 +14745,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14661,6 +14875,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14780,6 +15001,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15327,6 +15558,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16016,6 +16252,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16213,6 +16454,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16238,6 +16485,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "TV"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16693,6 +16945,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16761,6 +17027,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16844,6 +17115,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17358,6 +17639,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17450,6 +17736,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17649,6 +17940,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17657,6 +17953,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18037,6 +18338,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18064,6 +18370,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18838,6 +19149,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18872,6 +19190,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18896,6 +19221,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19140,6 +19472,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19602,6 +19939,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20004,6 +20348,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20172,6 +20522,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube Standard"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20189,6 +20554,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/en_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_CA/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -394,6 +401,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -628,6 +641,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1181,6 +1199,11 @@ msgstr "Add to %s"
 msgid "Add to Home Screen"
 msgstr "Add to Home Screen"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Add-ons"
@@ -1472,6 +1495,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1884,6 +1913,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4205,6 +4239,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4237,6 +4276,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4797,6 +4855,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4805,6 +4870,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5011,6 +5083,12 @@ msgstr "Dismiss"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5658,6 +5736,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6321,9 +6405,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7416,6 +7513,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7500,6 +7604,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9092,6 +9201,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Learn %sMore%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9609,6 +9723,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9815,6 +9935,11 @@ msgstr "Menu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10116,6 +10241,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "More at"
@@ -10273,6 +10403,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr " Muted red"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11152,6 +11287,27 @@ msgstr ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11762,6 +11918,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11770,6 +11931,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11814,6 +11980,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12828,6 +13006,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12977,6 +13160,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13184,6 +13372,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13217,6 +13410,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13765,6 +13968,11 @@ msgstr "Save your settings anonymously to the cloud"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14537,6 +14745,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14661,6 +14875,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14780,6 +15001,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15327,6 +15558,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16016,6 +16252,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16213,6 +16454,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16238,6 +16485,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "TV"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16693,6 +16945,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16761,6 +17027,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16844,6 +17115,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17358,6 +17639,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17450,6 +17736,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17649,6 +17940,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17657,6 +17953,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18037,6 +18338,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18064,6 +18370,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18838,6 +19149,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18872,6 +19190,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18896,6 +19221,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19140,6 +19472,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19602,6 +19939,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20004,6 +20348,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20172,6 +20522,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube Standard"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20189,6 +20554,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/en_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_GB/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -394,6 +401,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -628,6 +641,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1181,6 +1199,11 @@ msgstr "Add to %s"
 msgid "Add to Home Screen"
 msgstr "Add to Home Screen"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Add-ons"
@@ -1472,6 +1495,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1884,6 +1913,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4205,6 +4239,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4237,6 +4276,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4797,6 +4855,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4805,6 +4870,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5011,6 +5083,12 @@ msgstr "Dismiss"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5658,6 +5736,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6321,9 +6405,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7416,6 +7513,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7500,6 +7604,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9092,6 +9201,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Learn %sMore%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9609,6 +9723,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9815,6 +9935,11 @@ msgstr "Menu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10116,6 +10241,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "More at"
@@ -10273,6 +10403,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Muted red"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11152,6 +11287,27 @@ msgstr ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11762,6 +11918,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11770,6 +11931,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11814,6 +11980,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12828,6 +13006,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12977,6 +13160,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13184,6 +13372,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13217,6 +13410,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13765,6 +13968,11 @@ msgstr "Save your settings anonymously to the cloud"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14537,6 +14745,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14661,6 +14875,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14780,6 +15001,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15327,6 +15558,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16016,6 +16252,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16213,6 +16454,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16238,6 +16485,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "TV"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16693,6 +16945,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16761,6 +17027,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16844,6 +17115,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17358,6 +17639,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17450,6 +17736,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17649,6 +17940,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17657,6 +17953,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18037,6 +18338,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18064,6 +18370,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18838,6 +19149,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18872,6 +19190,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18896,6 +19221,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19140,6 +19472,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19602,6 +19939,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20004,6 +20348,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20172,6 +20522,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube Standard"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20189,6 +20554,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/en_US/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_US/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr ""
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr ""
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4193,6 +4227,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4225,6 +4264,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4785,6 +4843,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4793,6 +4858,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -4999,6 +5071,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5646,6 +5724,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6308,9 +6392,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7401,6 +7498,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7485,6 +7589,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9069,6 +9178,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9586,6 +9700,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9791,6 +9911,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10093,6 +10218,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10249,6 +10379,11 @@ msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
+msgstr ""
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
 msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -11127,6 +11262,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11731,6 +11887,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11739,6 +11900,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11783,6 +11949,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12797,6 +12975,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12946,6 +13129,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13153,6 +13341,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13186,6 +13379,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13734,6 +13937,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14498,6 +14706,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14622,6 +14836,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14741,6 +14962,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15288,6 +15519,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15977,6 +16213,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16174,6 +16415,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16198,6 +16445,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16651,6 +16903,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16719,6 +16985,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16802,6 +17073,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17316,6 +17597,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17408,6 +17694,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17607,6 +17898,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17615,6 +17911,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -17992,6 +18293,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18019,6 +18325,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18785,6 +19096,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18819,6 +19137,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18843,6 +19168,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19087,6 +19419,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19549,6 +19886,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19949,6 +20293,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20113,6 +20463,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20130,6 +20495,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/eo_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/eo_XX/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -398,6 +405,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -632,6 +645,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1185,6 +1203,11 @@ msgstr "Aldoni al %s"
 msgid "Add to Home Screen"
 msgstr "Aldoni al la ĉefa ekrano"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Aldonaĵoj"
@@ -1477,6 +1500,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1890,6 +1919,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4214,6 +4248,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4246,6 +4285,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4806,6 +4864,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4814,6 +4879,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5020,6 +5092,12 @@ msgstr "Rezignu"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5667,6 +5745,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6330,9 +6414,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7425,6 +7522,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7509,6 +7613,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9101,6 +9210,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Pli da %sinformo%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9618,6 +9732,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9824,6 +9944,11 @@ msgstr "Menuo"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menuo"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10125,6 +10250,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Pli ĉe"
@@ -10282,6 +10412,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Malhelruĝa"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11161,6 +11296,27 @@ msgstr ""
 "Sur Makontiŝo, %sAlklaku Maxthon > Preferoj%s, Sur Vindozo, %sAlklaku la %s "
 "bildsimbolon > Agordoj%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11771,6 +11927,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11779,6 +11940,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11823,6 +11989,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12837,6 +13015,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12986,6 +13169,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13193,6 +13381,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13226,6 +13419,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13774,6 +13977,11 @@ msgstr "Konservu viajn agordojn anonime en la nubo"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14547,6 +14755,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14671,6 +14885,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14790,6 +15011,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15337,6 +15568,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16028,6 +16264,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16225,6 +16466,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16250,6 +16497,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Televido"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16708,6 +16960,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16776,6 +17042,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16859,6 +17130,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17375,6 +17656,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17467,6 +17753,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17666,6 +17957,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17674,6 +17970,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18054,6 +18355,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18081,6 +18387,11 @@ msgstr "Ĝisdatigi"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18855,6 +19166,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18889,6 +19207,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18913,6 +19238,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19157,6 +19489,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19619,6 +19956,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20021,6 +20365,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20191,6 +20541,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Jutuba normo"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20208,6 +20573,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/es_AR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_AR/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -394,6 +401,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -628,6 +641,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1181,6 +1199,11 @@ msgstr "Añadir a %s"
 msgid "Add to Home Screen"
 msgstr "Agregar a la página de inicio"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Complementos"
@@ -1473,6 +1496,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1886,6 +1915,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4222,6 +4256,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4254,6 +4293,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4814,6 +4872,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4822,6 +4887,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5028,6 +5100,12 @@ msgstr "Descartar"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5675,6 +5753,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6339,9 +6423,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7436,6 +7533,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7520,6 +7624,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9119,6 +9228,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Conocé %sMás%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9640,6 +9754,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9846,6 +9966,11 @@ msgstr "Menú"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menú"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10147,6 +10272,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Más en"
@@ -10304,6 +10434,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rojo apagado"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11183,6 +11318,27 @@ msgstr ""
 "En Mac, %shacé clic en Maxthon > Preferencias%s, en Windows; %shacé clic en "
 "el ícono %s > Configuración%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11793,6 +11949,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11801,6 +11962,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11845,6 +12011,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12859,6 +13037,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13008,6 +13191,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13215,6 +13403,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13248,6 +13441,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13796,6 +13999,11 @@ msgstr "Guardá tus configuraciones anónimamente en la nube"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14577,6 +14785,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14703,6 +14917,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14822,6 +15043,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15369,6 +15600,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16059,6 +16295,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16256,6 +16497,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16281,6 +16528,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Televisión"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16737,6 +16989,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16805,6 +17071,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16888,6 +17159,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17404,6 +17685,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17497,6 +17783,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17696,6 +17987,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17704,6 +18000,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18090,6 +18391,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18117,6 +18423,11 @@ msgstr "Actualizar"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18893,6 +19204,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18927,6 +19245,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18951,6 +19276,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19195,6 +19527,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19659,6 +19996,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20065,6 +20409,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20234,6 +20584,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Estándar de YouTube"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20251,6 +20616,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/es_CL/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CL/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Agregar a %s"
 msgid "Add to Home Screen"
 msgstr "Añadir a la pantalla de inicio"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Complementos"
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4209,6 +4243,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4241,6 +4280,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4801,6 +4859,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4809,6 +4874,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5015,6 +5087,12 @@ msgstr "Cancelar"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5662,6 +5740,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6326,9 +6410,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7422,6 +7519,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7506,6 +7610,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9096,6 +9205,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Saber %sMás%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9615,6 +9729,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9820,6 +9940,11 @@ msgstr "Menú"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10122,6 +10247,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Más en"
@@ -10279,6 +10409,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rojo mudo"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11158,6 +11293,27 @@ msgstr ""
 "En Mac, %s Click Maxthon > Preferencias%s, En Windows, %sClick el %s ícono > "
 "Opciones%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11768,6 +11924,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11776,6 +11937,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11820,6 +11986,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12834,6 +13012,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12983,6 +13166,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13191,6 +13379,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13224,6 +13417,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13772,6 +13975,11 @@ msgstr "Guarda anónimamente tu configuración en la nube"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14553,6 +14761,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14679,6 +14893,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14798,6 +15019,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15345,6 +15576,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16034,6 +16270,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16231,6 +16472,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16255,6 +16502,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16708,6 +16960,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16776,6 +17042,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16859,6 +17130,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17375,6 +17656,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17468,6 +17754,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17667,6 +17958,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17675,6 +17971,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18061,6 +18362,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18088,6 +18394,11 @@ msgstr "Actualizar"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18856,6 +19167,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18890,6 +19208,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18914,6 +19239,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19158,6 +19490,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19620,6 +19957,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20023,6 +20367,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20190,6 +20540,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20207,6 +20572,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/es_CO/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CO/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -394,6 +401,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -628,6 +641,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1181,6 +1199,11 @@ msgstr "Agregar a %s"
 msgid "Add to Home Screen"
 msgstr "Agregar a la pantalla de inicio"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Complementos"
@@ -1473,6 +1496,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1885,6 +1914,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4217,6 +4251,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4249,6 +4288,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4809,6 +4867,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4817,6 +4882,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5023,6 +5095,12 @@ msgstr "Descartar"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5670,6 +5748,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6334,9 +6418,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7431,6 +7528,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7515,6 +7619,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9106,6 +9215,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Conoce %sMás%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9625,6 +9739,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9830,6 +9950,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10132,6 +10257,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Mas en"
@@ -10289,6 +10419,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Granate"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11168,6 +11303,27 @@ msgstr ""
 "En Mac, %sHaz click en Maxthon > Preferencias%s, En Windows, %sHaz click en "
 "el ícono de %s > Preferencias%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11778,6 +11934,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11786,6 +11947,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11830,6 +11996,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12844,6 +13022,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12993,6 +13176,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13200,6 +13388,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13233,6 +13426,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13781,6 +13984,11 @@ msgstr "Guardar anónimamente tu configuración en la nube"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14561,6 +14769,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14687,6 +14901,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14807,6 +15028,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15354,6 +15585,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16043,6 +16279,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16240,6 +16481,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16264,6 +16511,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16717,6 +16969,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16785,6 +17051,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16868,6 +17139,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17384,6 +17665,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17477,6 +17763,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17676,6 +17967,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17684,6 +17980,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18069,6 +18370,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18096,6 +18402,11 @@ msgstr "Actualizar"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18870,6 +19181,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18904,6 +19222,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18928,6 +19253,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19172,6 +19504,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19635,6 +19972,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20038,6 +20382,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20206,6 +20556,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Estándar de YouTube "
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20223,6 +20588,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/es_CR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CR/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Añadir a %s"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Extensiones"
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4196,6 +4230,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4228,6 +4267,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4788,6 +4846,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4796,6 +4861,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5002,6 +5074,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5649,6 +5727,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6311,9 +6395,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7406,6 +7503,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7490,6 +7594,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9078,6 +9187,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Aprende %sMás%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9595,6 +9709,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9800,6 +9920,11 @@ msgstr "Menú"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10102,6 +10227,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Más en"
@@ -10259,6 +10389,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rojo apagado"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11136,6 +11271,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11740,6 +11896,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11748,6 +11909,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11792,6 +11958,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12806,6 +12984,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12955,6 +13138,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13162,6 +13350,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13195,6 +13388,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13743,6 +13946,11 @@ msgstr "Guarda tus ajustes anónimamente a la nube"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14509,6 +14717,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14635,6 +14849,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14754,6 +14975,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15301,6 +15532,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15990,6 +16226,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16187,6 +16428,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16211,6 +16458,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16664,6 +16916,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16732,6 +16998,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16815,6 +17086,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17329,6 +17610,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17422,6 +17708,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17621,6 +17912,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17629,6 +17925,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18006,6 +18307,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18033,6 +18339,11 @@ msgstr "Actualizar"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18799,6 +19110,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18833,6 +19151,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18857,6 +19182,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19101,6 +19433,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19563,6 +19900,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19968,6 +20312,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20135,6 +20485,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20152,6 +20517,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/es_EC/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_EC/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Agregar a %s"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Complementarios"
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4200,6 +4234,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4232,6 +4271,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4792,6 +4850,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4800,6 +4865,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5006,6 +5078,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5653,6 +5731,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6316,9 +6400,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7413,6 +7510,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7497,6 +7601,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9085,6 +9194,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Saber %sMás%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9602,6 +9716,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9807,6 +9927,11 @@ msgstr "Menú"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10109,6 +10234,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Más en"
@@ -10266,6 +10396,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rojo apagado"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11143,6 +11278,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11749,6 +11905,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11757,6 +11918,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11801,6 +11967,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12815,6 +12993,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12964,6 +13147,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13172,6 +13360,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13205,6 +13398,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13753,6 +13956,11 @@ msgstr "Guardar sus ajustes de forma anónima en la nube"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14523,6 +14731,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14649,6 +14863,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14768,6 +14989,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15315,6 +15546,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16004,6 +16240,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16201,6 +16442,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16225,6 +16472,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16678,6 +16930,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16746,6 +17012,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16829,6 +17100,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17345,6 +17626,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17438,6 +17724,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17637,6 +17928,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17645,6 +17941,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18025,6 +18326,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18052,6 +18358,11 @@ msgstr "Actualizar"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18825,6 +19136,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18859,6 +19177,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18883,6 +19208,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19127,6 +19459,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19589,6 +19926,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19992,6 +20336,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20160,6 +20510,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Licencia estándar de YouTube"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20177,6 +20542,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "Porcentaje totalmente vacunado"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "Porcentaje vacunado"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -438,7 +446,8 @@ msgstr "%1$s palabras"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
+msgstr ""
+"%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -487,6 +496,13 @@ msgstr "%1$sMás información%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sDescubre cómo mantenemos la privacidad de tu ubicación%2$s."
+
+# smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -781,6 +797,12 @@ msgstr "Puntos ganados con el 2.º servicio"
 msgctxt "Sports module"
 msgid "2nd in Group %s"
 msgstr "2.º en el grupo %1$s"
+
+# smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1471,6 +1493,12 @@ msgid "Add to Home Screen"
 msgstr "Añadir a la pantalla de inicio"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Addons"
@@ -1834,6 +1862,13 @@ msgstr "Todos los tamaños"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Todos los tipos"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2206,19 +2241,22 @@ msgstr "¿Sigues ahí?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
+msgstr ""
+"¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
+msgstr ""
+"¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
+msgstr ""
+"¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2357,6 +2395,12 @@ msgstr "Pregunta sobre esta página"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask anything privately"
 msgstr "Pregunta cualquier cosa en privado"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -4530,7 +4574,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
+msgstr ""
+"Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4557,7 +4602,8 @@ msgstr "Haz clic en %1$sAjustes%2$s en el menú desplegable."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
+msgstr ""
+"Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4690,7 +4736,8 @@ msgstr "Haz clic en el %1$sicono de permisos%2$s en la barra de direcciones"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
+msgstr ""
+"¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5306,6 +5353,12 @@ msgid "Copy"
 msgstr "Copiar"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5314,7 +5367,8 @@ msgstr "Copiar"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
+msgstr ""
+"Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5345,6 +5399,28 @@ msgstr "Copia o guarda este código"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Copiar código de recuperación"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6019,13 +6095,22 @@ msgstr "¿Borrar los chats más antiguos para liberar espacio de almacenamiento?
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
+msgstr ""
+"¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
 msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr "¿Eliminar chats recientes?"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6038,6 +6123,14 @@ msgstr "¿Borrar este chat?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Chats borrados"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6133,7 +6226,8 @@ msgstr "Dictado en Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
+msgstr ""
+"Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6291,6 +6385,13 @@ msgstr "Descartar"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Descartar"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6800,7 +6901,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
+msgstr ""
+"¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6859,7 +6961,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr "Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
+msgstr ""
+"Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7157,6 +7260,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Navegador DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7839,7 +7949,8 @@ msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
+msgstr ""
+"Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7933,7 +8044,8 @@ msgstr "Guinea Ecuatorial"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
+msgstr ""
+"Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7998,10 +8110,25 @@ msgstr ""
 "por la privacidad."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Caducada"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8106,7 +8233,8 @@ msgstr "Explora Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
+msgstr ""
+"Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8411,7 +8539,8 @@ msgstr "Asesor financiero"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
+msgstr ""
+"Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8647,7 +8776,8 @@ msgstr "Chats gratuitos y privados, anonimizados por nosotros"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
+msgstr ""
+"Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8677,7 +8807,8 @@ msgstr "Libre de compartir y usar comercialmente"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
+msgstr ""
+"Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8758,9 +8889,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"En la barra de menú de la aplicación en Mac, selecciona "
-"<strong>DuckDuckGo</strong> &gt; <strong>Buscar actualizaciones...</strong> "
-"y, a continuación, selecciona <strong>Instalar actualización</strong>."
+"En la barra de menú de la aplicación en Mac, selecciona <strong>DuckDuckGo</"
+"strong> &gt; <strong>Buscar actualizaciones...</strong> y, a continuación, "
+"selecciona <strong>Instalar actualización</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9276,8 +9407,8 @@ msgstr "Obtén la app"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obtén el navegador gratuito DuckDuckGo %1$spara bloquear anuncios en "
-"YouTube.%2$s"
+"Obtén el navegador gratuito DuckDuckGo %1$spara bloquear anuncios en YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9374,6 +9505,14 @@ msgstr ""
 "Ve a %1$sAjustes de Duck.ai%2$s en tu otro navegador o a la aplicación "
 "DuckDuckGo y ve a %3$sChats › Sync & Backup › Sincronizar con otro "
 "dispositivo%4$s. O escanea el QR en tu PDF de recuperación."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9484,6 +9623,12 @@ msgstr "Entendido"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Entendido"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10203,7 +10348,8 @@ msgstr "Falta el horario"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr "Color de fondo al pasar el cursor, de los módulos y de los desplegables"
+msgstr ""
+"Color de fondo al pasar el cursor, de los módulos y de los desplegables"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10288,13 +10434,15 @@ msgstr "Cómo funciona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
+msgstr ""
+"¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
+msgstr ""
+"Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10549,7 +10697,8 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
+msgstr ""
+"Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10596,8 +10745,8 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr ""
-"Las indicaciones para las imágenes deben cumplir con las directrices de "
-"Duck.ai %1$s."
+"Las indicaciones para las imágenes deben cumplir con las directrices de Duck."
+"ai %1$s."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11466,6 +11615,12 @@ msgid "Learn %sMore%s"
 msgstr "%1$sMás información%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11522,7 +11677,8 @@ msgstr "Obtén más información sobre la protección de privacidad activa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr "Más información sobre la privacidad en Internet en tu bandeja de entrada."
+msgstr ""
+"Más información sobre la privacidad en Internet en tu bandeja de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11639,8 +11795,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Te permite alternar entre enviar consultas de búsqueda y sugerencias a "
-"Duck.ai"
+"Te permite alternar entre enviar consultas de búsqueda y sugerencias a Duck."
+"ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12103,6 +12259,13 @@ msgid "Manage"
 msgstr "Gestionar"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12352,6 +12515,12 @@ msgstr "Menú"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menú"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12724,6 +12893,12 @@ msgid "More about Duck.ai"
 msgstr "Más sobre Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Más en"
@@ -12916,6 +13091,12 @@ msgstr "Silenciado"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Granate"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13989,6 +14170,30 @@ msgstr ""
 "en el icono %4$s > Ajustes%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14740,6 +14945,12 @@ msgid "Past year"
 msgstr "Último año"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14750,6 +14961,12 @@ msgstr "Pegar"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Pegar código de sincronización"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14803,6 +15020,20 @@ msgstr "Cerrado permanentemente"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persa"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15016,7 +15247,8 @@ msgstr "Anclados"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Los chats anclados aparecerán en la parte superior de tus chats recientes."
+msgstr ""
+"Los chats anclados aparecerán en la parte superior de tus chats recientes."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15075,13 +15307,15 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
+msgstr ""
+"Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
+msgstr ""
+"Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15850,7 +16084,8 @@ msgstr "Pedir confirmación"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
+msgstr ""
+"Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16066,6 +16301,12 @@ msgid "Reading website…"
 msgstr "Leyendo sitio web…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16099,7 +16340,8 @@ msgstr "IA de razonamiento con moderación media integrada"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr "El razonamiento puede ofrecer mejores respuestas a preguntas complejas."
+msgstr ""
+"El razonamiento puede ofrecer mejores respuestas a preguntas complejas."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16258,6 +16500,12 @@ msgstr "Recuperación"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Código de recuperación"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16511,6 +16759,12 @@ msgid "Remove %s"
 msgstr "Eliminar %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16551,6 +16805,18 @@ msgstr "Eliminar selección de texto"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Elimina la puntuación innecesaria"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16918,7 +17184,8 @@ msgstr "Reseñas"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr "Reescribe esta receta ajustándola para un número diferente de raciones."
+msgstr ""
+"Reescribe esta receta ajustándola para un número diferente de raciones."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17203,7 +17470,8 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr "Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
+msgstr ""
+"Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17243,6 +17511,12 @@ msgstr "Guarda tus ajustes de forma anónima en la nube"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Saluda a Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17741,7 +18015,8 @@ msgstr "Segunda opinión"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
+msgstr ""
+"Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17964,7 +18239,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
+msgstr ""
+"Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18063,7 +18339,8 @@ msgstr "Selecciona %1$sMotor de búsqueda%2$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
+msgstr ""
+"Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18088,7 +18365,8 @@ msgstr "Selecciona %1$sAjustes%2$s en el menú desplegable."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
+msgstr ""
+"Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18103,7 +18381,8 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sSearch Engine%s"
-msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
+msgstr ""
+"Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18263,6 +18542,13 @@ msgid "Serbian (Latin)"
 msgstr "Serbio (latín)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18417,6 +18703,14 @@ msgid "Share"
 msgstr "Compartir"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18564,6 +18858,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Comparte tus ideas sobre el cuadro de búsqueda."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18812,7 +19118,8 @@ msgstr "Mostrar todos los resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
+msgstr ""
+"Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18976,7 +19283,8 @@ msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo al navegador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
+msgstr ""
+"Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18989,7 +19297,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows page numbers at result page breaks"
-msgstr "Muestra los números de página en los saltos de página de los resultados"
+msgstr ""
+"Muestra los números de página en los saltos de página de los resultados"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19002,7 +19311,8 @@ msgstr ""
 #. http://i.imgur.com/94erFcS.png
 msgctxt "settings"
 msgid "Shows suggestions under the search box as you type"
-msgstr "Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
+msgstr ""
+"Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19107,7 +19417,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
+msgstr ""
+"Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19251,6 +19562,12 @@ msgid "Something went wrong"
 msgstr "Se ha producido un error"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19315,7 +19632,8 @@ msgstr "Lo sentimos, se ha producido un error inesperado."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr "Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
+msgstr ""
+"Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -19682,7 +20000,8 @@ msgstr "Detén a los rastreadores ocultos que acechan en otros sitios web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
+msgstr ""
+"Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20099,6 +20418,12 @@ msgid "Switch model"
 msgstr "Cambiar modelo"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20316,7 +20641,8 @@ msgstr "Sincronizar con otro dispositivo"
 #. Title shown when sync service is temporarily unavailable.
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
-msgstr "La sincronización y la copia de seguridad no están disponibles temporalmente"
+msgstr ""
+"La sincronización y la copia de seguridad no están disponibles temporalmente"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
@@ -20355,6 +20681,13 @@ msgid "Synced Devices"
 msgstr "Dispositivos sincronizados"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Siria"
 
@@ -20385,6 +20718,12 @@ msgstr "Pte."
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "Televisión"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20452,7 +20791,8 @@ msgstr "Toma el control de tus datos personales"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
+msgstr ""
+"Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20823,7 +21163,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
+msgstr ""
+"Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20970,16 +21311,34 @@ msgstr ""
 "ofensiva (consulta %4$s para obtener más información)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
+msgstr ""
+"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
+msgstr ""
+"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20999,7 +21358,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
+msgstr ""
+"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21007,7 +21367,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
+msgstr ""
+"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21051,6 +21412,12 @@ msgstr "Este tipo de imagen no es compatible. Adjunta un JPG, PNG, WebP o GIF."
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Esta información no es útil"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21169,6 +21536,18 @@ msgstr ""
 "nunca muestra respuestas asistidas por IA en %1$s."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21223,7 +21602,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
+msgstr ""
+"Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21415,8 +21795,8 @@ msgstr "Hoy"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Cambia para probar el chat privado de IA o %1$sdesactívalo en el menú "
-"%2$s.%3$s"
+"Cambia para probar el chat privado de IA o %1$sdesactívalo en el menú %2$s."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21638,7 +22018,8 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
+msgstr ""
+"Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21646,7 +22027,8 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
+msgstr ""
+"Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21808,6 +22190,12 @@ msgid "Try Free"
 msgstr "Prueba gratis"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21895,14 +22283,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Prueba a activar la ubicación anónima para obtener resultados más precisos."
+msgstr ""
+"Prueba a activar la ubicación anónima para obtener resultados más precisos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
+msgstr ""
+"Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21921,6 +22311,12 @@ msgstr "Probar gratis"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Probar gratis"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22074,13 +22470,15 @@ msgstr "Prueba %1$s y %2$s de código abierto recientemente añadidos"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr "Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
+msgstr ""
+"Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
+msgstr ""
+"Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22165,6 +22563,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistán"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22175,6 +22579,12 @@ msgstr "Desactivar Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Desactivar Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22462,7 +22872,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
+msgstr ""
+"En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22642,7 +23053,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
+msgstr ""
+"Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -22655,6 +23067,12 @@ msgstr "Desbloquea protecciones prémium"
 msgctxt "voice chat"
 msgid "Unmute"
 msgstr "Dejar de silenciar"
+
+# smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22690,6 +23108,12 @@ msgstr "Actualizar"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Actualiza el navegador"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23218,7 +23642,8 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
+msgstr ""
+"Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23565,7 +23990,8 @@ msgstr "No te perseguimos con anuncios."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "No almacenamos nombres de usuario ni información personal identificable."
+msgstr ""
+"No almacenamos nombres de usuario ni información personal identificable."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23675,6 +24101,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Hemos terminado el chat por inactividad. ¿Quieres intentarlo de nuevo?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23721,15 +24155,25 @@ msgstr ""
 "cerca de ti. Siempre puedes cambiar de opinión más adelante."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
+msgstr ""
+"Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
+msgstr ""
+"Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23755,6 +24199,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Bloquearemos los rastreadores que intenten recopilar tus datos mientras "
 "navegas."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23963,7 +24415,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
+msgstr ""
+"¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24004,7 +24457,8 @@ msgstr "Conferencia Oeste"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "We’re currently experiencing an issue with DuckDuckGo Search."
-msgstr "En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
+msgstr ""
+"En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong even though we were able to show some organic results.
@@ -24075,6 +24529,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "¿Cuáles son los pros y los contras de las anualidades?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24406,7 +24866,8 @@ msgstr "¿Sobre qué te gustaría dar tu opinión?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
+msgstr ""
+"Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24438,7 +24899,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
+msgstr ""
+"Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24456,7 +24918,8 @@ msgstr "Dónde ver <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
+msgstr ""
+"Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24644,6 +25107,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Sin visibilidad cero del proveedor"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25132,7 +25603,8 @@ msgstr "Puedes empezar de cero en este nuevo dominio (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
+msgstr ""
+"Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -25145,6 +25617,13 @@ msgstr "Te quedan %1$s intentos."
 msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Te queda 1 intento."
+
+# smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25205,7 +25684,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "No volverás a ver este mensaje a menos que borres los datos de tu navegador."
+msgstr ""
+"No volverás a ver este mensaje a menos que borres los datos de tu navegador."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25310,12 +25790,14 @@ msgstr "Has alcanzado la duración máxima del chat de voz para una sola sesión
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
+msgstr ""
+"Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
+msgstr ""
+"Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25367,6 +25849,23 @@ msgid "YouTube Standard"
 msgstr "YouTube Estándar"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Tu historial de búsquedas de DuckDuckGo es privado"
@@ -25388,6 +25887,14 @@ msgstr "Tu ubicación real se mantiene confidencial"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Tu ubicación real se mantiene privada."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Este dispositivo)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -446,8 +446,7 @@ msgstr "%1$s palabras"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
+msgstr "%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -502,7 +501,7 @@ msgstr "%1$sDescubre cómo mantenemos la privacidad de tu ubicación%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sMás información%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -802,7 +801,7 @@ msgstr "2.º en el grupo %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2.ª opinión"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1496,7 +1495,7 @@ msgstr "Añadir a la pantalla de inicio"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Añadir a Mis chats"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1868,7 +1867,7 @@ msgstr "Todos los tipos"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Todos tus dispositivos están desconectados de la sincronización."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2241,22 +2240,19 @@ msgstr "¿Sigues ahí?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
+msgstr "¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
+msgstr "¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
+msgstr "¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2400,7 +2396,7 @@ msgstr "Pregunta cualquier cosa en privado"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Pregunta cualquier cosa en privado"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -4574,8 +4570,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
+msgstr "Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4602,8 +4597,7 @@ msgstr "Haz clic en %1$sAjustes%2$s en el menú desplegable."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
+msgstr "Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4736,8 +4730,7 @@ msgstr "Haz clic en el %1$sicono de permisos%2$s en la barra de direcciones"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
+msgstr "¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5356,7 +5349,7 @@ msgstr "Copiar"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Copiar"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5367,8 +5360,7 @@ msgstr "Copiar"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
+msgstr "Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5406,13 +5398,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Copiar enlace compartido"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Copia el código desde otro dispositivo"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5421,6 +5413,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Copia el código de otro dispositivo. Ve a %1$sAjustes de Duck.ai › Chats › "
+"Sync & Backup › Sincronizar con otro dispositivo%2$s e inténtalo de nuevo."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6095,8 +6089,7 @@ msgstr "¿Borrar los chats más antiguos para liberar espacio de almacenamiento?
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
+msgstr "¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6110,7 +6103,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Eliminar enlace compartido"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6131,6 +6124,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Eliminar un enlace hace que deje de funcionar. Las personas que lo hayan "
+"abierto y añadido la conversación a sus chats conservarán su propia copia."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6226,8 +6221,7 @@ msgstr "Dictado en Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
+msgstr "Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6391,7 +6385,7 @@ msgstr "Descartar"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Descartar"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6901,8 +6895,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
+msgstr "¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6961,8 +6954,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
+msgstr "Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7266,7 +7258,7 @@ msgstr "Navegador DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Páginas de ayuda de DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7949,8 +7941,7 @@ msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
+msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8044,8 +8035,7 @@ msgstr "Guinea Ecuatorial"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
+msgstr "Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8114,7 +8104,7 @@ msgstr ""
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Caducada"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8128,7 +8118,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Caduca el %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8233,8 +8223,7 @@ msgstr "Explora Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
+msgstr "Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8539,8 +8528,7 @@ msgstr "Asesor financiero"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
+msgstr "Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8776,8 +8764,7 @@ msgstr "Chats gratuitos y privados, anonimizados por nosotros"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
+msgstr "Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8807,8 +8794,7 @@ msgstr "Libre de compartir y usar comercialmente"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
+msgstr "Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8889,9 +8875,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"En la barra de menú de la aplicación en Mac, selecciona <strong>DuckDuckGo</"
-"strong> &gt; <strong>Buscar actualizaciones...</strong> y, a continuación, "
-"selecciona <strong>Instalar actualización</strong>."
+"En la barra de menú de la aplicación en Mac, selecciona "
+"<strong>DuckDuckGo</strong> &gt; <strong>Buscar actualizaciones...</strong> "
+"y, a continuación, selecciona <strong>Instalar actualización</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9407,8 +9393,8 @@ msgstr "Obtén la app"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obtén el navegador gratuito DuckDuckGo %1$spara bloquear anuncios en YouTube."
-"%2$s"
+"Obtén el navegador gratuito DuckDuckGo %1$spara bloquear anuncios en "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9513,6 +9499,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Ve a %1$sAjustes de Duck.ai%2$s › %3$sChats › Sync & Backup › Sincronizar "
+"con otro dispositivo%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9628,7 +9616,7 @@ msgstr "Entendido"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Entendido"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10348,8 +10336,7 @@ msgstr "Falta el horario"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Color de fondo al pasar el cursor, de los módulos y de los desplegables"
+msgstr "Color de fondo al pasar el cursor, de los módulos y de los desplegables"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10434,15 +10421,13 @@ msgstr "Cómo funciona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
+msgstr "¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
+msgstr "Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10697,8 +10682,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
+msgstr "Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10745,8 +10729,8 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr ""
-"Las indicaciones para las imágenes deben cumplir con las directrices de Duck."
-"ai %1$s."
+"Las indicaciones para las imágenes deben cumplir con las directrices de "
+"Duck.ai %1$s."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11618,7 +11602,7 @@ msgstr "%1$sMás información%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Más información"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11677,8 +11661,7 @@ msgstr "Obtén más información sobre la protección de privacidad activa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Más información sobre la privacidad en Internet en tu bandeja de entrada."
+msgstr "Más información sobre la privacidad en Internet en tu bandeja de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11795,8 +11778,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Te permite alternar entre enviar consultas de búsqueda y sugerencias a Duck."
-"ai"
+"Te permite alternar entre enviar consultas de búsqueda y sugerencias a "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12263,7 +12246,7 @@ msgstr "Gestionar"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Gestionar"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12520,7 +12503,7 @@ msgstr "Menú"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Los mensajes a partir de este punto solo son visibles para ti."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12896,7 +12879,7 @@ msgstr "Más sobre Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Más acciones"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13096,7 +13079,7 @@ msgstr "Granate"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Mis dispositivos"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14176,6 +14159,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"En otro dispositivo, ve a %1$sAjustes de Duck.ai%2$s › %3$sChats › Sync & "
+"Backup › Sincronizar con otro dispositivo%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14184,6 +14169,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"En otro dispositivo, ve a %1$sAjustes de Duck.ai%2$s › %3$sChats › Sync & "
+"Backup › Sincronizar con otro dispositivo%4$s y escanea este código:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14192,6 +14179,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"En otro dispositivo, ve a %1$sAjustes de Duck.ai%2$s › %3$sChats › Sync & "
+"Backup › Sincronizar con otro dispositivo%4$s. O escanea el QR en tu PDF de "
+"recuperación."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14948,7 +14938,7 @@ msgstr "Último año"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Pegar"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14966,7 +14956,7 @@ msgstr "Pegar código de sincronización"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Pégalo a continuación"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -15025,7 +15015,7 @@ msgstr "Persa"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -15034,6 +15024,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal busca tu información en los sitios de "
+"intermediarios de datos que la están vendiendo. Luego, trabajamos para "
+"conseguir que se elimine por ti."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15247,8 +15240,7 @@ msgstr "Anclados"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Los chats anclados aparecerán en la parte superior de tus chats recientes."
+msgstr "Los chats anclados aparecerán en la parte superior de tus chats recientes."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15307,15 +15299,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
+msgstr "Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
+msgstr "Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -16084,8 +16074,7 @@ msgstr "Pedir confirmación"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
+msgstr "Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16304,7 +16293,7 @@ msgstr "Leyendo sitio web…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "¿Listo para el eclipse solar?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16340,8 +16329,7 @@ msgstr "IA de razonamiento con moderación media integrada"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
-"El razonamiento puede ofrecer mejores respuestas a preguntas complejas."
+msgstr "El razonamiento puede ofrecer mejores respuestas a preguntas complejas."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16505,7 +16493,7 @@ msgstr "Código de recuperación"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Código de recuperación"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16762,7 +16750,7 @@ msgstr "Eliminar %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Eliminar dispositivo"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16810,13 +16798,13 @@ msgstr "Elimina la puntuación innecesaria"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Elimina tu información de internet"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Eliminar tu información en Internet"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17184,8 +17172,7 @@ msgstr "Reseñas"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Reescribe esta receta ajustándola para un número diferente de raciones."
+msgstr "Reescribe esta receta ajustándola para un número diferente de raciones."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17470,8 +17457,7 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
+msgstr "Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17516,7 +17502,7 @@ msgstr "Saluda a Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Saluda a Duck.ai, chat de IA gratuito y privado de DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -18015,8 +18001,7 @@ msgstr "Segunda opinión"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
+msgstr "Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18239,8 +18224,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
+msgstr "Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18339,8 +18323,7 @@ msgstr "Selecciona %1$sMotor de búsqueda%2$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
+msgstr "Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18365,8 +18348,7 @@ msgstr "Selecciona %1$sAjustes%2$s en el menú desplegable."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
+msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18381,8 +18363,7 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sSearch Engine%s"
-msgstr ""
-"Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
+msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18546,7 +18527,7 @@ msgstr "Serbio (latín)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Datos del servidor eliminados"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18708,7 +18689,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Compartir"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18863,13 +18844,13 @@ msgstr "Comparte tus ideas sobre el cuadro de búsqueda."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Enlaces de chat compartidos"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Enlaces de chat compartidos"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19118,8 +19099,7 @@ msgstr "Mostrar todos los resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
+msgstr "Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19283,8 +19263,7 @@ msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo al navegador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
+msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19297,8 +19276,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows page numbers at result page breaks"
-msgstr ""
-"Muestra los números de página en los saltos de página de los resultados"
+msgstr "Muestra los números de página en los saltos de página de los resultados"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19311,8 +19289,7 @@ msgstr ""
 #. http://i.imgur.com/94erFcS.png
 msgctxt "settings"
 msgid "Shows suggestions under the search box as you type"
-msgstr ""
-"Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
+msgstr "Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19417,8 +19394,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
+msgstr "Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19565,7 +19541,7 @@ msgstr "Se ha producido un error"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Se ha producido un error al cargar este chat compartido."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19632,8 +19608,7 @@ msgstr "Lo sentimos, se ha producido un error inesperado."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
+msgstr "Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -20000,8 +19975,7 @@ msgstr "Detén a los rastreadores ocultos que acechan en otros sitios web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
+msgstr "Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20421,7 +20395,7 @@ msgstr "Cambiar modelo"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Cambiar modelo"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20641,8 +20615,7 @@ msgstr "Sincronizar con otro dispositivo"
 #. Title shown when sync service is temporarily unavailable.
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
-msgstr ""
-"La sincronización y la copia de seguridad no están disponibles temporalmente"
+msgstr "La sincronización y la copia de seguridad no están disponibles temporalmente"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
@@ -20685,7 +20658,7 @@ msgstr "Dispositivos sincronizados"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Sincronizado el %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20723,7 +20696,7 @@ msgstr "Televisión"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabla"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20791,8 +20764,7 @@ msgstr "Toma el control de tus datos personales"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
+msgstr "Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21163,8 +21135,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
+msgstr "Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21314,7 +21285,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Este dispositivo"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21325,20 +21296,21 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Este dispositivo ya no podrá acceder a tus datos sincronizados en otros "
+"dispositivos. Los últimos %1$s chats seguirán disponibles en el "
+"almacenamiento local."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
+msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
+msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21358,8 +21330,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
+msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21367,8 +21338,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
+msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21417,7 +21387,7 @@ msgstr "Esta información no es útil"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Esta es una copia de un chat compartido."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21540,12 +21510,14 @@ msgstr ""
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
 msgstr ""
+"No se ha podido abrir este chat compartido. Es posible que el enlace esté "
+"incompleto."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Este enlace de chat compartido ya no está disponible."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21602,8 +21574,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
+msgstr "Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21795,8 +21766,8 @@ msgstr "Hoy"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Cambia para probar el chat privado de IA o %1$sdesactívalo en el menú %2$s."
-"%3$s"
+"Cambia para probar el chat privado de IA o %1$sdesactívalo en el menú "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22018,8 +21989,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
+msgstr "Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22027,8 +21997,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
+msgstr "Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22193,7 +22162,7 @@ msgstr "Prueba gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "¡Pruébalo gratis!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22283,16 +22252,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Prueba a activar la ubicación anónima para obtener resultados más precisos."
+msgstr "Prueba a activar la ubicación anónima para obtener resultados más precisos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
+msgstr "Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22316,7 +22283,7 @@ msgstr "Probar gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "¡Pruébalo gratis!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22470,15 +22437,13 @@ msgstr "Prueba %1$s y %2$s de código abierto recientemente añadidos"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
+msgstr "Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
+msgstr "Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22566,7 +22531,7 @@ msgstr "Turkmenistán"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Desactivar"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22584,7 +22549,7 @@ msgstr "Desactivar Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "¿Desactivar Sync & Backup y eliminar los datos del servidor?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22872,8 +22837,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
+msgstr "En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23053,8 +23017,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
+msgstr "Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23072,7 +23035,7 @@ msgstr "Dejar de silenciar"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Chat sin título"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23113,7 +23076,7 @@ msgstr "Actualiza el navegador"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Actualiza Duck.ai para ver este chat compartido."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23642,8 +23605,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
+msgstr "Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23990,8 +23952,7 @@ msgstr "No te perseguimos con anuncios."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"No almacenamos nombres de usuario ni información personal identificable."
+msgstr "No almacenamos nombres de usuario ni información personal identificable."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24107,6 +24068,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Encontramos y eliminamos tu información personal de los sitios de "
+"intermediarios de datos. Además, obtén una VPN y mucho más."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24161,19 +24124,20 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Escaneamos periódicamente los sitios de intermediarios de datos en busca de "
+"tu información personal y compartimos contigo nuestro progreso en un panel "
+"de control fácil de usar."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
+msgstr "Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
+msgstr "Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24207,6 +24171,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Escanearemos los sitios de intermediarios de datos en busca de tu correo "
+"electrónico, nombre, dirección y más y trabajaremos para eliminar todo lo "
+"que encontremos sobre ti."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24415,8 +24382,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
+msgstr "¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24457,8 +24423,7 @@ msgstr "Conferencia Oeste"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "We’re currently experiencing an issue with DuckDuckGo Search."
-msgstr ""
-"En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
+msgstr "En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong even though we were able to show some organic results.
@@ -24534,7 +24499,7 @@ msgstr "¿Cuáles son los pros y los contras de las anualidades?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "¿Cuáles son los beneficios de Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24866,8 +24831,7 @@ msgstr "¿Sobre qué te gustaría dar tu opinión?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
+msgstr "Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24899,8 +24863,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
+msgstr "Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24918,8 +24881,7 @@ msgstr "Dónde ver <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
+msgstr "Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25115,6 +25077,9 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Funciona directamente desde tu dispositivo para eliminar tu correo "
+"electrónico, nombre, dirección y más de los sitios de intermediarios de "
+"datos."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25603,8 +25568,7 @@ msgstr "Puedes empezar de cero en este nuevo dominio (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
+msgstr "Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -25623,7 +25587,7 @@ msgstr "Te queda 1 intento."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "No tienes enlaces de chat compartidos."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25684,8 +25648,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"No volverás a ver este mensaje a menos que borres los datos de tu navegador."
+msgstr "No volverás a ver este mensaje a menos que borres los datos de tu navegador."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25790,14 +25753,12 @@ msgstr "Has alcanzado la duración máxima del chat de voz para una sola sesión
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
+msgstr "Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
+msgstr "Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25857,6 +25818,8 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Tus %1$s chats más recientes estarán disponibles en el almacenamiento local "
+"de estos navegadores:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -25864,6 +25827,8 @@ msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
 msgstr ""
+"Tus chats de Duck.ai se están sincronizando con encriptación de extremo a "
+"extremo."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25895,6 +25860,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Tu copia de seguridad se borrará del servidor de DuckDuckGo. Todos los "
+"dispositivos se desconectarán de la sincronización."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/es_MX/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_MX/LC_MESSAGES/duckduckgo.po
@@ -39,6 +39,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -395,6 +402,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -629,6 +642,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1183,6 +1201,11 @@ msgstr "Añadir a %s"
 msgid "Add to Home Screen"
 msgstr "Añadir a Pantalla de Inicio"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Complementos"
@@ -1474,6 +1497,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1887,6 +1916,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4226,6 +4260,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4258,6 +4297,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4818,6 +4876,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4826,6 +4891,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5032,6 +5104,12 @@ msgstr "Descartar"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5679,6 +5757,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6343,9 +6427,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7442,6 +7539,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7526,6 +7630,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9124,6 +9233,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Aprende %sMás%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9644,6 +9758,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9850,6 +9970,11 @@ msgstr "Menú"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menú"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10151,6 +10276,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Más en"
@@ -10309,6 +10439,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rojo mutado"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11189,6 +11324,27 @@ msgstr ""
 "En Mac, %sHaga click en Maxthon > Preferencias%s, En Windows, %sHaga click "
 "en %s icono > Configuración%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11802,6 +11958,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11810,6 +11971,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11854,6 +12020,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12870,6 +13048,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13019,6 +13202,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13226,6 +13414,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13259,6 +13452,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13807,6 +14010,11 @@ msgstr "Guardar tu configuración anónimamente en la nube"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14590,6 +14798,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14716,6 +14930,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14835,6 +15056,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15382,6 +15613,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16072,6 +16308,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16269,6 +16510,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16294,6 +16541,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Televisión"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16752,6 +17004,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16820,6 +17086,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16903,6 +17174,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17419,6 +17700,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17512,6 +17798,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17712,6 +18003,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17720,6 +18016,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18110,6 +18411,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18137,6 +18443,11 @@ msgstr "Actualizar"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18914,6 +19225,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18948,6 +19266,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18972,6 +19297,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19216,6 +19548,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19679,6 +20016,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20083,6 +20427,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20253,6 +20603,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Estándar de YouTube"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20270,6 +20635,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/es_PE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_PE/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Adregar a  %s"
 msgid "Add to Home Screen"
 msgstr "Añadir a la pantalla principal"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Componentes adicionales "
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4205,6 +4239,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4237,6 +4276,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4797,6 +4855,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4805,6 +4870,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5011,6 +5083,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5658,6 +5736,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6320,9 +6404,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7415,6 +7512,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7499,6 +7603,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9088,6 +9197,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Conocer %smás%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9605,6 +9719,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9810,6 +9930,11 @@ msgstr "Menú"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10112,6 +10237,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Más en"
@@ -10269,6 +10399,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rojo silenciado"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11146,6 +11281,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11752,6 +11908,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11760,6 +11921,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11804,6 +11970,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12818,6 +12996,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12967,6 +13150,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13174,6 +13362,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13207,6 +13400,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13755,6 +13958,11 @@ msgstr "Guarda tus ajustes anónimamente en la nube"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14529,6 +14737,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14655,6 +14869,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14774,6 +14995,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15321,6 +15552,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16011,6 +16247,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16208,6 +16449,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16233,6 +16480,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Televisión"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16685,6 +16937,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16753,6 +17019,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16836,6 +17107,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17352,6 +17633,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17445,6 +17731,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17644,6 +17935,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17652,6 +17948,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18033,6 +18334,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18060,6 +18366,11 @@ msgstr "Actualizar"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18826,6 +19137,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18860,6 +19178,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18884,6 +19209,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19128,6 +19460,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19590,6 +19927,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19994,6 +20338,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20160,6 +20510,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20177,6 +20542,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/es_UY/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_UY/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Agregar a %s"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Complementos"
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4195,6 +4229,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4227,6 +4266,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4787,6 +4845,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4795,6 +4860,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5001,6 +5073,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5648,6 +5726,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6310,9 +6394,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7405,6 +7502,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7489,6 +7593,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9075,6 +9184,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Aprenda Más %s %s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9592,6 +9706,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9797,6 +9917,11 @@ msgstr "Menú"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10099,6 +10224,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Más en"
@@ -10256,6 +10386,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rojo tenue"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11133,6 +11268,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11737,6 +11893,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11745,6 +11906,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11789,6 +11955,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12803,6 +12981,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12952,6 +13135,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13159,6 +13347,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13192,6 +13385,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13740,6 +13943,11 @@ msgstr "Guarda tus configuraciones anonimamente en la nube."
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14504,6 +14712,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14630,6 +14844,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14749,6 +14970,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15296,6 +15527,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15985,6 +16221,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16182,6 +16423,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16207,6 +16454,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Tv"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16659,6 +16911,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16727,6 +16993,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16810,6 +17081,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17324,6 +17605,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17417,6 +17703,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17616,6 +17907,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17624,6 +17920,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18001,6 +18302,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18028,6 +18334,11 @@ msgstr "Actualizar"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18794,6 +19105,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18828,6 +19146,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18852,6 +19177,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19096,6 +19428,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19558,6 +19895,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19960,6 +20304,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20127,6 +20477,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20144,6 +20509,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/es_VE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_VE/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Añadir a %s"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Complementos"
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4202,6 +4236,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4234,6 +4273,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4794,6 +4852,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4802,6 +4867,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5008,6 +5080,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5655,6 +5733,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6317,9 +6401,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7414,6 +7511,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7498,6 +7602,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9086,6 +9195,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr " Aprenda %sMás %s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9603,6 +9717,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9808,6 +9928,11 @@ msgstr "Menú"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10110,6 +10235,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Más en"
@@ -10267,6 +10397,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rojo opaco"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11144,6 +11279,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11750,6 +11906,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11758,6 +11919,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11802,6 +11968,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12816,6 +12994,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12965,6 +13148,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13172,6 +13360,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13205,6 +13398,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13753,6 +13956,11 @@ msgstr "Guarde sus ajustes de forma anónima en la nube"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14521,6 +14729,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14647,6 +14861,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14766,6 +14987,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15313,6 +15544,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16004,6 +16240,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16201,6 +16442,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16225,6 +16472,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16678,6 +16930,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16746,6 +17012,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16829,6 +17100,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17343,6 +17624,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17436,6 +17722,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17635,6 +17926,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17643,6 +17939,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18022,6 +18323,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18049,6 +18355,11 @@ msgstr "Actualizar"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18815,6 +19126,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18849,6 +19167,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18873,6 +19198,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19117,6 +19449,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19579,6 +19916,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19982,6 +20326,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20149,6 +20499,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20166,6 +20531,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: et_EE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% täielikult vaktsineeritud"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% vaktsineeritud"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -434,7 +442,8 @@ msgstr "%1$s sõna"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
+msgstr ""
+"%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -483,6 +492,13 @@ msgstr "%1$sLoe lähemalt%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sLoe, kuidas me hoiame sinu asukohta privaatsena%2$s."
+
+# smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -775,6 +791,12 @@ msgstr "Teise servi punkte võidetud"
 msgctxt "Sports module"
 msgid "2nd in Group %s"
 msgstr "2. koht %1$s-alagrupis"
+
+# smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1460,6 +1482,12 @@ msgid "Add to Home Screen"
 msgstr "Lisa avakuvale"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Lisandid"
@@ -1822,6 +1850,13 @@ msgstr "Kõik suurused"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Kõik liigid"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2348,6 +2383,12 @@ msgid "Ask anything privately"
 msgstr "Küsi ükskõik mida privaatselt"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2407,8 +2448,8 @@ msgstr ""
 "mõnedele otsingutele, tuginedes asjakohase veebisisu kokkuvõttele. Saate "
 "valida, kui tihti soovite Assisti kuvada: mitte kunagi (eemaldab "
 "otsingutulemustest täielikult Assisti kasutajaliidese), nõudmisel (AI-toega "
-"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord "
-"(AI-toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
+"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord (AI-"
+"toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
 "sageli (kuvatakse sagedamini laiema otsingute valiku puhul). Praegu on AI "
 "abil genereeritud vastused saadaval ainult USA (ingliskeelses) piirkonnas."
 
@@ -2529,7 +2570,8 @@ msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse lõppu."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
+msgstr ""
+"Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -4438,9 +4480,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi "
-"%1$sDuck.ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab "
-"vestlusmudeleid OpenAI, Anthropic ja teised."
+"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi %1$sDuck."
+"ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab vestlusmudeleid "
+"OpenAI, Anthropic ja teised."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4499,7 +4541,8 @@ msgstr "Klõpsa %1$sSiia%2$s, et laadida alla DuckDuckGo laiend"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
+msgstr ""
+"Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -5279,6 +5322,12 @@ msgid "Copy"
 msgstr "Kopeeri"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5318,6 +5367,28 @@ msgstr "Kopeeri või salvesta see kood"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Kopeeri taastamiskood"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5703,7 +5774,8 @@ msgstr "Päevane piirang on saavutatud"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr ""
+"Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5999,6 +6071,14 @@ msgid "Delete recent chats?"
 msgstr "Kas kustutada hiljutised vestlused?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6009,6 +6089,14 @@ msgstr "Kustutada see vestlus?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Kustutatud vestlused"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6105,8 +6193,8 @@ msgstr "Dikteerimine Duck.ai-s"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi "
-"AI-mudelite koolitamiseks."
+"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi AI-"
+"mudelite koolitamiseks."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6264,6 +6352,13 @@ msgstr "Tühista"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Tühista"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6965,9 +7060,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
-"AI-põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab "
-"vestlusmudeleid OpenAI, Anthropic ja teisi."
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
+"põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab vestlusmudeleid "
+"OpenAI, Anthropic ja teisi."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6976,8 +7071,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
-"AI-põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
+"põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
 "Anthropicu vestlusmudeleid."
 
 # smartling.placeholder_format=C
@@ -7083,7 +7178,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
+msgstr ""
+"DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7116,6 +7212,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo brauser %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7937,13 +8040,29 @@ msgstr "Laienda kaarti"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
+msgstr ""
+"Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
+
+# smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Aegunud"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8579,7 +8698,8 @@ msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
+msgstr ""
+"Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8609,7 +8729,8 @@ msgstr "Tasuta jagatavad ja kaubanduslikult kasutatavad"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
+msgstr ""
+"Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9158,8 +9279,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Hangi meie turvaline, kasutajate andmeid salvestamatu VPN, täiustatud "
-"Duck.ai, Personal Information Removal ja Identity Theft Restoration teenus."
+"Hangi meie turvaline, kasutajate andmeid salvestamatu VPN, täiustatud Duck."
+"ai, Personal Information Removal ja Identity Theft Restoration teenus."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9211,7 +9332,8 @@ msgstr "Hangi rakendus"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "Hangi tasuta DuckDuckGo brauser %1$sreklaamide blokeerimiseks YouTube'is.%2$s"
+msgstr ""
+"Hangi tasuta DuckDuckGo brauser %1$sreklaamide blokeerimiseks YouTube'is.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9307,6 +9429,14 @@ msgstr ""
 "Ava teises brauseris %1$sDuck.ai Seaded%2$s või mine DuckDuckGo rakenduses "
 "menüüsse %3$sVestlused › Sync & Backup › Sünkrooni teise seadmega%4$s. Või "
 "skanni oma Recovery PDF-i QR-koodi."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9417,6 +9547,12 @@ msgstr "Sain aru"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Sain aru"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10225,7 +10361,8 @@ msgstr "Kui tihti soovid, et ilmuksid AI-toega vastused?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
+msgstr ""
+"Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -11045,7 +11182,8 @@ msgstr "See on kiire, tasuta ja pakub sulle veelgi suuremat võrgukaitset."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
+msgstr ""
+"Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11385,6 +11523,12 @@ msgid "Learn %sMore%s"
 msgstr "Loe %1$slisaks%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11557,7 +11701,8 @@ msgstr "Võimaldab sul DuckDuckGo abil anonüümselt otsida"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Võimaldab vahetada Duck.ai-le otsingupäringute ja käskluste saatmise vahel"
+msgstr ""
+"Võimaldab vahetada Duck.ai-le otsingupäringute ja käskluste saatmise vahel"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11649,7 +11794,8 @@ msgstr "Lingid:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
+msgstr ""
+"Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11946,7 +12092,8 @@ msgstr "Veendu, et kõik sõnad on korrektselt kirjutatud."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
+msgstr ""
+"Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12012,6 +12159,13 @@ msgstr "Pahavara"
 #. Text for generic link to send the user to a page to manage their settings.
 msgid "Manage"
 msgstr "Halda"
+
+# smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12263,6 +12417,12 @@ msgstr "Menüü"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menüü"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12635,6 +12795,12 @@ msgid "More about Duck.ai"
 msgstr "Rohkem Duck.ai kohta"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Rohkem siin"
@@ -12827,6 +12993,12 @@ msgstr "Vaigistatud"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Tumendatud punane"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13897,6 +14069,30 @@ msgstr ""
 "ikoonil > Seaded%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -13965,7 +14161,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
+msgstr ""
+"Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14304,8 +14501,8 @@ msgid ""
 "more premium protections. All in one subscription."
 msgstr ""
 "Meie kiire ja kasutajate andmeid salvestamatu VPN sisaldab nutikamaid "
-"tehisintellekti vestlusi kõrgemate piirangutega ning lisaks muid "
-"premium-kaitseid. Kõik ühes tellimuses."
+"tehisintellekti vestlusi kõrgemate piirangutega ning lisaks muid premium-"
+"kaitseid. Kõik ühes tellimuses."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14645,6 +14842,12 @@ msgid "Past year"
 msgstr "Viimane aasta"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14655,6 +14858,12 @@ msgstr "Kleebi"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Kleebi sünkroonimiskood"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14708,6 +14917,20 @@ msgstr "Püsivalt suletud"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "pärsia keel"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14871,7 +15094,8 @@ msgstr "Vali konkreetne probleem"
 #. Header instructing the user to follow the instructions for their ad blocker
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
-msgstr "Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
+msgstr ""
+"Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14967,19 +15191,22 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
+msgstr ""
+"Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
+msgstr ""
+"Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
+msgstr ""
+"Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15966,6 +16193,12 @@ msgid "Reading website…"
 msgstr "Veebilehe lugemine..."
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16005,13 +16238,15 @@ msgstr "Arutlus võib anda paremaid vastuseid keerulistele küsimustele."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Arutlus on põhjalikum, kuid jõuab kasutuspiiranguteni 2–5 korda varem. %1$s"
+msgstr ""
+"Arutlus on põhjalikum, kuid jõuab kasutuspiiranguteni 2–5 korda varem. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Arutlus on põhjalikum, kuid ammendab piiranguid 2–5 korda kiiremini. %1$s"
+msgstr ""
+"Arutlus on põhjalikum, kuid ammendab piiranguid 2–5 korda kiiremini. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16154,6 +16389,12 @@ msgstr "Taastamine"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Taastamiskood"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16407,6 +16648,12 @@ msgid "Remove %s"
 msgstr "Eemalda %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16447,6 +16694,18 @@ msgstr "Tühista teksti valik"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Eemaldage mittevajalikud kirjavahemärgid"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16743,7 +17002,8 @@ msgstr "Tulemused ei sisalda blokeeritud saitide teavet."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
+msgstr ""
+"Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16814,7 +17074,8 @@ msgstr "Arvustused"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr "Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
+msgstr ""
+"Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17106,7 +17367,8 @@ msgstr "Salvesta oma seadmesse kuni 30 viimast vestlust."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
+msgstr ""
+"Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17137,6 +17399,12 @@ msgstr "Salvesta seaded anonüümselt pilve"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Öelge tere Duck.ai'le"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17283,7 +17551,8 @@ msgstr "Keri alla ja leia loendist %1$soma brauser%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
+msgstr ""
+"Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17677,7 +17946,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
+msgstr ""
+"Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17837,7 +18107,8 @@ msgstr "Vali Safari menüüst %1$sSelle veebisaidi seadistamine...%2$s."
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
+msgstr ""
+"Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18124,6 +18395,13 @@ msgid "Serbian (Latin)"
 msgstr "serbia keel (ladina tähestik)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18224,7 +18502,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
+msgstr ""
+"Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18276,6 +18555,14 @@ msgid "Share"
 msgstr "Jaga"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18290,7 +18577,8 @@ msgstr "Jaga"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
+msgstr ""
+"Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18317,8 +18605,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. "
-"Duck.ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
+"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. Duck."
+"ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18424,14 +18712,26 @@ msgid "Share your thoughts on the search box."
 msgstr "Jaga oma mõtteid otsingukasti kohta."
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"Kaitse oma veebitegevust meie kasutajate andmeid salvestamatu ja kiire "
-"VPN-iga. Lihtne seadistada ning igal ajal hõlpsasti sisse ja välja lülitada."
+"Kaitse oma veebitegevust meie kasutajate andmeid salvestamatu ja kiire VPN-"
+"iga. Lihtne seadistada ning igal ajal hõlpsasti sisse ja välja lülitada."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19098,6 +19398,12 @@ msgid "Something went wrong"
 msgstr "Midagi läks valesti"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19265,7 +19571,8 @@ msgstr "Algtekst kustutatud"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
+msgstr ""
+"Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19940,6 +20247,12 @@ msgid "Switch model"
 msgstr "Vaheta mudelit"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20199,6 +20512,13 @@ msgid "Synced Devices"
 msgstr "Sünkroonitud seadmed"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Süüria"
 
@@ -20229,6 +20549,12 @@ msgstr "Hetkel määramata"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20569,7 +20895,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
+msgstr ""
+"Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20719,7 +21046,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
+msgstr ""
+"See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20807,6 +21135,22 @@ msgstr ""
 "saamiseks vt %4$s)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20888,6 +21232,12 @@ msgstr "Seda pilditüüpi ei toetata, palun lisa JPG, PNG, WebP või GIF."
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "See teave pole kasulik"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21003,6 +21353,18 @@ msgstr ""
 "%1$s."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21023,7 +21385,8 @@ msgstr "See tõlge on vale"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
+msgstr ""
+"Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21143,7 +21506,8 @@ msgstr "Soovitused"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
+msgstr ""
+"Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21201,8 +21565,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "Sünkroonitud andmete taastamiseks vajad taastamiskoodi, mille salvestasid "
-"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud "
-"PDF-vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
+"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud PDF-"
+"vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21593,7 +21957,8 @@ msgstr "Proovi %1$s, et selliseid sõnumeid enam ei näeks."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
+msgstr ""
+"Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21639,6 +22004,12 @@ msgstr "Proovi tasuta"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Proovi tasuta"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21720,7 +22091,8 @@ msgstr "Proovi teisi märksõnu."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
+msgstr ""
+"Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21752,6 +22124,12 @@ msgstr "Proovi tasuta"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Proovi tasuta"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21997,6 +22375,12 @@ msgid "Turkmenistan"
 msgstr "Türkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22007,6 +22391,12 @@ msgstr "Lülita Sync & Backup välja"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Lülita Sync & Backup välja"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22095,7 +22485,8 @@ msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Täpne asukoht“
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
+msgstr ""
+"Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22287,8 +22678,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: "
-"https://duckduckgo.com"
+"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22482,6 +22873,12 @@ msgid "Unmute"
 msgstr "Tühista vaigistamine"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22515,6 +22912,12 @@ msgstr "Uuenda"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Brauseri värskendamine"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22798,7 +23201,8 @@ msgstr "Kasuta DuckDuckGo privaatset otsingut"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
+msgstr ""
+"Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23387,7 +23791,8 @@ msgstr "Me ei jälita sind reklaamidega."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
+msgstr ""
+"Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23491,6 +23896,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Lõpetasime vestluse tegevusetuse tõttu. Soovid uuesti proovida?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23537,6 +23950,14 @@ msgstr ""
 "hiljem alati meelt muuta."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23547,7 +23968,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
+msgstr ""
+"Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23570,6 +23992,14 @@ msgstr ""
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr "Blokeerime jälgijad, mis üritavad sirvimise ajal sinu andmeid koguda."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23715,7 +24145,8 @@ msgstr "Nädala kasutuspiirang on saavutatud"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr ""
+"Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23886,6 +24317,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Millised on mõned annuiteedi plussid ja miinused?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24456,6 +24893,14 @@ msgid "Without zero provider visibility"
 msgstr "Ilma null teenusepakkuja nähtavuseta"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -24722,7 +25167,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
+msgstr ""
+"Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24762,8 +25208,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka "
-"%1$sDuck.ai%2$s."
+"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka %1$sDuck."
+"ai%2$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -24837,7 +25283,8 @@ msgstr "Saad vestlust jätkata, kasutades oma igakuist piirangut."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
+msgstr ""
+"Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24953,6 +25400,13 @@ msgid "You have 1 attempt left."
 msgstr "Sul on jäänud üks katse."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25011,7 +25465,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
+msgstr ""
+"Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25101,7 +25556,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
+msgstr ""
+"Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25114,7 +25570,8 @@ msgstr "Oled saavutanud ühe seansi maksimaalse häälvestluse kestuse."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
+msgstr ""
+"Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25172,6 +25629,23 @@ msgid "YouTube Standard"
 msgstr "YouTube - standardne"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Sinu DuckDuckGo otsinguajalugu on privaatne"
@@ -25193,6 +25667,14 @@ msgstr "Sinu tegelik asukoht jääb privaatseks"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Sinu tegelik asukoht jääb privaatseks."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25232,7 +25714,8 @@ msgstr "Sinu brauser näitab, kui oled seda linki külastanud"
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr "Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
+msgstr ""
+"Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -25274,8 +25757,8 @@ msgstr "Sinu vestlused salvestatakse nüüd."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi "
-"AI-mudelite treenimiseks"
+"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi AI-"
+"mudelite treenimiseks"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: et_EE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (See seade)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -442,8 +442,7 @@ msgstr "%1$s sõna"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
+msgstr "%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -498,7 +497,7 @@ msgstr "%1$sLoe, kuidas me hoiame sinu asukohta privaatsena%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sLisateave%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -796,7 +795,7 @@ msgstr "2. koht %1$s-alagrupis"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2. arvamus"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1485,7 +1484,7 @@ msgstr "Lisa avakuvale"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Lisa minu vestlustesse"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1856,7 +1855,7 @@ msgstr "Kõik liigid"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Kõik teie seadmed on sünkroonimisest lahti ühendatud."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2386,7 +2385,7 @@ msgstr "Küsi ükskõik mida privaatselt"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Küsi ükskõik mida privaatselt"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2448,8 +2447,8 @@ msgstr ""
 "mõnedele otsingutele, tuginedes asjakohase veebisisu kokkuvõttele. Saate "
 "valida, kui tihti soovite Assisti kuvada: mitte kunagi (eemaldab "
 "otsingutulemustest täielikult Assisti kasutajaliidese), nõudmisel (AI-toega "
-"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord (AI-"
-"toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
+"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord "
+"(AI-toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
 "sageli (kuvatakse sagedamini laiema otsingute valiku puhul). Praegu on AI "
 "abil genereeritud vastused saadaval ainult USA (ingliskeelses) piirkonnas."
 
@@ -2570,8 +2569,7 @@ msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse lõppu."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
+msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -4480,9 +4478,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi %1$sDuck."
-"ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab vestlusmudeleid "
-"OpenAI, Anthropic ja teised."
+"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi "
+"%1$sDuck.ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab "
+"vestlusmudeleid OpenAI, Anthropic ja teised."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4541,8 +4539,7 @@ msgstr "Klõpsa %1$sSiia%2$s, et laadida alla DuckDuckGo laiend"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
+msgstr "Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -5325,7 +5322,7 @@ msgstr "Kopeeri"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopeeri"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5374,13 +5371,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Kopeeri jagatud link"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Kopeeri kood teisest seadmest"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5389,6 +5386,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Kopeeri kood teisest seadmest. Avage %1$sDuck.ai Seaded › Vestlused › Sync & "
+"Backup › Sünkrooni teise seadmega%2$s ja proovige uuesti."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5774,8 +5773,7 @@ msgstr "Päevane piirang on saavutatud"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr "Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6076,7 +6074,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Kustuta jagatud link"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6097,6 +6095,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Lingi kustutamisel lakkab see töötamast. Inimesed, kes on selle avanud ja "
+"vestluse oma vestlustesse lisanud, säilitavad oma koopia."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6193,8 +6193,8 @@ msgstr "Dikteerimine Duck.ai-s"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi AI-"
-"mudelite koolitamiseks."
+"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi "
+"AI-mudelite koolitamiseks."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6358,7 +6358,7 @@ msgstr "Tühista"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Tühista"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -7060,9 +7060,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
-"põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab vestlusmudeleid "
-"OpenAI, Anthropic ja teisi."
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
+"AI-põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab "
+"vestlusmudeleid OpenAI, Anthropic ja teisi."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7071,8 +7071,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
-"põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
+"AI-põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
 "Anthropicu vestlusmudeleid."
 
 # smartling.placeholder_format=C
@@ -7178,8 +7178,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
+msgstr "DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7218,7 +7217,7 @@ msgstr "DuckDuckGo brauser %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo abilehed"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -8040,15 +8039,14 @@ msgstr "Laienda kaarti"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
+msgstr "Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Aegunud"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8062,7 +8060,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Aegub %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8698,8 +8696,7 @@ msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
+msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8729,8 +8726,7 @@ msgstr "Tasuta jagatavad ja kaubanduslikult kasutatavad"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
+msgstr "Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9279,8 +9275,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Hangi meie turvaline, kasutajate andmeid salvestamatu VPN, täiustatud Duck."
-"ai, Personal Information Removal ja Identity Theft Restoration teenus."
+"Hangi meie turvaline, kasutajate andmeid salvestamatu VPN, täiustatud "
+"Duck.ai, Personal Information Removal ja Identity Theft Restoration teenus."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9332,8 +9328,7 @@ msgstr "Hangi rakendus"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"Hangi tasuta DuckDuckGo brauser %1$sreklaamide blokeerimiseks YouTube'is.%2$s"
+msgstr "Hangi tasuta DuckDuckGo brauser %1$sreklaamide blokeerimiseks YouTube'is.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9437,6 +9432,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Avage %1$sDuck.ai seaded%2$s › %3$sVestlused › Sync & Backup › Sünkrooni "
+"teise seadmega%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9552,7 +9549,7 @@ msgstr "Sain aru"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Sain aru"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10361,8 +10358,7 @@ msgstr "Kui tihti soovid, et ilmuksid AI-toega vastused?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
+msgstr "Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -11182,8 +11178,7 @@ msgstr "See on kiire, tasuta ja pakub sulle veelgi suuremat võrgukaitset."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
+msgstr "Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11526,7 +11521,7 @@ msgstr "Loe %1$slisaks%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Loe edasi"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11701,8 +11696,7 @@ msgstr "Võimaldab sul DuckDuckGo abil anonüümselt otsida"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Võimaldab vahetada Duck.ai-le otsingupäringute ja käskluste saatmise vahel"
+msgstr "Võimaldab vahetada Duck.ai-le otsingupäringute ja käskluste saatmise vahel"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11794,8 +11788,7 @@ msgstr "Lingid:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
+msgstr "Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12092,8 +12085,7 @@ msgstr "Veendu, et kõik sõnad on korrektselt kirjutatud."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
+msgstr "Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12165,7 +12157,7 @@ msgstr "Halda"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Halda"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12422,7 +12414,7 @@ msgstr "Menüü"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Sellest punktist edasi olevad sõnumid on nähtavad ainult teile."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12798,7 +12790,7 @@ msgstr "Rohkem Duck.ai kohta"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Veel tegevusi"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12998,7 +12990,7 @@ msgstr "Tumendatud punane"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Minu seadmed"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14075,6 +14067,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Avage teises seadmes %1$sDuck.ai seaded%2$s › %3$sVestlused › Sync & Backup "
+"› Sünkrooni teise seadmega%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14083,6 +14077,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Avage teises seadmes %1$sDuck.ai seaded%2$s › %3$sVestlused › Sync & Backup "
+"› Sünkrooni teise seadmega%4$s ja skanni see kood:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14091,6 +14087,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Avage teises seadmes %1$sDuck.ai seaded%2$s › %3$sVestlused › Sync & Backup "
+"› Sünkrooni teise seadmega%4$s. Või skannige oma Recovery PDF-i QR-kood."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14161,8 +14159,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
+msgstr "Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14501,8 +14498,8 @@ msgid ""
 "more premium protections. All in one subscription."
 msgstr ""
 "Meie kiire ja kasutajate andmeid salvestamatu VPN sisaldab nutikamaid "
-"tehisintellekti vestlusi kõrgemate piirangutega ning lisaks muid premium-"
-"kaitseid. Kõik ühes tellimuses."
+"tehisintellekti vestlusi kõrgemate piirangutega ning lisaks muid "
+"premium-kaitseid. Kõik ühes tellimuses."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14845,7 +14842,7 @@ msgstr "Viimane aasta"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Kleebi"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14863,7 +14860,7 @@ msgstr "Kleebi sünkroonimiskood"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Kleebi see allapoole"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14922,7 +14919,7 @@ msgstr "pärsia keel"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14931,6 +14928,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal leiab teie andmed andmevahendajate saitidelt, "
+"mis neid müüvad. Seejärel töötame selle nimel, et need teie eest eemaldada."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15094,8 +15093,7 @@ msgstr "Vali konkreetne probleem"
 #. Header instructing the user to follow the instructions for their ad blocker
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
-msgstr ""
-"Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
+msgstr "Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15191,22 +15189,19 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
+msgstr "Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
+msgstr "Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
+msgstr "Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -16196,7 +16191,7 @@ msgstr "Veebilehe lugemine..."
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Kas olete päikesevarjutuseks valmis?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16238,15 +16233,13 @@ msgstr "Arutlus võib anda paremaid vastuseid keerulistele küsimustele."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Arutlus on põhjalikum, kuid jõuab kasutuspiiranguteni 2–5 korda varem. %1$s"
+msgstr "Arutlus on põhjalikum, kuid jõuab kasutuspiiranguteni 2–5 korda varem. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Arutlus on põhjalikum, kuid ammendab piiranguid 2–5 korda kiiremini. %1$s"
+msgstr "Arutlus on põhjalikum, kuid ammendab piiranguid 2–5 korda kiiremini. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16394,7 +16387,7 @@ msgstr "Taastamiskood"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Taastamiskood"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16651,7 +16644,7 @@ msgstr "Eemalda %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Eemalda seade"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16699,13 +16692,13 @@ msgstr "Eemaldage mittevajalikud kirjavahemärgid"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Eemalda oma andmed internetist"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Eemalda oma andmed veebist"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17002,8 +16995,7 @@ msgstr "Tulemused ei sisalda blokeeritud saitide teavet."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
+msgstr "Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17074,8 +17066,7 @@ msgstr "Arvustused"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
+msgstr "Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17367,8 +17358,7 @@ msgstr "Salvesta oma seadmesse kuni 30 viimast vestlust."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
+msgstr "Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17404,7 +17394,7 @@ msgstr "Öelge tere Duck.ai'le"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Tervita Duck.ai'd – tasuta ja privaatne AI-vestlus DuckDuckGo-lt."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17551,8 +17541,7 @@ msgstr "Keri alla ja leia loendist %1$soma brauser%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
+msgstr "Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17946,8 +17935,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
+msgstr "Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18107,8 +18095,7 @@ msgstr "Vali Safari menüüst %1$sSelle veebisaidi seadistamine...%2$s."
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
+msgstr "Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18399,7 +18386,7 @@ msgstr "serbia keel (ladina tähestik)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Serveri andmed kustutatud"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18502,8 +18489,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
+msgstr "Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18560,7 +18546,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Jaga"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18577,8 +18563,7 @@ msgstr "Jaga"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
+msgstr "Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18605,8 +18590,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. Duck."
-"ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
+"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. "
+"Duck.ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18715,13 +18700,13 @@ msgstr "Jaga oma mõtteid otsingukasti kohta."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Jagatud vestluse lingid"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Jagatud vestluse lingid"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18730,8 +18715,8 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"Kaitse oma veebitegevust meie kasutajate andmeid salvestamatu ja kiire VPN-"
-"iga. Lihtne seadistada ning igal ajal hõlpsasti sisse ja välja lülitada."
+"Kaitse oma veebitegevust meie kasutajate andmeid salvestamatu ja kiire "
+"VPN-iga. Lihtne seadistada ning igal ajal hõlpsasti sisse ja välja lülitada."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19401,7 +19386,7 @@ msgstr "Midagi läks valesti"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Selle jagatud vestluse laadimisel läks midagi valesti."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19571,8 +19556,7 @@ msgstr "Algtekst kustutatud"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
+msgstr "Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20250,7 +20234,7 @@ msgstr "Vaheta mudelit"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Vaheta mudelit"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20516,7 +20500,7 @@ msgstr "Sünkroonitud seadmed"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Sünkroonitud %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20554,7 +20538,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabel"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20895,8 +20879,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
+msgstr "Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21046,8 +21029,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
+msgstr "See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21138,7 +21120,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "See seade"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21149,6 +21131,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"See seade ei pääse enam ligi teie sünkroonitud andmetele teistes seadmetes. "
+"Viimased %1$s vestlust jäävad endiselt kohalikku salvestusruumi "
+"kättesaadavaks."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21237,7 +21222,7 @@ msgstr "See teave pole kasulik"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "See on jagatud vestluse koopia."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21356,13 +21341,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Seda jagatud vestlust ei saanud avada. Link võib olla ebatäielik."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "See jagatud vestluse link pole enam saadaval."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21385,8 +21370,7 @@ msgstr "See tõlge on vale"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
+msgstr "Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21506,8 +21490,7 @@ msgstr "Soovitused"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
+msgstr "Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21565,8 +21548,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "Sünkroonitud andmete taastamiseks vajad taastamiskoodi, mille salvestasid "
-"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud PDF-"
-"vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
+"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud "
+"PDF-vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21957,8 +21940,7 @@ msgstr "Proovi %1$s, et selliseid sõnumeid enam ei näeks."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
+msgstr "Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22009,7 +21991,7 @@ msgstr "Proovi tasuta"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Proovi tasuta!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22091,8 +22073,7 @@ msgstr "Proovi teisi märksõnu."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
+msgstr "Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22129,7 +22110,7 @@ msgstr "Proovi tasuta"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Proovi tasuta!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22378,7 +22359,7 @@ msgstr "Türkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Lülita välja"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22396,7 +22377,7 @@ msgstr "Lülita Sync & Backup välja"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Kas lülitada Sync & Backup välja ja kustutada serveri andmed?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22485,8 +22466,7 @@ msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Täpne asukoht“
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
+msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22678,8 +22658,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: https://"
-"duckduckgo.com"
+"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22876,7 +22856,7 @@ msgstr "Tühista vaigistamine"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Pealkirjata vestlus"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22917,7 +22897,7 @@ msgstr "Brauseri värskendamine"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Uuendage Duck.ai-d, et vaadata seda jagatud vestlust."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23201,8 +23181,7 @@ msgstr "Kasuta DuckDuckGo privaatset otsingut"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
+msgstr "Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23791,8 +23770,7 @@ msgstr "Me ei jälita sind reklaamidega."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
+msgstr "Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23902,6 +23880,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Leiame ja eemaldame teie isikuandmed andmevahendajate saitidelt. Lisaks "
+"saate VPN-i ja palju muud."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23956,6 +23936,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Skannime regulaarselt andmevahendajate saite teie isikuandmete leidmiseks ja "
+"jagame oma edusamme teiega hõlpsalt kasutataval juhtpaneelil."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23968,8 +23950,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
+msgstr "Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24000,6 +23981,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Skannime andmevahendajate saite, et leida teie e-posti aadress, nimi, "
+"aadress ja muu, ning töötame selle nimel, et kõik teie kohta leitu "
+"eemaldataks."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24145,8 +24129,7 @@ msgstr "Nädala kasutuspiirang on saavutatud"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr "Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24322,7 +24305,7 @@ msgstr "Millised on mõned annuiteedi plussid ja miinused?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Millised on Duck.ai eelised?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24899,6 +24882,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Töötab otse teie seadmest, et eemaldada andmevahendajate saitidelt teie "
+"e-posti aadress, nimi, aadress ja muu."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25167,8 +25152,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
+msgstr "Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25208,8 +25192,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka %1$sDuck."
-"ai%2$s."
+"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka "
+"%1$sDuck.ai%2$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -25283,8 +25267,7 @@ msgstr "Saad vestlust jätkata, kasutades oma igakuist piirangut."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
+msgstr "Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25404,7 +25387,7 @@ msgstr "Sul on jäänud üks katse."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Teil pole jagatud vestluslinke."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25465,8 +25448,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
+msgstr "Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25556,8 +25538,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
+msgstr "Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25570,8 +25551,7 @@ msgstr "Oled saavutanud ühe seansi maksimaalse häälvestluse kestuse."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
+msgstr "Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25637,13 +25617,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Teie %1$s viimast vestlust on saadaval kohalikus salvestusruumis nendes "
+"brauserites:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Teie Duck.ai vestlused sünkroonitakse otspunktkrüpteerimisega."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25675,6 +25657,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Teie varukoopia kustutatakse DuckDuckGo serverist. Kõik seadmed lülitatakse "
+"sünkroonimisest välja."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25714,8 +25698,7 @@ msgstr "Sinu brauser näitab, kui oled seda linki külastanud"
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
+msgstr "Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -25757,8 +25740,8 @@ msgstr "Sinu vestlused salvestatakse nüüd."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi AI-"
-"mudelite treenimiseks"
+"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi "
+"AI-mudelite treenimiseks"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.

--- a/locales/eu_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/eu_ES/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "%s(e)ra gehitu"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Gehigarriak"
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4195,6 +4229,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4227,6 +4266,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4787,6 +4845,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4795,6 +4860,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5001,6 +5073,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5648,6 +5726,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6310,9 +6394,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7405,6 +7502,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7489,6 +7593,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9075,6 +9184,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Ikasi %sgehiago%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9592,6 +9706,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9797,6 +9917,11 @@ msgstr "Menua"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10099,6 +10224,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Gehiago hemen "
@@ -10256,6 +10386,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Mututako gorria"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11133,6 +11268,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11737,6 +11893,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11745,6 +11906,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11789,6 +11955,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12803,6 +12981,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12952,6 +13135,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13159,6 +13347,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13192,6 +13385,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13740,6 +13943,11 @@ msgstr "Gorde zure ezarpenak odeian ezezagun bezela"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14506,6 +14714,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14630,6 +14844,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14749,6 +14970,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15296,6 +15527,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15985,6 +16221,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16182,6 +16423,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16207,6 +16454,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Telebista"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16659,6 +16911,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16727,6 +16993,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16810,6 +17081,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17324,6 +17605,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17416,6 +17702,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17615,6 +17906,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17623,6 +17919,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18000,6 +18301,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18027,6 +18333,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18793,6 +19104,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18827,6 +19145,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18851,6 +19176,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19095,6 +19427,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19557,6 +19894,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19960,6 +20304,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20127,6 +20477,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20144,6 +20509,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/fa_IR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fa_IR/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -395,6 +402,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -629,6 +642,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1188,6 +1206,11 @@ msgstr "افزودن به %s"
 msgid "Add to Home Screen"
 msgstr "به صفحه خانگی اضافه کن"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "افزونه ها"
@@ -1479,6 +1502,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1894,6 +1923,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4223,6 +4257,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4255,6 +4294,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4815,6 +4873,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4823,6 +4888,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5029,6 +5101,12 @@ msgstr "لغو"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5678,6 +5756,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6356,9 +6440,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7455,6 +7552,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7539,6 +7643,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9150,6 +9259,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "%sMore%s بیاموزید"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9669,6 +9783,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9875,6 +9995,11 @@ msgstr "فهرست انتخاب"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "منو"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10176,6 +10301,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "اطلاعات بیشتر در"
@@ -10333,6 +10463,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "سرخ مات"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11214,6 +11349,27 @@ msgstr ""
 "‫در مک روی %sMaxthon > Preferences%s کلیک کنید٬ در ویندوز روی %s%s icon > "
 "Settings%s‬"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11824,6 +11980,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11832,6 +11993,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11876,6 +12042,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12890,6 +13068,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13039,6 +13222,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13247,6 +13435,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13280,6 +13473,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13828,6 +14031,11 @@ msgstr "تنظیمات خود را به صورت ناشناس در سرور اب
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14611,6 +14819,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14737,6 +14951,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14860,6 +15081,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15407,6 +15638,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16098,6 +16334,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16297,6 +16538,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16322,6 +16569,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "تلویزیون"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16780,6 +17032,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16848,6 +17114,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16931,6 +17202,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17445,6 +17726,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17537,6 +17823,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17738,6 +18029,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17746,6 +18042,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18130,6 +18431,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18157,6 +18463,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18937,6 +19248,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18971,6 +19289,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18995,6 +19320,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19239,6 +19571,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19703,6 +20040,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20106,6 +20450,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20275,6 +20625,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "استاندارد یوتیوب"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20292,6 +20657,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/fi_FI/LC_MESSAGES/duckduckgo.po
+++ b/locales/fi_FI/LC_MESSAGES/duckduckgo.po
@@ -43,6 +43,14 @@ msgid "% Vaccinated"
 msgstr "% rokotettu"
 
 # smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -485,6 +493,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sLue lisää sijainnin pitämisestä yksityisenä%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -774,6 +789,12 @@ msgstr "Kakkossyötön voitetut pisteet"
 msgctxt "Sports module"
 msgid "2nd in Group %s"
 msgstr "2. lohkossa %1$s"
+
+# smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1459,6 +1480,12 @@ msgid "Add to Home Screen"
 msgstr "Lisää kotinäytölle"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Laajennukset"
@@ -1815,6 +1842,13 @@ msgstr "Kaikki koot"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Kaikki tyypit"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2333,6 +2367,12 @@ msgstr "Kysy tästä sivusta"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask anything privately"
 msgstr "Kysy mitä tahansa yksityisesti"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -5261,6 +5301,12 @@ msgid "Copy"
 msgstr "Kopioi"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5300,6 +5346,28 @@ msgstr "Kopioi tai tallenna tämä koodi"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Kopioi palautuskoodi"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5981,6 +6049,14 @@ msgid "Delete recent chats?"
 msgstr "Poistetaanko viimeaikaiset keskustelut?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -5991,6 +6067,14 @@ msgstr "Poistetaanko tämä keskustelu?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Poistetut keskustelut"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6246,6 +6330,13 @@ msgstr "Ohita"
 # smartling.placeholder_format=C
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -7096,6 +7187,13 @@ msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo-selain %1$s"
 
 # smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
 msgid "DuckDuckGo Instant Answer API"
 msgstr "DuckDuckGo Instant Answer API"
@@ -7922,10 +8020,25 @@ msgstr ""
 "yksityisyydestä."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Vanhentunut"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -9265,6 +9378,14 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -9373,6 +9494,12 @@ msgstr "Selvä"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Selvä"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -11344,6 +11471,12 @@ msgid "Learn %sMore%s"
 msgstr "Lue %1$slisää%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11975,6 +12108,13 @@ msgid "Manage"
 msgstr "Hallitse"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12224,6 +12364,12 @@ msgstr "Valikko"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Valikko"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12595,6 +12741,12 @@ msgid "More about Duck.ai"
 msgstr "Lisätietoja Duck.ai:sta"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Lisätietoja:"
@@ -12787,6 +12939,12 @@ msgstr "Mykistetty"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Himmeän punainen"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13858,6 +14016,30 @@ msgstr ""
 "kuvaketta > Asetukset%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14602,6 +14784,12 @@ msgid "Past year"
 msgstr "Viime vuosi"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14611,6 +14799,12 @@ msgstr "Liitä"
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -14665,6 +14859,20 @@ msgstr "Suljettu pysyvästi"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persia"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15924,6 +16132,12 @@ msgid "Reading website…"
 msgstr "Luetaan verkkosivustoa..."
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16110,6 +16324,12 @@ msgstr "Palautus"
 # smartling.placeholder_format=C
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -16365,6 +16585,12 @@ msgid "Remove %s"
 msgstr "Poista %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16405,6 +16631,18 @@ msgstr ""
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Poista tarpeettomat välimerkit"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17099,6 +17337,12 @@ msgstr "Tallenna asetuksesi pilveen anonyymisti"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Esittelyssä Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -18095,6 +18339,13 @@ msgid "Serbian (Latin)"
 msgstr "Serbia (latinalainen)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18249,6 +18500,14 @@ msgid "Share"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18397,6 +18656,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Jaa ajatuksesi hakukentästä."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19070,6 +19341,12 @@ msgstr "Jotain muuta"
 msgctxt "duckai_migration"
 msgid "Something went wrong"
 msgstr "Jokin meni pieleen"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19918,6 +20195,12 @@ msgid "Switch model"
 msgstr "Vaihda mallia"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20176,6 +20459,13 @@ msgid "Synced Devices"
 msgstr "Synkronoidut laitteet"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Syyria"
 
@@ -20206,6 +20496,12 @@ msgstr "Ei tiedossa"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20786,6 +21082,22 @@ msgstr ""
 "loukkaavia tietoja (katso lisätietoja kohdasta %4$s)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20869,6 +21181,12 @@ msgstr "Kuvatyyppiä ei tueta. Liitä JPG-, PNG-, WebP- tai GIF-tiedosto."
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Nämä tiedot eivät ole hyödyllisiä"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -20981,6 +21299,18 @@ msgstr ""
 "tyhjennät duckduckgo.com-selaintiedot, saatat nähdä tekoälyavusteisia "
 "vastauksia uudelleen. Meillä on kuitenkin myös aloitussivu, joka ei koskaan "
 "näytä tekoälyavusteisia vastauksia: %1$s."
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21625,6 +21955,12 @@ msgid "Try Free"
 msgstr "Kokeile maksutta"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21736,6 +22072,12 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -21980,6 +22322,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -21990,6 +22338,12 @@ msgstr "Poista Synkronoi ja varmuuskopioi -toiminto käytöstä"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Poista Sync & Backup käytöstä"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22477,6 +22831,12 @@ msgid "Unmute"
 msgstr "Poista mykistys"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22510,6 +22870,12 @@ msgstr "Päivitä"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Päivitä selain"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23483,6 +23849,14 @@ msgstr ""
 "Lopetimme keskustelun toimettomuuden vuoksi. Haluatko yrittää uudelleen?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23529,6 +23903,14 @@ msgstr ""
 "lähempää sijaintiasi. Voit aina muuttaa mieltäsi myöhemmin."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23564,6 +23946,14 @@ msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Estämme seurantaohjelmat, jotka yrittävät kerätä tietojasi selaillessasi."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23880,6 +24270,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Mitkä ovat annuiteettien edut ja haitat?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24438,6 +24834,14 @@ msgid "Without zero provider visibility"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -24937,6 +25341,13 @@ msgid "You have 1 attempt left."
 msgstr "Sinulla on yksi yritys jäljellä."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25160,6 +25571,23 @@ msgid "YouTube Standard"
 msgstr "YouTube-standardi"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "DuckDuckGo-hakuhistoriasi on yksityinen"
@@ -25181,6 +25609,14 @@ msgstr "Todellinen sijaintisi pysyy yksityisenä"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Todellinen sijaintisi pysyy yksityisenä."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/fr_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_BE/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Ajouter à %s"
 msgid "Add to Home Screen"
 msgstr "Ajouter à l'écran d'accueil"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Extensions"
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4211,6 +4245,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4243,6 +4282,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4803,6 +4861,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4811,6 +4876,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5017,6 +5089,12 @@ msgstr "Fermer"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5664,6 +5742,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6330,9 +6414,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7425,6 +7522,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7509,6 +7613,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9103,6 +9212,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "En Apprendre %sPlus%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9622,6 +9736,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9827,6 +9947,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10129,6 +10254,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Plus d'infos sur"
@@ -10286,6 +10416,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rouge doux"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11167,6 +11302,27 @@ msgstr ""
 "Sur Mac, %sCliquez sur Maxthon > Préférences%s, Sur Windows, %s Cliquez sur "
 "%s l'icône > Paramètres%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11777,6 +11933,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11785,6 +11946,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11829,6 +11995,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12843,6 +13021,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12992,6 +13175,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13200,6 +13388,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13233,6 +13426,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13781,6 +13984,11 @@ msgstr "Stocker anonymement vos paramètres dans le cloud"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14565,6 +14773,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14689,6 +14903,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14810,6 +15031,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15357,6 +15588,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16048,6 +16284,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16245,6 +16486,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16269,6 +16516,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16722,6 +16974,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16790,6 +17056,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16873,6 +17144,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17388,6 +17669,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17480,6 +17766,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17679,6 +17970,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17687,6 +17983,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18073,6 +18374,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18100,6 +18406,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18877,6 +19188,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18911,6 +19229,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18935,6 +19260,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19179,6 +19511,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19641,6 +19978,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20047,6 +20391,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20216,6 +20566,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Standard YouTube"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20233,6 +20598,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/fr_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CA/LC_MESSAGES/duckduckgo.po
@@ -43,6 +43,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -393,6 +400,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -627,6 +640,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1180,6 +1198,11 @@ msgstr "Ajouter à %s"
 msgid "Add to Home Screen"
 msgstr "Ajouter à l'écran d'accueil"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Extensions"
@@ -1472,6 +1495,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1884,6 +1913,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4215,6 +4249,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4247,6 +4286,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4807,6 +4865,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4815,6 +4880,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5021,6 +5093,12 @@ msgstr "Ignorer"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5668,6 +5746,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6331,9 +6415,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7426,6 +7523,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7510,6 +7614,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9106,6 +9215,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "En apprendre %sPlus%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9627,6 +9741,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9832,6 +9952,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10134,6 +10259,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Plus à"
@@ -10291,6 +10421,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rouge muet"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11170,6 +11305,27 @@ msgstr ""
 "Sur Mac, cliquez sur %sMaxthon > Préférences%s. Sur Windows, cliquez sur %s "
 "l'icône %s > Préférences%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11780,6 +11936,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11788,6 +11949,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11832,6 +11998,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12846,6 +13024,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12995,6 +13178,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13203,6 +13391,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13236,6 +13429,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13784,6 +13987,11 @@ msgstr "Sauvegardez vos paramètres anonymement dans le nuage"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14564,6 +14772,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14690,6 +14904,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14811,6 +15032,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15358,6 +15589,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16047,6 +16283,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16244,6 +16485,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16268,6 +16515,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16721,6 +16973,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16789,6 +17055,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16872,6 +17143,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17388,6 +17669,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17481,6 +17767,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17680,6 +17971,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17688,6 +17984,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18075,6 +18376,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18102,6 +18408,11 @@ msgstr "Actualiser"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18882,6 +19193,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18916,6 +19234,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18940,6 +19265,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19184,6 +19516,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19647,6 +19984,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20051,6 +20395,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20223,6 +20573,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube standard"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20240,6 +20605,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/fr_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CH/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Ajouter à %s"
 msgid "Add to Home Screen"
 msgstr "Ajouter à l'écran d'accueil"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Extensions"
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4211,6 +4245,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4243,6 +4282,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4803,6 +4861,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4811,6 +4876,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5017,6 +5089,12 @@ msgstr "Rejeter"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5664,6 +5742,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6327,9 +6411,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7423,6 +7520,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7507,6 +7611,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9098,6 +9207,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "En savoir %splus%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9618,6 +9732,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9823,6 +9943,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10125,6 +10250,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Plus sur"
@@ -10282,6 +10412,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rouge doux"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11161,6 +11296,27 @@ msgstr ""
 "Sur Mac, %sCliquez sur Maxthon > Préférences%s, Sur Windows, %sCliquez sur "
 "l'icône %s > Paramètres%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11771,6 +11927,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11779,6 +11940,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11823,6 +11989,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12837,6 +13015,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12986,6 +13169,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13194,6 +13382,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13227,6 +13420,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13775,6 +13978,11 @@ msgstr "Sauver vos paramètres anonymement dans le Cloud"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14556,6 +14764,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14682,6 +14896,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14801,6 +15022,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15348,6 +15579,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16039,6 +16275,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16236,6 +16477,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16260,6 +16507,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16713,6 +16965,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16781,6 +17047,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16864,6 +17135,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17380,6 +17661,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17473,6 +17759,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17672,6 +17963,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17680,6 +17976,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18066,6 +18367,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18093,6 +18399,11 @@ msgstr "Actualiser"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18863,6 +19174,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18897,6 +19215,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18921,6 +19246,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19165,6 +19497,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19628,6 +19965,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20034,6 +20378,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20200,6 +20550,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20217,6 +20582,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% de personnes entièrement vaccinées"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% de personnes vaccinées"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -491,6 +499,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sDécouvrez comment nous conservons votre localisation privée%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -785,6 +800,12 @@ msgid "2nd in Group %s"
 msgstr "2e du groupe %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -997,8 +1018,8 @@ msgstr ""
 "AI Chat vous permet d'avoir des conversations anonymes avec des modèles de "
 "chat IA tiers. La désactivation de cette option masquera la fonctionnalité "
 "AI Chat sur DuckDuckGo Search. Vous pouvez toujours accéder à l'AI Chat "
-"lorsque ce paramètre est désactivé en consultant "
-"%1$sduckduckgo.com/aichat%2$s."
+"lorsque ce paramètre est désactivé en consultant %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1415,7 +1436,8 @@ msgstr "Ajouter un champ de recherche %1$s à votre site !"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr "Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
+msgstr ""
+"Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1472,6 +1494,12 @@ msgstr "Ajoutez à %1$s"
 #. Button that creates a shortcut to the current page on the home screen of the user's phone.
 msgid "Add to Home Screen"
 msgstr "Ajouter à la page d'accueil"
+
+# smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1839,6 +1867,13 @@ msgstr "Toutes les tailles"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Tous types"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2220,7 +2255,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
+msgstr ""
+"Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2368,6 +2404,12 @@ msgstr "Posez des questions sur cette page"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask anything privately"
 msgstr "Posez toutes vos questions en privé"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2542,18 +2584,21 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr ""
+"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr ""
+"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
+msgstr ""
+"Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2855,8 +2900,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Avant de stocker ce rapport, DuckDuckGo anonymisera votre conversation en "
-"supprimant les données à caractère personnel comme les noms, les adresses "
-"e-mail et les métadonnées d'identification."
+"supprimant les données à caractère personnel comme les noms, les adresses e-"
+"mail et les métadonnées d'identification."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2992,7 +3037,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
+msgstr ""
+"La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3008,7 +3054,8 @@ msgstr "Bloquer ce site dans tous les résultats"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
+msgstr ""
+"Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3356,7 +3403,8 @@ msgstr "En cliquant sur « %1$s », vous acceptez nos %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
+msgstr ""
+"En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3741,7 +3789,8 @@ msgstr "Change l'affichage de l'URL des résultats"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
+msgstr ""
+"Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4215,7 +4264,8 @@ msgstr "Choix de modèles d'IA, y compris %1$s et %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
+msgstr ""
+"Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4583,7 +4633,8 @@ msgstr "Cliquez sur %1$sParamètres%2$s dans le menu déroulant."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
+msgstr ""
+"Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5342,6 +5393,12 @@ msgid "Copy"
 msgstr "Copier"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5381,6 +5438,28 @@ msgstr "Copier ou enregistrer ce code"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Copier le code de récupération"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6068,6 +6147,14 @@ msgid "Delete recent chats?"
 msgstr "Supprimer les discussions récentes ?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6080,10 +6167,19 @@ msgid "Deleted chats"
 msgstr "Discussions supprimées"
 
 # smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr "La suppression des cookies aura pour effet de réinitialiser ces paramètres."
+msgstr ""
+"La suppression des cookies aura pour effet de réinitialiser ces paramètres."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6105,7 +6201,8 @@ msgstr "Décrivez les modifications en fonction de l'image"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Décrivez les modifications souhaitées pour continuer à modifier cette image"
+msgstr ""
+"Décrivez les modifications souhaitées pour continuer à modifier cette image"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6274,7 +6371,8 @@ msgstr "Désactiver et déconnecter"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
+msgstr ""
+"Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6333,6 +6431,13 @@ msgstr "Rejeter"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Ignorer"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6841,7 +6946,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
+msgstr ""
+"Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6932,7 +7038,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
+msgstr ""
+"Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6948,7 +7055,8 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr "Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
+msgstr ""
+"Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7199,6 +7307,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Navigateur DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7618,7 +7733,8 @@ msgstr "Activer les fonctionnalités d'IA"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
+msgstr ""
+"Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7879,13 +7995,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
+msgstr ""
+"Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Vérifiez que votre navigateur est autorisé à accéder à la localisation."
+msgstr ""
+"Vérifiez que votre navigateur est autorisé à accéder à la localisation."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8047,10 +8165,25 @@ msgstr ""
 "confidentialité."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Périmé"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8333,8 +8466,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, "
-"copiez-collez le code dans votre site."
+"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, copiez-"
+"collez le code dans votre site."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8411,7 +8544,8 @@ msgstr "Filtres inefficaces"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Filtre les images générées par l'IA des résultats de recherche d'images"
+msgstr ""
+"Filtre les images générées par l'IA des résultats de recherche d'images"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8468,7 +8602,8 @@ msgstr "Vous trouverez <b>%1$s</b> dans votre dossier de téléchargements"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
+msgstr ""
+"Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8579,7 +8714,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
+msgstr ""
+"Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8806,8 +8942,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dans la barre de menu de l'application sur Mac, sélectionnez "
-"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à "
-"jour…</strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
+"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à jour…</"
+"strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9278,8 +9414,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Bénéficiez de notre VPN sécurisé sans journalisation, du chat avancé "
-"Duck.ai, de Personal Information Removal et d'Identity Theft Restoration."
+"Bénéficiez de notre VPN sécurisé sans journalisation, du chat avancé Duck."
+"ai, de Personal Information Removal et d'Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9433,10 +9569,19 @@ msgstr ""
 "votre PDF de récupération."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
+msgstr ""
+"Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9542,6 +9687,12 @@ msgstr "J'ai compris"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "J'ai compris"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9707,7 +9858,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
+msgstr ""
+"Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9907,7 +10059,8 @@ msgstr "Aide-nous à améliorer DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
+msgstr ""
+"Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9965,7 +10118,8 @@ msgstr "Aidez votre famille et vos ami(e)s à rejoindre le côté Duck !"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
+msgstr ""
+"Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10367,7 +10521,8 @@ msgstr "À quelle fréquence souhaitez-vous voir des réponses %1$s ?"
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr "À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
+msgstr ""
+"À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10656,7 +10811,8 @@ msgstr "Les prompts d’image doivent respecter les %1$s"
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
-msgstr "Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
+msgstr ""
+"Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11176,7 +11332,8 @@ msgstr "Cela peut prendre quelques minutes."
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr "Il est rapide, gratuit et vous offre encore plus de protection en ligne."
+msgstr ""
+"Il est rapide, gratuit et vous offre encore plus de protection en ligne."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -11525,6 +11682,12 @@ msgid "Learn %sMore%s"
 msgstr "En savoir %1$splus%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11793,7 +11956,8 @@ msgstr "Liens :"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
+msgstr ""
+"Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12162,6 +12326,13 @@ msgid "Manage"
 msgstr "Gérer"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12411,6 +12582,12 @@ msgstr "Menu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12783,6 +12960,12 @@ msgid "More about Duck.ai"
 msgstr "En savoir plus sur Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Plus sur"
@@ -12975,6 +13158,12 @@ msgstr "Son désactivé"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rouge doux"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14007,7 +14196,8 @@ msgstr "Oman"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
+msgstr ""
+"Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14047,6 +14237,30 @@ msgid ""
 msgstr ""
 "Sur Mac, %1$sCliquez sur Maxthon > Préférences%2$s, Sur Windows, %3$sCliquez "
 "sur l'icône %4$s > Réglages%5$s"
+
+# smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14194,7 +14408,8 @@ msgstr "Ouvrir %1$sParamètres%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
+msgstr ""
+"Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14343,7 +14558,8 @@ msgstr "Ouvrir le volet « Comment fonctionne Duck.ai »"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
+msgstr ""
+"Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14802,6 +15018,12 @@ msgid "Past year"
 msgstr "Moins d'un an"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14812,6 +15034,12 @@ msgstr "Coller"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Coller le code de synchronisation"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14865,6 +15093,20 @@ msgstr "Fermé définitivement"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persan"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15080,7 +15322,8 @@ msgstr "Épinglé"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Les discussions épinglées apparaîtront en haut de vos discussions récentes."
+msgstr ""
+"Les discussions épinglées apparaîtront en haut de vos discussions récentes."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -16140,6 +16383,12 @@ msgid "Reading website…"
 msgstr "Lecture du site Web…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16173,7 +16422,8 @@ msgstr "IA de raisonnement avec modération intégrée moyenne"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr "Le raisonnement peut donner de meilleures réponses aux questions complexes."
+msgstr ""
+"Le raisonnement peut donner de meilleures réponses aux questions complexes."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16332,6 +16582,12 @@ msgstr "Récupération"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Code de récupération"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16552,7 +16808,8 @@ msgstr "Mémoriser mon choix"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
+msgstr ""
+"Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16583,6 +16840,12 @@ msgstr "Supprimer %1$s"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "Supprimer %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16625,6 +16888,18 @@ msgstr "Supprimer la sélection de texte"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Supprimez la ponctuation inutile"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16996,7 +17271,8 @@ msgstr "Avis"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr "Réécris cette recette pour l'adapter à un nombre de portions différent."
+msgstr ""
+"Réécris cette recette pour l'adapter à un nombre de portions différent."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17326,6 +17602,12 @@ msgid "Say hello to Duck.ai"
 msgstr "Dites bonjour à Duck.ai"
 
 # smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai!"
@@ -17471,7 +17753,8 @@ msgstr ""
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down and locate %syour browser%s in the list."
-msgstr "Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
+msgstr ""
+"Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -18046,31 +18329,35 @@ msgstr "Sélectionner %1$s%2$s%3$s, puis %4$sMoteur de recherche%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
+msgstr ""
+"Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Selectionnez %1$sPersonnaliser%2$s et saisissez "
-"%3$shttps://duckduckgo.com%4$s dans le champ de saisie"
+"Selectionnez %1$sPersonnaliser%2$s et saisissez %3$shttps://duckduckgo."
+"com%4$s dans le champ de saisie"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
+msgstr ""
+"Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
+msgstr ""
+"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
+msgstr ""
+"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18111,7 +18398,8 @@ msgstr "Sélectionnez %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
+msgstr ""
+"Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18185,7 +18473,8 @@ msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sRéglages avancés%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
+msgstr ""
+"Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18246,7 +18535,8 @@ msgstr "Sélectionnez tous les carrés contenant un canard :"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr "Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
+msgstr ""
+"Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -18281,7 +18571,8 @@ msgstr "Texte sélectionné de %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
+msgstr ""
+"Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18348,6 +18639,13 @@ msgstr "Serbe (alphabet cyrillique)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Serbe (alphabet latin)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18504,6 +18802,14 @@ msgid "Share"
 msgstr "Partager"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18651,6 +18957,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Donnez votre avis sur le champ de recherche."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18968,8 +19286,8 @@ msgstr "Afficher la barre latérale"
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
-"Découvrez des conseils étape par étape pour tirer le meilleur parti de "
-"Duck.ai."
+"Découvrez des conseils étape par étape pour tirer le meilleur parti de Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19116,7 +19434,8 @@ msgstr "Montre l'arrière-plan du bouton de recherche"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Affiche un message de bienvenue en haut de la page des résultats de recherche"
+msgstr ""
+"Affiche un message de bienvenue en haut de la page des résultats de recherche"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19323,7 +19642,8 @@ msgstr "Résolvez des problèmes complexes grâce au mode de raisonnement !"
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
 msgctxt "Promotional text for reasoning mode"
 msgid "Solve complex problems with the new reasoning mode!"
-msgstr "Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
+msgstr ""
+"Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
@@ -19346,6 +19666,12 @@ msgstr "Autre chose"
 msgctxt "duckai_migration"
 msgid "Something went wrong"
 msgstr "Une erreur s'est produite"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19389,7 +19715,8 @@ msgstr "Parfois"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
+msgstr ""
+"Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19728,7 +20055,8 @@ msgstr "Reste sur DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
+msgstr ""
+"Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19783,7 +20111,8 @@ msgstr "Arrêtez les traqueurs qui se cachent sur d'autres sites Web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
+msgstr ""
+"Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19873,8 +20202,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans "
-"Duck.ai, ou revenez plus tard pour créer plus d'images."
+"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans Duck."
+"ai, ou revenez plus tard pour créer plus d'images."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20200,10 +20529,17 @@ msgid "Switch model"
 msgstr "Changer de modèle"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr "Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
+msgstr ""
+"Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -20395,8 +20731,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Comment fonctionne ce code ?\n"
-"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de "
-"Duck.ai.\n"
+"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de Duck."
+"ai.\n"
 "2. Sélectionnez « Activer Sync & Backup », puis « Récupérer les données "
 "synchronisées »\n"
 "3. Copiez le code de récupération ci-dessus et collez-le là où il est écrit "
@@ -20461,6 +20797,13 @@ msgid "Synced Devices"
 msgstr "Appareils synchronisés"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Syrie"
 
@@ -20491,6 +20834,12 @@ msgstr "À confirmer"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "Télévision"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20765,13 +21114,15 @@ msgstr "Merci pour vos commentaires !"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre !"
+msgstr ""
+"Merci pour votre patience pendant que nous mettons les choses en ordre !"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre."
+msgstr ""
+"Merci pour votre patience pendant que nous mettons les choses en ordre."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -20816,7 +21167,8 @@ msgstr "Les fichiers joints dépassent la limite totale de taille de %1$s Mo."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
+msgstr ""
+"L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20841,7 +21193,8 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr "Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
+msgstr ""
+"Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20901,7 +21254,8 @@ msgstr "Thèmes"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "There was an error displaying the search results."
-msgstr "Une erreur s'est produite lors de l'affichage des résultats de recherche."
+msgstr ""
+"Une erreur s'est produite lors de l'affichage des résultats de recherche."
 
 # smartling.placeholder_format=C
 #. Error message displayed when there was an issue in saving the chat locally to the browser's storage
@@ -21083,16 +21437,34 @@ msgstr ""
 "ou offensantes (voir %4$s pour en savoir plus)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
+msgstr ""
+"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
+msgstr ""
+"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21130,7 +21502,8 @@ msgstr ""
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
 msgctxt "Error message when an uploaded file type is not supported"
 msgid "This file type is not supported, please attach a %s."
-msgstr "Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
+msgstr ""
+"Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21174,6 +21547,12 @@ msgid "This information isn’t useful"
 msgstr "Ces informations sont inutiles"
 
 # smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
@@ -21214,8 +21593,8 @@ msgid ""
 "Other model providers follow a zero data retention model."
 msgstr ""
 "Ce fournisseur de modèles supprime les données associées à cette discussion "
-"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de "
-"non-conservation des données."
+"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de non-"
+"conservation des données."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21293,6 +21672,18 @@ msgstr ""
 "%1$s."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21321,7 +21712,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
+msgstr ""
+"Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21462,7 +21854,8 @@ msgstr "Souligner le titre"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr "Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
+msgstr ""
+"Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -21476,7 +21869,8 @@ msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
+msgstr ""
+"Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21543,8 +21937,8 @@ msgstr "Auj."
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Activez cette option pour essayer le chat privé avec l’IA ou "
-"%1$sdésactivez-la dans le menu %2$s.%3$s"
+"Activez cette option pour essayer le chat privé avec l’IA ou %1$sdésactivez-"
+"la dans le menu %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21892,7 +22286,8 @@ msgstr "Essayez %1$s pour ne plus voir de messages comme celui-ci."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
+msgstr ""
+"Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21938,6 +22333,12 @@ msgstr "Essayer gratuitement"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Essayer gratuitement"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22027,14 +22428,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
+msgstr ""
+"Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
+msgstr ""
+"N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22053,6 +22456,12 @@ msgstr "Essayer gratuitement"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Essayer gratuitement"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22208,13 +22617,15 @@ msgstr "Essayez les logiciels open source %1$s et %2$s récemment ajoutés"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr "Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
+msgstr ""
+"Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
+msgstr ""
+"Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22222,7 +22633,8 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr "Essayez d'utiliser un autre terme ou une autre expression de recherche."
+msgstr ""
+"Essayez d'utiliser un autre terme ou une autre expression de recherche."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -22300,6 +22712,12 @@ msgid "Turkmenistan"
 msgstr "Turkménistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22310,6 +22728,12 @@ msgstr "Désactiver Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Désactiver Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22398,7 +22822,8 @@ msgstr "Activez la « position exacte » pour des résultats plus précis."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Activez « Utiliser la position exacte » pour des résultats plus précis."
+msgstr ""
+"Activez « Utiliser la position exacte » pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22591,18 +23016,20 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et saisissez "
-": https://duckduckgo.com"
+"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et "
+"saisissez : https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
+msgstr ""
+"Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
+msgstr ""
+"Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22797,6 +23224,12 @@ msgid "Unmute"
 msgstr "Réactiver le son"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22832,6 +23265,12 @@ msgstr "Actualiser"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Mettre à jour le navigateur"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23151,7 +23590,8 @@ msgstr "Vous utilisez le Wi-Fi public ? Utilisez notre VPN."
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr "Utilisez le Fire Button pour supprimer une conversation de l’historique."
+msgstr ""
+"Utilisez le Fire Button pour supprimer une conversation de l’historique."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23314,7 +23754,8 @@ msgstr "Voir les prix de votre séjour"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "DuckDuckGo protège la confidentialité lors de la consultation des publicités."
+msgstr ""
+"DuckDuckGo protège la confidentialité lors de la consultation des publicités."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23394,9 +23835,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de "
-"Duck.ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser "
-"avec un autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
+"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de Duck."
+"ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser avec un "
+"autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
 "récupération."
 
 # smartling.placeholder_format=C
@@ -23827,6 +24268,14 @@ msgstr ""
 "réessayer ?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23851,7 +24300,8 @@ msgstr "Nous avons perdu la connexion ; veuillez réessayer plus tard."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
+msgstr ""
+"Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -23872,6 +24322,14 @@ msgstr ""
 "Nous n'utilisons votre localisation anonyme que pour vous fournir de "
 "meilleurs résultats, plus proches de vous. Vous pouvez modifier ce réglage "
 "plus tard."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23912,6 +24370,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Nous bloquerons les traqueurs qui essaient de recueillir vos données pendant "
 "que vous naviguez sur Internet."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24120,7 +24586,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
+msgstr ""
+"Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24232,6 +24699,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Quels sont les avantages et les inconvénients des rentes ?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24466,7 +24939,8 @@ msgstr "À quoi cela répond-il ?"
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
-msgstr "Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
+msgstr ""
+"Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
 
 # smartling.placeholder_format=C
 #. Header above a list of types of information that gets saved by the cloud save feature.
@@ -24478,7 +24952,8 @@ msgstr "Quelles informations sont sauvegardées ?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr "Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
+msgstr ""
+"Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -24487,8 +24962,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi "
-"est-il différent du bookmarklet avec URL de paramétrage ?"
+"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi est-"
+"il différent du bookmarklet avec URL de paramétrage ?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24806,6 +25281,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Sans aucune visibilité du fournisseur"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25147,7 +25630,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
+msgstr ""
+"Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25177,7 +25661,8 @@ msgstr "Vous pouvez trouver le"
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
 msgctxt "duckai_migration"
 msgid "You can find the <b>%s</b> file in your downloads folder."
-msgstr "Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
+msgstr ""
+"Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
 
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
@@ -25314,6 +25799,13 @@ msgstr "Il vous reste %1$s tentatives."
 msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Il vous reste 1 tentative."
+
+# smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25475,7 +25967,8 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
+msgstr ""
+"Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -25489,7 +25982,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
+msgstr ""
+"Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25544,6 +26038,23 @@ msgid "YouTube Standard"
 msgstr "YouTube standard"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Votre historique de recherche DuckDuckGo est privé"
@@ -25565,6 +26076,14 @@ msgstr "Votre emplacement réel reste confidentiel"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Votre position réelle reste confidentielle."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25613,8 +26132,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Votre navigateur fournit une liste des sites que vous visitez le "
-"plus.DuckDuckGo n'a jamais accès à ces données."
+"Votre navigateur fournit une liste des sites que vous visitez le plus."
+"DuckDuckGo n'a jamais accès à ces données."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25880,7 +26399,8 @@ msgstr ""
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr "Vos discussions synchronisées sont en cours de restauration sur cet appareil."
+msgstr ""
+"Vos discussions synchronisées sont en cours de restauration sur cet appareil."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25948,7 +26468,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
+msgstr ""
+"Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Cet appareil)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -503,7 +503,7 @@ msgstr "%1$sDécouvrez comment nous conservons votre localisation privée%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sEn savoir plus%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -803,7 +803,7 @@ msgstr "2e du groupe %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2e avis"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1018,8 +1018,8 @@ msgstr ""
 "AI Chat vous permet d'avoir des conversations anonymes avec des modèles de "
 "chat IA tiers. La désactivation de cette option masquera la fonctionnalité "
 "AI Chat sur DuckDuckGo Search. Vous pouvez toujours accéder à l'AI Chat "
-"lorsque ce paramètre est désactivé en consultant %1$sduckduckgo.com/"
-"aichat%2$s."
+"lorsque ce paramètre est désactivé en consultant "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1436,8 +1436,7 @@ msgstr "Ajouter un champ de recherche %1$s à votre site !"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr ""
-"Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
+msgstr "Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1499,7 +1498,7 @@ msgstr "Ajouter à la page d'accueil"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Ajouter à mes discussions"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1873,7 +1872,7 @@ msgstr "Tous types"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Tous vos appareils sont déconnectés de la synchronisation."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2255,8 +2254,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
+msgstr "Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2409,7 +2407,7 @@ msgstr "Posez toutes vos questions en privé"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Posez toutes vos questions en privé"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2584,21 +2582,18 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2900,8 +2895,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Avant de stocker ce rapport, DuckDuckGo anonymisera votre conversation en "
-"supprimant les données à caractère personnel comme les noms, les adresses e-"
-"mail et les métadonnées d'identification."
+"supprimant les données à caractère personnel comme les noms, les adresses "
+"e-mail et les métadonnées d'identification."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3037,8 +3032,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
+msgstr "La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3054,8 +3048,7 @@ msgstr "Bloquer ce site dans tous les résultats"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
+msgstr "Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3403,8 +3396,7 @@ msgstr "En cliquant sur « %1$s », vous acceptez nos %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
+msgstr "En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3789,8 +3781,7 @@ msgstr "Change l'affichage de l'URL des résultats"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
+msgstr "Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4264,8 +4255,7 @@ msgstr "Choix de modèles d'IA, y compris %1$s et %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
+msgstr "Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4633,8 +4623,7 @@ msgstr "Cliquez sur %1$sParamètres%2$s dans le menu déroulant."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
+msgstr "Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5396,7 +5385,7 @@ msgstr "Copier"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Copier"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5445,13 +5434,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Copier le lien partagé"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Copiez le code depuis un autre appareil"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5460,6 +5449,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Copiez le code depuis un autre appareil. Allez dans %1$sParamètres Duck.ai › "
+"Discussions › Sync & Backup › Synchroniser avec un autre appareil%2$s et "
+"réessayez."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6152,7 +6144,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Supprimer le lien partagé"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6173,13 +6165,15 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"La suppression d’un lien l'empêche de fonctionner. Les personnes qui l’ont "
+"ouvert et ont ajouté la conversation à leurs discussions conserveront leur "
+"propre copie."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"La suppression des cookies aura pour effet de réinitialiser ces paramètres."
+msgstr "La suppression des cookies aura pour effet de réinitialiser ces paramètres."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6201,8 +6195,7 @@ msgstr "Décrivez les modifications en fonction de l'image"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Décrivez les modifications souhaitées pour continuer à modifier cette image"
+msgstr "Décrivez les modifications souhaitées pour continuer à modifier cette image"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6371,8 +6364,7 @@ msgstr "Désactiver et déconnecter"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
+msgstr "Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6437,7 +6429,7 @@ msgstr "Ignorer"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Ignorer"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6946,8 +6938,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
+msgstr "Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7038,8 +7029,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
+msgstr "Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7055,8 +7045,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
+msgstr "Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7313,7 +7302,7 @@ msgstr "Navigateur DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Pages d'aide DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7733,8 +7722,7 @@ msgstr "Activer les fonctionnalités d'IA"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
+msgstr "Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7995,15 +7983,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
+msgstr "Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Vérifiez que votre navigateur est autorisé à accéder à la localisation."
+msgstr "Vérifiez que votre navigateur est autorisé à accéder à la localisation."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8169,7 +8155,7 @@ msgstr ""
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Périmé"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8183,7 +8169,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Expire le %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8466,8 +8452,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, copiez-"
-"collez le code dans votre site."
+"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, "
+"copiez-collez le code dans votre site."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8544,8 +8530,7 @@ msgstr "Filtres inefficaces"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Filtre les images générées par l'IA des résultats de recherche d'images"
+msgstr "Filtre les images générées par l'IA des résultats de recherche d'images"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8602,8 +8587,7 @@ msgstr "Vous trouverez <b>%1$s</b> dans votre dossier de téléchargements"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
+msgstr "Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8714,8 +8698,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
+msgstr "Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8942,8 +8925,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dans la barre de menu de l'application sur Mac, sélectionnez "
-"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à jour…</"
-"strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
+"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à "
+"jour…</strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9414,8 +9397,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Bénéficiez de notre VPN sécurisé sans journalisation, du chat avancé Duck."
-"ai, de Personal Information Removal et d'Identity Theft Restoration."
+"Bénéficiez de notre VPN sécurisé sans journalisation, du chat avancé "
+"Duck.ai, de Personal Information Removal et d'Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9575,13 +9558,14 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Accédez à %1$sParamètres Duck.ai%2$s › %3$sDiscussions › Sync & Backup › "
+"Synchroniser avec un autre appareil%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
+msgstr "Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9692,7 +9676,7 @@ msgstr "J'ai compris"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "J'ai compris"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9858,8 +9842,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
+msgstr "Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10059,8 +10042,7 @@ msgstr "Aide-nous à améliorer DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
+msgstr "Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10118,8 +10100,7 @@ msgstr "Aidez votre famille et vos ami(e)s à rejoindre le côté Duck !"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
+msgstr "Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10521,8 +10502,7 @@ msgstr "À quelle fréquence souhaitez-vous voir des réponses %1$s ?"
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
+msgstr "À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10811,8 +10791,7 @@ msgstr "Les prompts d’image doivent respecter les %1$s"
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
-msgstr ""
-"Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
+msgstr "Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11332,8 +11311,7 @@ msgstr "Cela peut prendre quelques minutes."
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"Il est rapide, gratuit et vous offre encore plus de protection en ligne."
+msgstr "Il est rapide, gratuit et vous offre encore plus de protection en ligne."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -11685,7 +11663,7 @@ msgstr "En savoir %1$splus%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "En savoir plus"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11956,8 +11934,7 @@ msgstr "Liens :"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
+msgstr "Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12330,7 +12307,7 @@ msgstr "Gérer"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Gérer"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12587,7 +12564,7 @@ msgstr "Menu"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Vous uniquement pouvez voir les messages au-delà de ce point."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12963,7 +12940,7 @@ msgstr "En savoir plus sur Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Plus d'actions"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13163,7 +13140,7 @@ msgstr "Rouge doux"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Mes appareils"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14196,8 +14173,7 @@ msgstr "Oman"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
+msgstr "Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14245,6 +14221,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Sur un autre appareil, accédez à %1$sParamètres Duck.ai%2$s › "
+"%3$sDiscussions › Sync & Backup › Synchroniser avec un autre appareil%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14253,6 +14231,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Sur un autre appareil, accédez à %1$sParamètres Duck.ai%2$s › "
+"%3$sDiscussions › Sync & Backup › Synchroniser avec un autre appareil%4$s et "
+"scannez ce code :"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14261,6 +14242,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Sur un autre appareil, accédez à %1$sParamètres Duck.ai%2$s › "
+"%3$sDiscussions › Sync & Backup › Synchroniser avec un autre appareil%4$s. "
+"Ou scannez le code QR figurant sur votre PDF de récupération."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14408,8 +14392,7 @@ msgstr "Ouvrir %1$sParamètres%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
+msgstr "Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14558,8 +14541,7 @@ msgstr "Ouvrir le volet « Comment fonctionne Duck.ai »"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
+msgstr "Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15021,7 +15003,7 @@ msgstr "Moins d'un an"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Coller"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -15039,7 +15021,7 @@ msgstr "Coller le code de synchronisation"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Collez-le ci-dessous"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -15098,7 +15080,7 @@ msgstr "Persan"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -15107,6 +15089,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal trouve vos informations sur les sites de "
+"courtiers en données qui les vendent. Ensuite, nous nous efforçons de les "
+"faire supprimer pour vous."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15322,8 +15307,7 @@ msgstr "Épinglé"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Les discussions épinglées apparaîtront en haut de vos discussions récentes."
+msgstr "Les discussions épinglées apparaîtront en haut de vos discussions récentes."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -16386,7 +16370,7 @@ msgstr "Lecture du site Web…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Prêt(e) pour l'éclipse solaire ?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16422,8 +16406,7 @@ msgstr "IA de raisonnement avec modération intégrée moyenne"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
-"Le raisonnement peut donner de meilleures réponses aux questions complexes."
+msgstr "Le raisonnement peut donner de meilleures réponses aux questions complexes."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16587,7 +16570,7 @@ msgstr "Code de récupération"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Code de récupération"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16808,8 +16791,7 @@ msgstr "Mémoriser mon choix"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
+msgstr "Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16845,7 +16827,7 @@ msgstr "Supprimer %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Supprimer l'appareil"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16893,13 +16875,13 @@ msgstr "Supprimez la ponctuation inutile"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Supprimez vos informations d'Internet"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Supprimer vos informations en ligne"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17271,8 +17253,7 @@ msgstr "Avis"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Réécris cette recette pour l'adapter à un nombre de portions différent."
+msgstr "Réécris cette recette pour l'adapter à un nombre de portions différent."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17605,7 +17586,7 @@ msgstr "Dites bonjour à Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Dites bonjour à Duck.ai – chat IA gratuit et privé par DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17753,8 +17734,7 @@ msgstr ""
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down and locate %syour browser%s in the list."
-msgstr ""
-"Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
+msgstr "Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -18329,35 +18309,31 @@ msgstr "Sélectionner %1$s%2$s%3$s, puis %4$sMoteur de recherche%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
+msgstr "Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Selectionnez %1$sPersonnaliser%2$s et saisissez %3$shttps://duckduckgo."
-"com%4$s dans le champ de saisie"
+"Selectionnez %1$sPersonnaliser%2$s et saisissez "
+"%3$shttps://duckduckgo.com%4$s dans le champ de saisie"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18398,8 +18374,7 @@ msgstr "Sélectionnez %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
+msgstr "Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18473,8 +18448,7 @@ msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sRéglages avancés%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
+msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18535,8 +18509,7 @@ msgstr "Sélectionnez tous les carrés contenant un canard :"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr ""
-"Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
+msgstr "Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -18571,8 +18544,7 @@ msgstr "Texte sélectionné de %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
+msgstr "Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18645,7 +18617,7 @@ msgstr "Serbe (alphabet latin)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Données du serveur supprimées"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18807,7 +18779,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Partager"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18962,13 +18934,13 @@ msgstr "Donnez votre avis sur le champ de recherche."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Liens des discussions partagées"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Liens de discussions partagées"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19286,8 +19258,8 @@ msgstr "Afficher la barre latérale"
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
-"Découvrez des conseils étape par étape pour tirer le meilleur parti de Duck."
-"ai."
+"Découvrez des conseils étape par étape pour tirer le meilleur parti de "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19434,8 +19406,7 @@ msgstr "Montre l'arrière-plan du bouton de recherche"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Affiche un message de bienvenue en haut de la page des résultats de recherche"
+msgstr "Affiche un message de bienvenue en haut de la page des résultats de recherche"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19642,8 +19613,7 @@ msgstr "Résolvez des problèmes complexes grâce au mode de raisonnement !"
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
 msgctxt "Promotional text for reasoning mode"
 msgid "Solve complex problems with the new reasoning mode!"
-msgstr ""
-"Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
+msgstr "Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
@@ -19671,7 +19641,7 @@ msgstr "Une erreur s'est produite"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Une erreur s'est produite lors du chargement de cette discussion partagée."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19715,8 +19685,7 @@ msgstr "Parfois"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
+msgstr "Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -20055,8 +20024,7 @@ msgstr "Reste sur DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
+msgstr "Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20111,8 +20079,7 @@ msgstr "Arrêtez les traqueurs qui se cachent sur d'autres sites Web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
+msgstr "Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20202,8 +20169,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans Duck."
-"ai, ou revenez plus tard pour créer plus d'images."
+"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans "
+"Duck.ai, ou revenez plus tard pour créer plus d'images."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20532,14 +20499,13 @@ msgstr "Changer de modèle"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Changer de modèle"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr ""
-"Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
+msgstr "Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -20731,8 +20697,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Comment fonctionne ce code ?\n"
-"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de Duck."
-"ai.\n"
+"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de "
+"Duck.ai.\n"
 "2. Sélectionnez « Activer Sync & Backup », puis « Récupérer les données "
 "synchronisées »\n"
 "3. Copiez le code de récupération ci-dessus et collez-le là où il est écrit "
@@ -20801,7 +20767,7 @@ msgstr "Appareils synchronisés"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Synchronisé le %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20839,7 +20805,7 @@ msgstr "Télévision"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tableau"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -21114,15 +21080,13 @@ msgstr "Merci pour vos commentaires !"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Merci pour votre patience pendant que nous mettons les choses en ordre !"
+msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre !"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Merci pour votre patience pendant que nous mettons les choses en ordre."
+msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -21167,8 +21131,7 @@ msgstr "Les fichiers joints dépassent la limite totale de taille de %1$s Mo."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
+msgstr "L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21193,8 +21156,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
+msgstr "Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21254,8 +21216,7 @@ msgstr "Thèmes"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "There was an error displaying the search results."
-msgstr ""
-"Une erreur s'est produite lors de l'affichage des résultats de recherche."
+msgstr "Une erreur s'est produite lors de l'affichage des résultats de recherche."
 
 # smartling.placeholder_format=C
 #. Error message displayed when there was an issue in saving the chat locally to the browser's storage
@@ -21440,7 +21401,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Cet appareil"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21451,20 +21412,21 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Cet appareil ne pourra plus accéder à vos données synchronisées sur d'autres "
+"appareils. Les %1$s dernières discussions resteront disponibles dans le "
+"stockage local."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
+msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
+msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21502,8 +21464,7 @@ msgstr ""
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
 msgctxt "Error message when an uploaded file type is not supported"
 msgid "This file type is not supported, please attach a %s."
-msgstr ""
-"Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
+msgstr "Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21550,7 +21511,7 @@ msgstr "Ces informations sont inutiles"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Ceci est une copie d'une discussion partagée."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21593,8 +21554,8 @@ msgid ""
 "Other model providers follow a zero data retention model."
 msgstr ""
 "Ce fournisseur de modèles supprime les données associées à cette discussion "
-"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de non-"
-"conservation des données."
+"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de "
+"non-conservation des données."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21676,12 +21637,14 @@ msgstr ""
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
 msgstr ""
+"Cette discussion partagée n'a pas pu être ouverte. Le lien est peut-être "
+"incomplet."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Ce lien de discussion partagée n'est plus disponible."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21712,8 +21675,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
+msgstr "Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21854,8 +21816,7 @@ msgstr "Souligner le titre"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
+msgstr "Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -21869,8 +21830,7 @@ msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
+msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21937,8 +21897,8 @@ msgstr "Auj."
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Activez cette option pour essayer le chat privé avec l’IA ou %1$sdésactivez-"
-"la dans le menu %2$s.%3$s"
+"Activez cette option pour essayer le chat privé avec l’IA ou "
+"%1$sdésactivez-la dans le menu %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22286,8 +22246,7 @@ msgstr "Essayez %1$s pour ne plus voir de messages comme celui-ci."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
+msgstr "Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22338,7 +22297,7 @@ msgstr "Essayer gratuitement"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Essayez gratuitement !"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22428,16 +22387,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
+msgstr "Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
+msgstr "N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22461,7 +22418,7 @@ msgstr "Essayer gratuitement"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Essayez gratuitement !"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22617,15 +22574,13 @@ msgstr "Essayez les logiciels open source %1$s et %2$s récemment ajoutés"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
+msgstr "Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
+msgstr "Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22633,8 +22588,7 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr ""
-"Essayez d'utiliser un autre terme ou une autre expression de recherche."
+msgstr "Essayez d'utiliser un autre terme ou une autre expression de recherche."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -22715,7 +22669,7 @@ msgstr "Turkménistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Désactiver"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22733,7 +22687,7 @@ msgstr "Désactiver Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Désactiver Sync & Backup et supprimer les données du serveur ?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22822,8 +22776,7 @@ msgstr "Activez la « position exacte » pour des résultats plus précis."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Activez « Utiliser la position exacte » pour des résultats plus précis."
+msgstr "Activez « Utiliser la position exacte » pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23016,20 +22969,18 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et "
-"saisissez : https://duckduckgo.com"
+"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et saisissez "
+": https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
+msgstr "Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
+msgstr "Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23227,7 +23178,7 @@ msgstr "Réactiver le son"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Discussion sans titre"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23270,7 +23221,7 @@ msgstr "Mettre à jour le navigateur"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Mets à jour Duck.ai pour voir ce chat partagé."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23590,8 +23541,7 @@ msgstr "Vous utilisez le Wi-Fi public ? Utilisez notre VPN."
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
-"Utilisez le Fire Button pour supprimer une conversation de l’historique."
+msgstr "Utilisez le Fire Button pour supprimer une conversation de l’historique."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23754,8 +23704,7 @@ msgstr "Voir les prix de votre séjour"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"DuckDuckGo protège la confidentialité lors de la consultation des publicités."
+msgstr "DuckDuckGo protège la confidentialité lors de la consultation des publicités."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23835,9 +23784,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de Duck."
-"ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser avec un "
-"autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
+"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de "
+"Duck.ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser "
+"avec un autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
 "récupération."
 
 # smartling.placeholder_format=C
@@ -24274,6 +24223,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Nous trouvons et supprimons vos informations personnelles des sites de "
+"courtiers en données. En prime, obtenez un VPN et bien plus encore."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24300,8 +24251,7 @@ msgstr "Nous avons perdu la connexion ; veuillez réessayer plus tard."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
+msgstr "Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24330,6 +24280,9 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Nous analysons régulièrement les sites de courtiers en données en "
+"recherchant vos informations personnelles et nous partageons notre "
+"progression dans un tableau de bord simple d’utilisation."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24378,6 +24331,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Nous analyserons les sites de courtiers en données en recherchant votre "
+"adresse e-mail, votre nom, votre adresse et plus encore, et nous nous "
+"efforcerons de faire supprimer tout ce que nous trouverons sur vous."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24586,8 +24542,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
+msgstr "Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24704,7 +24659,7 @@ msgstr "Quels sont les avantages et les inconvénients des rentes ?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Quels sont les avantages de Duck.ai ?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24939,8 +24894,7 @@ msgstr "À quoi cela répond-il ?"
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
-msgstr ""
-"Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
+msgstr "Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
 
 # smartling.placeholder_format=C
 #. Header above a list of types of information that gets saved by the cloud save feature.
@@ -24952,8 +24906,7 @@ msgstr "Quelles informations sont sauvegardées ?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
-"Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
+msgstr "Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -24962,8 +24915,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi est-"
-"il différent du bookmarklet avec URL de paramétrage ?"
+"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi "
+"est-il différent du bookmarklet avec URL de paramétrage ?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25289,6 +25242,9 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Fonctionne directement depuis votre appareil pour supprimer votre adresse "
+"e-mail, votre nom, votre adresse et plus encore des sites de courtiers en "
+"données."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25630,8 +25586,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
+msgstr "Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25661,8 +25616,7 @@ msgstr "Vous pouvez trouver le"
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
 msgctxt "duckai_migration"
 msgid "You can find the <b>%s</b> file in your downloads folder."
-msgstr ""
-"Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
+msgstr "Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
 
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
@@ -25805,7 +25759,7 @@ msgstr "Il vous reste 1 tentative."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Vous n'avez aucun lien de discussion partagée."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25967,8 +25921,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
+msgstr "Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -25982,8 +25935,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
+msgstr "Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26046,6 +25998,8 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Vos %1$s dernières discussions seront disponibles dans le stockage local de "
+"ces navigateurs :"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -26053,6 +26007,8 @@ msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
 msgstr ""
+"Vos discussions Duck.ai sont en cours de synchronisation avec un cryptage de "
+"bout en bout."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26084,6 +26040,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Votre sauvegarde sera supprimée du serveur de DuckDuckGo. Tous les appareils "
+"seront déconnectés de la synchronisation."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26132,8 +26090,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Votre navigateur fournit une liste des sites que vous visitez le plus."
-"DuckDuckGo n'a jamais accès à ces données."
+"Votre navigateur fournit une liste des sites que vous visitez le "
+"plus.DuckDuckGo n'a jamais accès à ces données."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -26399,8 +26357,7 @@ msgstr ""
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"Vos discussions synchronisées sont en cours de restauration sur cet appareil."
+msgstr "Vos discussions synchronisées sont en cours de restauration sur cet appareil."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26468,8 +26425,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
+msgstr "Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language

--- a/locales/ga_IE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ga_IE/LC_MESSAGES/duckduckgo.po
@@ -44,6 +44,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -402,6 +409,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -636,6 +649,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1189,6 +1207,11 @@ msgstr "Cuir le %s é"
 msgid "Add to Home Screen"
 msgstr "Cuir leis an Scáileán Baile"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Breiseáin"
@@ -1482,6 +1505,12 @@ msgstr "Gach méid"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Gach cineál"
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
@@ -1894,6 +1923,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4231,6 +4265,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4263,6 +4302,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4823,6 +4881,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4831,6 +4896,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5037,6 +5109,12 @@ msgstr "Ruaig é seo"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5685,6 +5763,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6351,9 +6435,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7448,6 +7545,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7532,6 +7636,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9130,6 +9239,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Cuir %stuilleadh%s eolas air"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9655,6 +9769,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9861,6 +9981,11 @@ msgstr "Roghchlár"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Roghchlár"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10164,6 +10289,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Tá tuilleadh ag"
@@ -10321,6 +10451,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Dearg"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11200,6 +11335,27 @@ msgstr ""
 "Ar Mac, %sBrúigh Maxthon > Preferences%s, Ar Windows, %sBrúigh an deilbhín "
 "%s > Socruithe%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11810,6 +11966,11 @@ msgstr "Le seachtain anuas"
 msgid "Past year"
 msgstr "Le bliain anuas"
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11818,6 +11979,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11863,6 +12029,18 @@ msgstr ""
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Peirsis"
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
 msgctxt "Assistant role option label for Personal trainer"
@@ -12877,6 +13055,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13026,6 +13209,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13233,6 +13421,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13266,6 +13459,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13814,6 +14017,11 @@ msgstr "Cuir do chuid socruithe i dtaisce go neamhaithnid sa scamall"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14596,6 +14804,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Seirbis (Laidineach)"
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14720,6 +14934,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14841,6 +15062,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15396,6 +15627,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16089,6 +16325,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16287,6 +16528,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16312,6 +16559,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Cianamharcaíocht"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16773,6 +17025,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16841,6 +17107,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16925,6 +17196,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17450,6 +17731,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17542,6 +17828,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17742,6 +18033,11 @@ msgstr "Tuircis"
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17750,6 +18046,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18138,6 +18439,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18165,6 +18471,11 @@ msgstr "Nuashonraigh é"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18944,6 +19255,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18978,6 +19296,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -19003,6 +19328,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19247,6 +19579,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19711,6 +20048,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20119,6 +20463,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20288,6 +20638,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Caighdeán YouTube"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20305,6 +20670,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/gd_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/gd_GB/LC_MESSAGES/duckduckgo.po
@@ -44,6 +44,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -394,6 +401,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -628,6 +641,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1181,6 +1199,11 @@ msgstr "Cuir ri %s"
 msgid "Add to Home Screen"
 msgstr "Cuir ris an sgrìn-mhòr"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Tuilleadain"
@@ -1474,6 +1497,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1884,6 +1913,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4217,6 +4251,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4249,6 +4288,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4809,6 +4867,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4817,6 +4882,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5023,6 +5095,12 @@ msgstr "Leig seachad"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5672,6 +5750,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6336,9 +6420,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7434,6 +7531,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7518,6 +7622,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9111,6 +9220,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Barrachd %sfiosrachaidh%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9630,6 +9744,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9835,6 +9955,11 @@ msgstr "An clàr-taice"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10137,6 +10262,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Barrachd aig"
@@ -10294,6 +10424,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Dearg sèimh"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11173,6 +11308,27 @@ msgstr ""
 "Air Mac, %sbriog air Maxthon » Preferences%s; air Windows, %sbriog air "
 "ìomhaigheag %s » Roghainnean%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11783,6 +11939,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11791,6 +11952,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11835,6 +12001,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12849,6 +13027,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12998,6 +13181,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13206,6 +13394,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13239,6 +13432,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13787,6 +13990,11 @@ msgstr "Sàbhail na roghainnean agad san neul gun urra"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14564,6 +14772,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14688,6 +14902,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14809,6 +15030,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15356,6 +15587,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16047,6 +16283,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16244,6 +16485,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16269,6 +16516,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "TBh"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16721,6 +16973,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16789,6 +17055,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16872,6 +17143,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17389,6 +17670,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17481,6 +17767,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17681,6 +17972,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17689,6 +17985,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18073,6 +18374,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18100,6 +18406,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18877,6 +19188,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18911,6 +19229,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18935,6 +19260,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19179,6 +19511,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19643,6 +19980,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20050,6 +20394,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20219,6 +20569,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Ceadachas YouTube stannardach"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20236,6 +20601,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/gl_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/gl_ES/LC_MESSAGES/duckduckgo.po
@@ -44,6 +44,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -399,6 +406,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -633,6 +646,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1188,6 +1206,11 @@ msgstr "Engadir a %s"
 msgid "Add to Home Screen"
 msgstr "Engadir á pantalla de inicio"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Complementos"
@@ -1480,6 +1503,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1893,6 +1922,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4226,6 +4260,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4258,6 +4297,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4818,6 +4876,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4826,6 +4891,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5032,6 +5104,12 @@ msgstr "Rexeitar"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5679,6 +5757,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6342,9 +6426,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7441,6 +7538,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7525,6 +7629,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9120,6 +9229,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Saber %smáis%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9638,6 +9752,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9844,6 +9964,11 @@ msgstr "Menú"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menú"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10145,6 +10270,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Máis en"
@@ -10302,6 +10432,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Vermello apagado"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11181,6 +11316,27 @@ msgstr ""
 "En Mac, %sPrema Maxthon > Preferencias%s, en Windows, %sprema a %sicona > "
 "Opcións%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11794,6 +11950,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11802,6 +11963,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11846,6 +12012,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12860,6 +13038,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13009,6 +13192,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13216,6 +13404,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13249,6 +13442,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13797,6 +14000,11 @@ msgstr "Garde as súas preferencias anonimamente na nube"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14578,6 +14786,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14702,6 +14916,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14822,6 +15043,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15369,6 +15600,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16058,6 +16294,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16255,6 +16496,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16280,6 +16527,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "TV"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16739,6 +16991,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16807,6 +17073,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16890,6 +17161,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17405,6 +17686,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17497,6 +17783,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17696,6 +17987,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17704,6 +18000,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18086,6 +18387,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18113,6 +18419,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18889,6 +19200,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18923,6 +19241,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18947,6 +19272,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19191,6 +19523,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19653,6 +19990,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20056,6 +20400,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20224,6 +20574,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Estándar de YouTube"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20241,6 +20606,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/gu_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/gu_IN/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -394,6 +401,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -628,6 +641,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1181,6 +1199,11 @@ msgstr "%s માં ઉમેરો"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "ઍડૉનો"
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4195,6 +4229,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4227,6 +4266,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4787,6 +4845,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4795,6 +4860,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5001,6 +5073,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5648,6 +5726,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6318,9 +6402,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7411,6 +7508,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7495,6 +7599,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9079,6 +9188,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9596,6 +9710,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9801,6 +9921,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10103,6 +10228,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10259,6 +10389,11 @@ msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
+msgstr ""
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
 msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -11137,6 +11272,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11741,6 +11897,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11749,6 +11910,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11793,6 +11959,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12807,6 +12985,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12956,6 +13139,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13163,6 +13351,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13196,6 +13389,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13744,6 +13947,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14510,6 +14718,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14634,6 +14848,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14753,6 +14974,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15300,6 +15531,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15989,6 +16225,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16186,6 +16427,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16210,6 +16457,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16663,6 +16915,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16731,6 +16997,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16814,6 +17085,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17328,6 +17609,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17420,6 +17706,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17619,6 +17910,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17627,6 +17923,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18004,6 +18305,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18031,6 +18337,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18797,6 +19108,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18831,6 +19149,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18855,6 +19180,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19099,6 +19431,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19561,6 +19898,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19961,6 +20305,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20125,6 +20475,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20142,6 +20507,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/he_IL/LC_MESSAGES/duckduckgo.po
+++ b/locales/he_IL/LC_MESSAGES/duckduckgo.po
@@ -44,6 +44,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% מחוסנים באופן חלקי"
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -394,6 +401,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -628,6 +641,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1181,6 +1199,11 @@ msgstr "הוסף אל %s"
 msgid "Add to Home Screen"
 msgstr "הוסף למסך הבית"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "תוספים"
@@ -1472,6 +1495,12 @@ msgstr "כל המידות"
 msgctxt "image-type"
 msgid "All types"
 msgstr "כל הסוגים"
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
@@ -1884,6 +1913,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4205,6 +4239,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4237,6 +4276,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4797,6 +4855,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4805,6 +4870,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5011,6 +5083,12 @@ msgstr "שחרר"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5658,6 +5736,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6320,9 +6404,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7414,6 +7511,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7498,6 +7602,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9086,6 +9195,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "למדו %sעוד%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9603,6 +9717,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9809,6 +9929,11 @@ msgstr "תפריט"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "תפריט"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10110,6 +10235,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "עוד אצל"
@@ -10267,6 +10397,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "אדום מושתק/דהוי"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11145,6 +11280,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11754,6 +11910,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11762,6 +11923,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11806,6 +11972,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12820,6 +12998,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12969,6 +13152,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13176,6 +13364,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13209,6 +13402,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13757,6 +13960,11 @@ msgstr "שמור את ההגדרות שלך באופן אנונימי על הע�
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14526,6 +14734,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14650,6 +14864,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14769,6 +14990,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15316,6 +15547,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16005,6 +16241,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16202,6 +16443,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16227,6 +16474,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "טלוויזיה"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16679,6 +16931,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16747,6 +17013,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16830,6 +17101,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17344,6 +17625,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17436,6 +17722,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17635,6 +17926,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17643,6 +17939,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18023,6 +18324,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18050,6 +18356,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18818,6 +19129,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18852,6 +19170,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18876,6 +19201,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19120,6 +19452,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19582,6 +19919,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19984,6 +20328,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20150,6 +20500,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "הסטנדרטי של YouTube"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20167,6 +20532,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hi_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% पूरी तरह से टीकाकरण किया ग�
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% टीकाकरण किया गया"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -182,9 +190,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
-"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
-"स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
+"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -194,9 +201,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
-"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
-"स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
+"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -212,9 +218,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस "
-"ब्राउज़र में अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
-"पर स्विच करें।"
+"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -223,8 +228,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में "
-"फिर से कोशिश करें।"
+"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में फिर से कोशिश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -300,9 +305,7 @@ msgstr "%1$s रैंकिंग अभी तक उपलब्ध नही
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता है। "
-"%2$s"
+msgstr "%1$s बेसिक मॉडलों की तुलना में 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता है। %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -323,9 +326,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल "
-"प्रोवाइडर भी आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस "
-"चैट को अपने सर्वर पर सेव कर सकता है।"
+"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल प्रोवाइडर भी "
+"आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस चैट को अपने सर्वर पर सेव "
+"कर सकता है।"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -373,8 +376,7 @@ msgstr "%1$s उपयोग किया गया"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
-"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना तक तेज़ी से लिमिट्स का इस्तेमाल करता "
-"है %2$s"
+"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना तक तेज़ी से लिमिट्स का इस्तेमाल करता है %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -413,8 +415,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी "
-"रखने के लिए मॉडल बदल सकते हैं।"
+"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी रखने "
+"के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -425,8 +427,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को "
-"जारी रखने के लिए मॉडल बदल सकते हैं।"
+"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को जारी रखने के "
+"लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -439,8 +441,8 @@ msgstr "%1$s शब्द"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, "
-"फिर %6$sठीक हैं%7$s पर क्लिक करें"
+"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, फिर %6$sठीक "
+"हैं%7$s पर क्लिक करें"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -448,8 +450,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
-"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति दें%7$s पर "
+"निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -459,8 +461,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें "
-"%6$sअनुमति दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
+"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -489,21 +491,26 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sजानें कि हम आपका स्‍थान कैसे गोपनीय रखते हैं%2$s।"
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर "
-"किया जाता है।"
+"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर "
-"जानें।%2$s"
+"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर जानें।%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -515,9 +522,7 @@ msgstr "होम स्क्रीन पर DuckDuckGo ऐप आइकन �
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से "
-"कोशिश करें।"
+msgstr "%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -781,6 +786,12 @@ msgid "2nd in Group %s"
 msgstr "ग्रुप %1$s में दूसरा"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -862,9 +873,7 @@ msgstr "6 घंटे की उपयोग सीमा पूरी हो �
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
-"हैं।"
+msgstr "6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -872,8 +881,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके "
-"चैटिंग जारी रख सकते हैं।"
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके चैटिंग जारी रख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -927,26 +936,22 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना "
-"कनेक्शन जांचें और फिर से कोशिश करें।"
+"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना कनेक्शन "
+"जांचें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
-"करें।"
+msgstr "AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
-"करें।"
+msgstr "Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -990,10 +995,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
-"सुविधा देता है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप "
-"जाएगा। जब यह सेटिंग बंद हो तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI "
-"Chat का उपयोग कर सकते हैं।"
+"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा देता "
+"है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप जाएगा। जब यह सेटिंग बंद हो "
+"तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI Chat का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1054,10 +1058,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते "
-"हैं। हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और "
-"अक्सर उससे लिंक करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और "
-"Anthropic, और अन्य के चैट मॉडलों को सपोर्ट करती है।"
+"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते हैं। "
+"हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और अक्सर उससे लिंक "
+"करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और Anthropic, और अन्य के चैट "
+"मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1242,8 +1246,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या "
-"किसी मुफ़्त मॉडल पर स्विच करें।"
+"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
+"पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1279,8 +1283,8 @@ msgstr "विज्ञापन"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका "
-"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग आपकी "
+"व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1288,8 +1292,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और "
-"इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग "
+"आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1340,8 +1344,7 @@ msgstr "DuckDuckGo एक्सटेंशन जोड़ें"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials "
-"जोड़ें:"
+"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials जोड़ें:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1468,6 +1471,12 @@ msgid "Add to Home Screen"
 msgstr "होम स्क्रीन पर जोड़े"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "एड-ऑन"
@@ -1569,8 +1578,7 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2–5 गुना तेज़ी से उपयोग सीमा तक पहुंच "
-"सकते हैं। %1$s"
+"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2–5 गुना तेज़ी से उपयोग सीमा तक पहुंच सकते हैं। %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1579,8 +1587,7 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
-"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2-5 गुना तेज़ी से लिमिट का इस्तेमाल "
-"कर सकते हैं। %1$s"
+"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2-5 गुना तेज़ी से लिमिट का इस्तेमाल कर सकते हैं। %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1622,9 +1629,7 @@ msgstr "जैसे ही वह डाउनलोड होकर खुल�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल "
-"क्लिक करें"
+msgstr "डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल क्लिक करें"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1761,8 +1766,8 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "सभी चैट DuckDuckGo द्वारा अनाम कर दी जाती हैं, और आपकी बातचीत का इस्तेमाल "
-"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं "
-"किया जाता है"
+"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं किया "
+"जाता है"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1795,8 +1800,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से "
-"रोका गया है।"
+"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से रोका गया "
+"है।"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1811,8 +1816,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) "
-"हटा दिया जाता है।"
+"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) हटा दिया "
+"जाता है।"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1833,6 +1838,13 @@ msgid "All types"
 msgstr "सभी प्रकार"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1844,8 +1856,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन "
-"एक्सेस की अनुमति दें।"
+"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन एक्सेस की अनुमति "
+"दें।"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1868,8 +1880,7 @@ msgstr "इस चैट के लिए गुमनाम फ़ाइल र
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
 msgstr ""
-"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को "
-"अनुमति दें"
+"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को अनुमति दें"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1879,10 +1890,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स "
-"के जवाबों को बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही "
-"भेजता है, जिनमें डेटा रिटेंशन की लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स "
-"और जवाबों पर अभी भी %3$sप्रोवाइडर की विज़िबिलिटी शून्य%4$s रहती है।"
+"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स के जवाबों को "
+"बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही भेजता है, जिनमें डेटा रिटेंशन की "
+"लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स और जवाबों पर अभी भी %3$sप्रोवाइडर की "
+"विज़िबिलिटी शून्य%4$s रहती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1890,8 +1901,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता "
-"है (Cloud Save का उपयोग करने के लिए आवश्यक है)"
+"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता है (Cloud "
+"Save का उपयोग करने के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2029,8 +2040,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
-"%3$s और %4$s शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
+"शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2039,8 +2050,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
-"%3$s और %4$s शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
+"शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2054,8 +2065,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। "
-"चुनें कि इसे कितनी बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
+"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। चुनें कि इसे कितनी "
+"बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2102,8 +2113,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे "
-"बतख संबंधी तथ्य बताएं"
+"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे बतख संबंधी "
+"तथ्य बताएं"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2203,8 +2214,8 @@ msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
 msgstr ""
-"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा "
-"नहीं किया जा सकता।"
+"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा नहीं किया "
+"जा सकता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2225,8 +2236,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, "
-"जिनमें पिन की गई चैट्स भी शामिल हैं।"
+"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, जिनमें पिन "
+"की गई चैट्स भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2235,8 +2246,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी "
-"चैट को भी डिलीट कर देगा।"
+"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी चैट को भी "
+"डिलीट कर देगा।"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2274,8 +2285,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा "
-"नहीं करते हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
+"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा नहीं करते "
+"हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2356,6 +2367,12 @@ msgid "Ask anything privately"
 msgstr "गोपनीय रूप से कुछ भी पूछें"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2411,13 +2428,12 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ "
-"खोजों के लिए गुमनाम रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन "
-"सकते हैं कि Assist को कितनी बार दिखाना है: कभी नहीं (यह खोज परिणामों से "
-"Assist के UI को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप "
-"'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे "
-"बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फिलहाल, AI "
-"की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
+"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ खोजों के लिए गुमनाम "
+"रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन सकते हैं कि Assist को कितनी बार "
+"दिखाना है: कभी नहीं (यह खोज परिणामों से Assist के UI को पूरी तरह हटा देता है), ऑन-"
+"डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ "
+"तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता "
+"है)। फिलहाल, AI की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2429,12 +2445,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, "
-"खोज संबंधी क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, "
-"यह वेब को स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री "
-"से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित "
-"नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद रखना ज़रूरी है कि "
-"जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
+"क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके "
+"क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम "
+"शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद "
+"रखना ज़रूरी है कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
 "आधारित होते हैं।"
 
 # smartling.placeholder_format=C
@@ -2461,8 +2476,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"कैफ़े, एयरपोर्ट या होटल में, DuckDuckGo VPN आपके कनेक्शन को एन्क्रिप्ट करता "
-"है और वाई-फ़ाई पर आपके IP एड्रेस को छिपाता है।"
+"कैफ़े, एयरपोर्ट या होटल में, DuckDuckGo VPN आपके कनेक्शन को एन्क्रिप्ट करता है और वाई-फ़ाई "
+"पर आपके IP एड्रेस को छिपाता है।"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2537,8 +2552,8 @@ msgstr "चैट खत्म होने के बाद ऑडियो ह
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
 msgstr ""
-"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर "
-"नहीं किया जाता है।"
+"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर नहीं किया जाता "
+"है।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2580,16 +2595,14 @@ msgstr "स्वत: उत्तर"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां "
-"हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में "
-"अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में अशुद्धियां हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2614,9 +2627,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, "
-"जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता "
-"है। फिलहाल, Assist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, जानकारी को "
+"गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता है। फिलहाल, Assist केवल "
+"अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2625,17 +2638,15 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए "
-"DuckAssist जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल "
-"DuckAssist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए DuckAssist "
+"जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल DuckAssist केवल अंग्रेज़ी "
+"क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू "
-"ऑटोप्ले करें।"
+msgstr "वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू ऑटोप्ले करें।"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2835,9 +2846,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस "
-"और पहचान बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर "
-"उसे अनाम बना देगा।"
+"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस और पहचान "
+"बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर उसे अनाम बना देगा।"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2967,8 +2977,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"हमारे सब्सक्रिप्शन के माध्यम से हानिकारक साइटों को ब्लॉक करें, अपना IP "
-"एड्रेस छिपाएं, और ज़्यादा प्रीमियम सुरक्षा पाएं।"
+"हमारे सब्सक्रिप्शन के माध्यम से हानिकारक साइटों को ब्लॉक करें, अपना IP एड्रेस छिपाएं, और "
+"ज़्यादा प्रीमियम सुरक्षा पाएं।"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3228,18 +3238,16 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने "
-"खोज इंजन, ट्रैकर ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s "
-"एक्सटेंशन%3$s में बंडल किया है।"
+"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने खोज इंजन, ट्रैकर "
+"ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल किया है।"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज "
-"इंजन, ट्रैकर ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s "
-"में बंडल कर दिया है।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज इंजन, ट्रैकर "
+"ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल कर दिया है।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3247,9 +3255,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख "
-"ब्राउज़र्स%2$s के लिए गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, "
-"सब कुछ एक ही डाउनलोड में।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख ब्राउज़र्स%2$s के लिए "
+"गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, सब कुछ एक ही डाउनलोड में।"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3356,11 +3363,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र "
-"में) में संग्रहित किया जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से "
-"(क्लाउड में रिमोट सर्वर पर) संग्रहित करने के लिए अनाम क्लाउड सेव का उपयोग कर "
-"सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी जानकारी क्लाउड में संग्रहित "
-"नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं होगा।"
+"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र में) में संग्रहित किया "
+"जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से (क्लाउड में रिमोट सर्वर पर) संग्रहित "
+"करने के लिए अनाम क्लाउड सेव का उपयोग कर सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी "
+"जानकारी क्लाउड में संग्रहित नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं "
+"होगा।"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3368,8 +3375,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
-"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
+"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3378,8 +3385,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
-"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
+"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3715,9 +3722,7 @@ msgstr "यूआरएल के दिखाई देने का तरी�
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर "
-"देता है"
+msgstr "जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर देता है"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3865,11 +3870,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के "
-"साथ गुमनाम ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि "
-"मॉडलों को सपोर्ट करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat "
-"बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर भी आप "
-"%1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Chat का इस्तेमाल कर सकते हैं।"
+"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम "
+"ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि मॉडलों को सपोर्ट "
+"करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat बटन और लिंक छिप जाएंगे। "
+"हालांकि, यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
+"Chat का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3925,8 +3930,7 @@ msgstr "गोपनीय ढंग से चैट करें"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय "
-"ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3934,8 +3938,7 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय "
-"ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4004,8 +4007,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर "
-"स्टोर की जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
+"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर स्टोर की "
+"जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4017,11 +4020,10 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
-"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते "
-"हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट "
-"हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और "
-"रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए "
+"जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
+"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई "
+"चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4044,9 +4046,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर "
-"अपलोड की गई सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर "
-"द्वारा गुमनाम रूप से किया जाता है।"
+"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर अपलोड की गई "
+"सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर द्वारा गुमनाम रूप से किया "
+"जाता है।"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4054,8 +4056,7 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए "
-"स्टोरेज खाली करें।"
+"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए स्टोरेज खाली करें।"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4211,8 +4212,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"हानिकारक साइटों और स्कैम को ब्लॉक करने में मदद के लिए दुनिया भर में 40+ "
-"सर्वर लोकेशन में से चुनें।"
+"हानिकारक साइटों और स्कैम को ब्लॉक करने में मदद के लिए दुनिया भर में 40+ सर्वर लोकेशन में से "
+"चुनें।"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4230,8 +4231,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस "
-"ऐप का इस्तेमाल करना है"
+"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस ऐप का "
+"इस्तेमाल करना है"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4412,9 +4413,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को "
-"लंबे समय तक रख सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर "
-"उन्हें ऑटो-डिलीट कर सकते हैं।"
+"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को लंबे समय तक रख "
+"सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर उन्हें ऑटो-डिलीट कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4424,9 +4424,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए "
-"बिना, हाल की चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के "
-"बाद अपने-आप हटाया जा सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
+"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए बिना, हाल की "
+"चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के बाद अपने-आप हटाया जा "
+"सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4435,8 +4435,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी "
-"ब्लॉक लिस्ट को हमेशा के लिए सेव करें"
+"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी ब्लॉक लिस्ट को "
+"हमेशा के लिए सेव करें"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4445,9 +4445,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप "
-"प्रश्न %1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो "
-"OpenAI, Anthropic और अन्य के चैट मॉडलों को सपोर्ट करती है।"
+"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप प्रश्न "
+"%1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो OpenAI, Anthropic "
+"और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4489,8 +4489,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > "
-"प्राथमिकताएं%4$s (Mac पर) क्लिक करें"
+"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > प्राथमिकताएं%4$s "
+"(Mac पर) क्लिक करें"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4506,9 +4506,7 @@ msgstr "DuckDuckGo एकस्टेंशन को डाउनलोड क�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक "
-"करें"
+msgstr "DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक करें"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4523,8 +4521,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर "
-"%3$sगियर आइकन%4$s पर क्लिक करें)"
+"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर %3$sगियर "
+"आइकन%4$s पर क्लिक करें)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4541,9 +4539,7 @@ msgstr "ड्रॉपडाउन में %1$sसेटिंग्स%2$s �
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s "
-"करें।"
+msgstr "%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s करें।"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4556,8 +4552,7 @@ msgstr "%1$sहां%2$s पर क्लिक करें"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक "
-"करें"
+"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक करें"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4619,9 +4614,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा "
-"हटा देता है, लेकिन यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी "
-"खोज सेटिंग रीसेट करें%4$s पर क्लिक/टैप नहीं कर देते।"
+"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटा देता है, लेकिन "
+"यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी खोज सेटिंग रीसेट करें%4$s पर "
+"क्लिक/टैप नहीं कर देते।"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4632,9 +4627,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता "
-"है, लेकिन यह आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स "
-"रीसेट%4$s पर क्लिक/टैप नहीं करते।"
+"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता है, लेकिन यह "
+"आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स रीसेट%4$s पर क्लिक/टैप नहीं करते।"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4703,8 +4697,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर "
-"क्लिक करें और %3$sDuckDuckGo%4$s चुनें।"
+"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर क्लिक करें और "
+"%3$sDuckDuckGo%4$s चुनें।"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4712,8 +4706,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र "
-"के ऊपरी दाएं कोने में होता है।"
+"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र के ऊपरी दाएं "
+"कोने में होता है।"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4914,8 +4908,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा "
-"सुरक्षित रख सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
+"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा सुरक्षित रख "
+"सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5290,6 +5284,12 @@ msgid "Copy"
 msgstr "कॉपी करें"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5329,6 +5329,28 @@ msgstr "इस कोड को कॉपी या सेव करें"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "रिकवरी कोड कॉपी करें"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5720,8 +5742,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट "
-"करना जारी रख सकते हैं।"
+"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट करना "
+"जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6006,6 +6028,14 @@ msgid "Delete recent chats?"
 msgstr "हालिया चैट डिलीट करें?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6016,6 +6046,14 @@ msgstr "इस चैट को डिलीट करें?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "डिलीट की गई चैट"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6112,8 +6150,8 @@ msgstr "Duck.ai में डिक्टेशन"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
-"के लिए नहीं किया जाता है।"
+"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए नहीं "
+"किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6131,8 +6169,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता "
-"है, ताकि आप बिना टाइप किए भी Duck.ai में चैट कर सकें।"
+"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता है, ताकि आप "
+"बिना टाइप किए भी Duck.ai में चैट कर सकें।"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6271,6 +6309,13 @@ msgstr "निरस्त करें"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "खारिज करें"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6444,8 +6489,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा "
-"नहीं है और AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा नहीं है और "
+"AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6454,8 +6499,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI "
-"फ़ीचर्स और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI फ़ीचर्स "
+"और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6571,8 +6616,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
-"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
+"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
+"जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6581,8 +6626,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
-"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
+"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
+"जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6603,8 +6648,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी "
-"में लोगों को आमंत्रित करने के लिए है।"
+"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी में लोगों को "
+"आमंत्रित करने के लिए है।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6613,8 +6658,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग "
-"बढ़ाने की मेरी रणनीतियों के बारे में लिखना है।"
+"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग बढ़ाने की मेरी "
+"रणनीतियों के बारे में लिखना है।"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6746,9 +6791,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। "
-"पेज का कंटेंट तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग "
-"में पेजों को ऑटोमैटिकली अटैच करने का विकल्प न चुना हो।"
+"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। पेज का कंटेंट "
+"तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग में पेजों को ऑटोमैटिकली अटैच "
+"करने का विकल्प न चुना हो।"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6758,9 +6803,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। "
-"कृपया अपनी ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) "
-"करें और फिर से कोशिश करें।"
+"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। कृपया अपनी "
+"ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6769,8 +6813,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस "
-"चैट को अब कल जारी रखें।"
+"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस चैट को अब "
+"कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -6786,9 +6830,8 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन "
-"कंपनी हैं, जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने "
-"हाथ में लेना चाहते हैं।"
+"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन कंपनी हैं, "
+"जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने हाथ में लेना चाहते हैं।"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6803,8 +6846,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी "
-"आसान होगा: https://duck.ai"
+"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी आसान "
+"होगा: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6819,8 +6862,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम "
-"कोड %1$s को %2$s पर ईमेल करें"
+"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम कोड "
+"%1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6841,9 +6884,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता "
-"है। इसे बंद करने से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी "
-"%1$sduck.ai%2$s पर जा सकते हैं सीधे ही।"
+"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता है। इसे बंद करने "
+"से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी %1$sduck.ai%2$s पर जा सकते हैं "
+"सीधे ही।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6854,11 +6897,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
-"सुविधा मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग "
-"को बंद करने से DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, "
-"यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
-"Duck.ai का इस्तेमाल कर सकते हैं।"
+"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा "
+"मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग को बंद करने से "
+"DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर "
+"भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Duck.ai का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6873,8 +6915,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी "
-"रख सकते हैं।"
+"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी रख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6888,8 +6930,8 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता "
-"संबंधी कोई जांच नहीं होती है।"
+"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता संबंधी कोई जांच "
+"नहीं होती है।"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -6923,9 +6965,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, "
-"बिना साइन अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, "
-"गोपनीयता केंद्रित AI, बिना खाता AI चैट"
+"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, बिना साइन "
+"अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, गोपनीयता "
+"केंद्रित AI, बिना खाता AI चैट"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6953,13 +6995,12 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके "
-"बारे में खास जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार "
-"दिखाना है: कभी नहीं (यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा "
-"देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते "
-"हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई "
-"तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, DuckAssist सिर्फ़ अमेरिका "
-"(अंग्रेज़ी) में उपलब्ध है।"
+"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास "
+"जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार दिखाना है: कभी नहीं "
+"(यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी "
+"दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब "
+"नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, "
+"DuckAssist सिर्फ़ अमेरिका (अंग्रेज़ी) में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6969,8 +7010,8 @@ msgid ""
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा "
-"है जो OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
+"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा है जो "
+"OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6980,8 +7021,8 @@ msgid ""
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा "
-"है जो OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
+"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा है जो "
+"OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6993,12 +7034,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज "
-"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और "
-"संबंधित साइटों को स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे "
-"जुड़ी खास जानकारी को जनरेट करने के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी "
-"का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल इसके जवाब Wikipedia और "
-"संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं की जाती है।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
+"क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और संबंधित साइटों को "
+"स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे जुड़ी खास जानकारी को जनरेट करने "
+"के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल "
+"इसके जवाब Wikipedia और संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं "
+"की जाती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7012,15 +7053,13 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम "
-"रहकर, खोज संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को "
-"स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी "
-"जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल "
-"लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा एक या दो "
-"स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, "
-"ताकि आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है "
-"कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
-"आधारित होते हैं।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज "
+"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके क्वेरी से जुड़ी "
+"सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने "
+"के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा "
+"एक या दो स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, ताकि "
+"आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है कि जवाब, दूसरे "
+"स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर आधारित होते हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7028,8 +7067,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते "
-"हैं और इनकी सटीकता की जांच नहीं की जाती है।"
+"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते हैं और इनकी "
+"सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7038,8 +7077,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। "
-"कृपया इस चैट को अब कल जारी रखें।"
+"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। कृपया इस चैट को "
+"अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7048,8 +7087,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
-"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
+"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7058,8 +7097,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
-"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
+"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7068,8 +7107,7 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे "
-"सकती है।"
+"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7078,8 +7116,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो "
-"कृपया इस अनाम कोड %1$s को %2$s पर ईमेल करें"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस "
+"अनाम कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7088,8 +7126,7 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से "
-"कोशिश करें।"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7122,6 +7159,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo ब्राउज़र %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7238,9 +7282,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी "
-"मेटाडेटा जैसी व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को "
-"एनोनिमाइज़ कर देता है।"
+"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी मेटाडेटा जैसी "
+"व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को एनोनिमाइज़ कर देता है।"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7248,8 +7291,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की "
-"%2$s से सहमत होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की %2$s से "
+"सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7258,8 +7301,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से "
-"सहमत होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से सहमत "
+"होते हैं।"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7268,9 +7311,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता "
-"है, जिसमें Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर "
-"आपको अन्य वेबसाइटों पर ट्रैक करने की कोशिश करते हैं।"
+"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता है, जिसमें "
+"Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर आपको अन्य वेबसाइटों पर "
+"ट्रैक करने की कोशिश करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7282,12 +7325,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो "
-"यह केवल आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो "
-"आपकी डिवाइस उसे हमें भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर "
-"बनाने के लिए करते हैं और फिर हम तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही "
-"रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने इस तकनीक को कैसे डिज़ाइन "
-"किया है, इसके बारे में और जानें%2$s।"
+"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो यह केवल "
+"आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो आपकी डिवाइस उसे हमें "
+"भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर बनाने के लिए करते हैं और फिर हम "
+"तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने "
+"इस तकनीक को कैसे डिज़ाइन किया है, इसके बारे में और जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7307,8 +7349,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक "
-"के बेहतर परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
+"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक के बेहतर "
+"परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7400,10 +7442,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक "
-"शब्दों की लंबी सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों "
-"का चयन करते हैं, यह सुनिश्चित करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर "
-"लंबा है।"
+"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक शब्दों की लंबी "
+"सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों का चयन करते हैं, यह सुनिश्चित "
+"करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर लंबा है।"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7474,8 +7515,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब "
-"तैयार होगा।"
+"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब तैयार "
+"होगा।"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7613,8 +7654,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना "
-"विचार बदल सकते हैं।"
+"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना विचार बदल सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7657,9 +7698,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते "
-"हैं, लेकिन फिर भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते "
-"हैं।"
+"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते हैं, लेकिन फिर "
+"भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते हैं।"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7821,8 +7861,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह "
-"आपके नए पासफ्रेज़ के तहत आपके डेटा को बचाएगा।"
+"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह आपके नए पासफ्रेज़ के "
+"तहत आपके डेटा को बचाएगा।"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7848,8 +7888,8 @@ msgstr "टेक्स्ट डालें"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s "
-"उपनाम %6$s: d%7$s"
+"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s उपनाम "
+"%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7950,14 +7990,29 @@ msgstr "मैप का विस्तार करें"
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
-"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी "
-"की सचमुच परवाह है।"
+"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी की सचमुच "
+"परवाह है।"
+
+# smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "समय-सीमा समाप्त"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8220,8 +8275,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार "
-"संंबंधी कार्यों में मदद मिलती है।"
+"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार संंबंधी कार्यों में मदद "
+"मिलती है।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8230,9 +8285,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की "
-"कोशिश में मदद मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे "
-"आपने शेयर किया है।"
+"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की कोशिश में मदद "
+"मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे आपने शेयर किया है।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8240,8 +8294,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी "
-"वेबसाइट में कॉपी पेस्ट करें।"
+"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी वेबसाइट में कॉपी "
+"पेस्ट करें।"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8330,9 +8384,7 @@ msgstr "इमेज खोज परिणामों से AI-जनरे�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
-"इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर "
-"जानें%2$s"
+msgstr "इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर जानें%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8410,9 +8462,7 @@ msgstr "अपने नज़दीक के परिणामों को �
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती "
-"है।"
+msgstr "अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती है।"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8476,8 +8526,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई "
-"मेन्यू विकल्प चुनें या कोई बटन क्लिक करें।"
+"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई मेन्यू विकल्प चुनें "
+"या कोई बटन क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8625,8 +8675,8 @@ msgstr "व्यावसायिक रूप से शेयर और उ�
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
 msgstr ""
-"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट "
-"नहीं की जाएंगी।"
+"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट नहीं की "
+"जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8707,8 +8757,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट "
-"देखें...</strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
+"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट देखें...</"
+"strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8994,14 +9044,15 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"प्राप्त करें DuckDuckGo VPN, एडवांस्ड Duck.ai, Personal Info Removal, और "
-"Identity Theft Restoration."
+"प्राप्त करें DuckDuckGo VPN, एडवांस्ड Duck.ai, Personal Info Removal, और Identity "
+"Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "DuckDuckGo VPN, एडवांस्ड Duck.ai, और Identity Theft Restoration प्राप्त करें।"
+msgstr ""
+"DuckDuckGo VPN, एडवांस्ड Duck.ai, और Identity Theft Restoration प्राप्त करें।"
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9081,8 +9132,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, Personal Info Removal, और Identity "
-"Theft Restoration पाएं।"
+"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, Personal Info Removal, और Identity Theft "
+"Restoration पाएं।"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9091,8 +9142,7 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, और Identity Theft Restoration "
-"प्राप्त करें।"
+"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, और Identity Theft Restoration प्राप्त करें।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9101,9 +9151,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस "
-"प्राप्त करें, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल "
-"हैं।"
+"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस प्राप्त करें, जिसमें "
+"हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9114,9 +9163,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo "
-"सब्सक्रिप्शन के साथ, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी "
-"शामिल हैं।"
+"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo सब्सक्रिप्शन के साथ, "
+"जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9160,8 +9208,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"हमारा तेज़, नो-लॉग VPN पाएं, साथ ही ज़्यादा चैट लिमिट वाले एडवांस्ड AI मॉडल "
-"का ऑप्शनल एक्सेस और कई प्रीमियम प्रोटेक्शन भी पाएं।"
+"हमारा तेज़, नो-लॉग VPN पाएं, साथ ही ज़्यादा चैट लिमिट वाले एडवांस्ड AI मॉडल का ऑप्शनल "
+"एक्सेस और कई प्रीमियम प्रोटेक्शन भी पाएं।"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9222,8 +9270,7 @@ msgstr "ऐप प्राप्त करें"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"DuckDuckGo ब्राउज़र मुफ़्त में डाउनलोड करें और %1$sYouTube पर विज्ञापन ब्लॉक "
-"करें।%2$s"
+"DuckDuckGo ब्राउज़र मुफ़्त में डाउनलोड करें और %1$sYouTube पर विज्ञापन ब्लॉक करें।%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9245,9 +9292,7 @@ msgstr "यह गाना यहां पाएंः"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr ""
-"आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद "
-"करें!"
+msgstr "आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद करें!"
 
 # smartling.placeholder_format=C
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
@@ -9284,9 +9329,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में "
-"जाएं और %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › "
-"टेक्स्ट कोड कॉपी करें%4$sपर जाएं"
+"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › टेक्स्ट कोड कॉपी "
+"करें%4$sपर जाएं"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9295,8 +9340,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
-"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
+"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9306,9 +9351,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
-"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और "
-"इस कोड को स्कैन करें:"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
+"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और इस कोड को स्कैन करें:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9318,9 +9362,17 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
-"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या "
-"अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
+"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या अपनी रिकवरी PDF "
+"पर मौजूद QR कोड स्कैन करें।"
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9335,8 +9387,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि "
-"\"स्थान सेवाएं\" चालू है।"
+"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि \"स्थान "
+"सेवाएं\" चालू है।"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9345,8 +9397,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे "
-"स्क्रॉल करके %3$sDuckDuckGo%4$s पर जाएं।"
+"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे स्क्रॉल करके "
+"%3$sDuckDuckGo%4$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9431,6 +9483,12 @@ msgstr "समझ आ गया"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "समझ गया"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10029,8 +10087,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist "
-"उत्तरों में मुख्य तथ्यों को हाइलाइट करता है।"
+"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist उत्तरों में मुख्य "
+"तथ्यों को हाइलाइट करता है।"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10057,8 +10115,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s "
-"दबाएं%3$s। %4$sफिर %5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
+"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s दबाएं%3$s। %4$sफिर "
+"%5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10072,8 +10130,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा "
-"गोपनीयता संरक्षण खो देंगे।"
+"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा गोपनीयता "
+"संरक्षण खो देंगे।"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10123,8 +10181,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते "
-"हैं और इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं और इनका "
+"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10266,8 +10324,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह "
-"व्यवहारकुशलता से बात करनी चाहिए और क्या कहना चाहिए?"
+"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह व्यवहारकुशलता से "
+"बात करनी चाहिए और क्या कहना चाहिए?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10389,8 +10447,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ "
-"कौन-सी हैं और क्यों?"
+"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ कौन-सी हैं और "
+"क्यों?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10425,8 +10483,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट "
-"> 'स्थान और गोपनीयता रीसेट करें' पर जाएं%2$s।"
+"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट > 'स्थान और "
+"गोपनीयता रीसेट करें' पर जाएं%2$s।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10436,9 +10494,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > "
-"सेटिंग्‍स > साइट सेटिंग्स > स्थान%2$s पर जाएं, और सुनिश्चित करें कि "
-"DuckDuckGo को स्थान एक्सेस की अनुमति है।"
+"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > सेटिंग्‍स > साइट सेटिंग्स "
+"> स्थान%2$s पर जाएं, और सुनिश्चित करें कि DuckDuckGo को स्थान एक्सेस की अनुमति है।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10453,8 +10510,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज "
-"इंजन%4$s की सूची में जोड़ना होगा"
+"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज इंजन%4$s "
+"की सूची में जोड़ना होगा"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10463,8 +10520,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, "
-"तो आप सीधे %1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
+"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, तो आप सीधे "
+"%1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10473,17 +10530,15 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर "
-"करने के लिए आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के "
-"रूप में अपने डिवाइस पर सेव कर सकते हैं।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर करने के लिए "
+"आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के रूप में अपने डिवाइस पर सेव "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें "
-"%2$s"
+msgstr "अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें %2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10493,17 +10548,15 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे "
-"%1$s या %2$s संस्करणों का उपयोग करें।"
+"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे %1$s या "
+"%2$s संस्करणों का उपयोग करें।"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ "
-"खोलें)"
+msgstr "अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ खोलें)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10632,8 +10685,7 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में "
-"सुधार करता है"
+"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में सुधार करता है"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10646,8 +10698,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों "
-"को रीडायरेक्ट करना आवश्यक है। %1$sऔर जानें%2$s।"
+"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों को रीडायरेक्ट करना "
+"आवश्यक है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10658,8 +10710,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य "
-"डिवाइस के साथ सिंक करें” चुनें।"
+"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य डिवाइस के "
+"साथ सिंक करें” चुनें।"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10674,8 +10726,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते "
-"हैं कि हम क्या जानकारी संग्रहित करते हैं।"
+"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते हैं कि हम क्या "
+"जानकारी संग्रहित करते हैं।"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11011,9 +11063,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश "
-"बताएं।"
+msgstr "क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश बताएं।"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11064,8 +11114,7 @@ msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा "
-"बार) ठीक है"
+"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा बार) ठीक है"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11084,10 +11133,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और "
-"Microsoft के विज्ञापन नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे "
-"मर्चेंट लैंडिंग पेज पर ले जाते हैं और विज्ञापनों के विपरीत, DuckDuckGo को इन "
-"परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
+"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और Microsoft के विज्ञापन "
+"नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे मर्चेंट लैंडिंग पेज पर ले जाते हैं और "
+"विज्ञापनों के विपरीत, DuckDuckGo को इन परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11096,8 +11144,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और "
-"अधिक सुरक्षित भी है।"
+"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और अधिक सुरक्षित "
+"भी है।"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11403,6 +11451,12 @@ msgid "Learn %sMore%s"
 msgstr "%1$sज़्यादा%2$s जानें"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11576,8 +11630,7 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"यह आपको Duck.ai पर सर्च क्वेरी और प्रॉम्प्ट सबमिट करने के बीच स्विच करने की "
-"सुविधा देता है"
+"यह आपको Duck.ai पर सर्च क्वेरी और प्रॉम्प्ट सबमिट करने के बीच स्विच करने की सुविधा देता है"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11669,9 +11722,7 @@ msgstr "लिंक्स:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी "
-"लिस्ट दें।"
+msgstr "इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी लिस्ट दें।"
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12036,6 +12087,13 @@ msgid "Manage"
 msgstr "मैनेज करें"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12287,6 +12345,12 @@ msgid "Menu"
 msgstr "मेनू"
 
 # smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
 msgstr "मैट्रिक (किलोग्राम, मीटर, सेल्सियस)"
@@ -12315,8 +12379,8 @@ msgstr "माइक्रोनेशिया"
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
 msgstr ""
-"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की "
-"अनुमति दें और फिर से प्रयास करें।"
+"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की अनुमति दें और फिर "
+"से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12655,6 +12719,12 @@ msgid "More about Duck.ai"
 msgstr "Duck.ai के बारे में और भी"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "ज्यादा जानकारी यहां"
@@ -12847,6 +12917,12 @@ msgstr "म्यूट किया"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "म्यूटेड रेड"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13088,11 +13164,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और "
-"अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
-"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से "
-"पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी "
-"स्टोरेज भी बंद हो जाएगा।"
+"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से "
+"DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को "
+"रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और "
+"नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13914,8 +13989,32 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s "
-"आइकन > सेटिंग्स%5$s पर क्लिक करें"
+"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s आइकन "
+"> सेटिंग्स%5$s पर क्लिक करें"
+
+# smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13943,8 +14042,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया "
-"%1$s पेज या उससे कम वाली फ़ाइलें अपलोड करें।"
+"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया %1$s पेज या उससे "
+"कम वाली फ़ाइलें अपलोड करें।"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13971,8 +14070,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल "
-"पैरामीटर%2$s पेज पर है।"
+"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल पैरामीटर%2$s पेज "
+"पर है।"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13987,8 +14086,7 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में "
-"फिर से प्रयास करें।"
+"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14311,8 +14409,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में "
-"हो। हम आपको — अवधि में ट्रैक नहीं करते हैं।"
+"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में हो। हम आपको — "
+"अवधि में ट्रैक नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14326,8 +14424,8 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"हमारा तेज़, नो-लॉग VPN ज़्यादा लिमिट वाले स्मार्ट AI चैट्स और ज़्यादा "
-"प्रीमियम प्रोटेक्शन के साथ आता है। सब कुछ एक ही सब्सक्रिप्शन में।"
+"हमारा तेज़, नो-लॉग VPN ज़्यादा लिमिट वाले स्मार्ट AI चैट्स और ज़्यादा प्रीमियम प्रोटेक्शन के "
+"साथ आता है। सब कुछ एक ही सब्सक्रिप्शन में।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14335,8 +14433,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर "
-"नहीं करते हैं।"
+"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर नहीं "
+"करते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14344,8 +14442,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, "
-"एनक्रिप्शन एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
+"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, एनक्रिप्शन "
+"एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14598,8 +14696,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, "
-"ब्राउज़र फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
+"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, ब्राउज़र "
+"फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14666,6 +14764,12 @@ msgid "Past year"
 msgstr "पिछला साल"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14676,6 +14780,12 @@ msgstr "पेस्ट करें"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "सिंक कोड पेस्ट करें"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14729,6 +14839,20 @@ msgstr "हमेशा के लिए बंद"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "फ़ारसी"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14799,10 +14923,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
-"तो AI की मदद से दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर "
-"जवाब अक्सर मिलते हैं। उन्हें बंद करने और Assist बटन छिपाने के लिए %1$sखोज "
-"सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो AI की मदद से "
+"दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। उन्हें बंद "
+"करने और Assist बटन छिपाने के लिए %1$sखोज सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14811,10 +14934,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
-"तो DuckAssist के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। "
-"इस फ़ीचर के काम करने के तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, "
-"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
+"के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इस फ़ीचर के काम करने के "
+"तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, %1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14824,10 +14946,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
-"तो DuckAssist अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते "
-"हैं। इसे बंद करने और Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist "
-"Settings%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
+"अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इसे बंद करने और "
+"Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist Settings%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14860,8 +14981,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, "
-"Mistral, वगैरह।"
+"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, Mistral, "
+"वगैरह।"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14880,8 +15001,7 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा "
-"उपलब्ध नहीं होगी।"
+"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा उपलब्ध नहीं होगी।"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14894,8 +15014,8 @@ msgstr "कोई विशिष्ट समस्या चुनें"
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए "
-"निर्देशों का पालन करें।"
+"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए निर्देशों का "
+"पालन करें।"
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14984,8 +15104,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया "
-"निम्नलिखित चुनौती को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया निम्नलिखित "
+"चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14994,8 +15114,8 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया "
-"निम्नलिखित चुनौती को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया निम्नलिखित चुनौती "
+"को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15028,8 +15148,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट "
-"सेशन डिलीट हो जाएगा।"
+"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट सेशन डिलीट हो "
+"जाएगा।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15038,9 +15158,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
-"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या "
-"गैरकानूनी है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
+"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या गैरकानूनी है।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15049,9 +15168,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
-"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या "
-"नुकसानदेह है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
+"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या नुकसानदेह है।"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15204,8 +15322,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या "
-"सुझावों को प्रभावित नहीं करेगा।"
+"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
+"प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15268,8 +15386,7 @@ msgstr "खराब फॉर्मेटिंग"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
-"लोकप्रिय AI मॉडल उपलब्ध हैं। किसी अकाउंट की ज़रूरत नहीं है। चैट हमारे द्वारा "
-"अनाम की गईं।"
+"लोकप्रिय AI मॉडल उपलब्ध हैं। किसी अकाउंट की ज़रूरत नहीं है। चैट हमारे द्वारा अनाम की गईं।"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15779,8 +15896,8 @@ msgstr "मुझे प्रॉम्प्ट करें"
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
 msgstr ""
-"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के "
-"लिए प्रेरित करें।"
+"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के लिए प्रेरित "
+"करें।"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15799,8 +15916,7 @@ msgstr "खोजते और ब्राउज़ करते समय अ�
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
 msgstr ""
-"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को "
-"सुरक्षित रखें।"
+"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15825,8 +15941,7 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का "
-"टेक्स्ट यहां डालें।]"
+"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का टेक्स्ट यहां डालें।]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15998,6 +16113,12 @@ msgid "Reading website…"
 msgstr "वेबसाइट पढ़ी जा रही है…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16038,16 +16159,16 @@ msgstr "रीज़निंग जटिल सवालों के बे�
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन यह 2-5 गुना जल्दी उपयोग सीमा तक "
-"पहुंच जाता है। %1$s"
+"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन यह 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता "
+"है। %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
-"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन इसमें लिमिट्स का इस्तेमाल 2-5 "
-"गुना तेज़ी से होता है। %1$s"
+"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन इसमें लिमिट्स का इस्तेमाल 2-5 गुना तेज़ी से होता "
+"है। %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16097,8 +16218,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
-"स्थानीय स्तर पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
+"पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16107,8 +16228,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
-"स्थानीय स्तर पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
+"पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16118,10 +16239,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स "
-"भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर "
-"पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया "
-"जा सके।"
+"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
+"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि "
+"आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके।"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16192,6 +16312,12 @@ msgid "Recovery Code"
 msgstr "रिकवरी कोड"
 
 # smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Red"
 msgstr "लाल"
@@ -16257,8 +16383,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट "
-"के आकार को घटाता है"
+"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट के आकार को "
+"घटाता है"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16399,8 +16525,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने "
-"ब्राउज़र के &quot;रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
+"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने ब्राउज़र के &quot;"
+"रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16441,6 +16567,12 @@ msgstr "%1$s हटाएं"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "%1$s हटाएं"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16485,13 +16617,25 @@ msgid "Remove unnecessary punctuation"
 msgstr "अनावश्यक विराम चिह्न हटाएं"
 
 # smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप "
-"से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई देते "
+"हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16499,9 +16643,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर "
-"स्वचालित रूप से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित "
-"होते हैं।"
+"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई "
+"देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16559,9 +16702,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए "
-"DuckDuckGo को भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए "
-"आपकी अनाम प्रतिक्रिया भी %1$s के साथ शेयर की जाती है।"
+"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए DuckDuckGo को "
+"भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए आपकी अनाम प्रतिक्रिया भी "
+"%1$s के साथ शेयर की जाती है।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16569,8 +16712,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई "
-"भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
+"पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16579,9 +16722,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें "
-"आपने इस पेज लोड के दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने "
-"फ़ीडबैक में कोई भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें आपने इस पेज लोड के "
+"दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
+"पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16673,10 +16816,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
-"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
-"जाना चाहिए। AI की मदद से दिए गए जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन "
-"हैं।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
+"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। AI की मदद से दिए गए "
+"जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन हैं।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16685,9 +16827,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
-"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
-"जाना चाहिए। DuckAssist हमारी %1$sसेवा की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
+"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। DuckAssist हमारी "
+"%1$sसेवा की शर्तों%2$s के अधीन है।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16697,11 +16839,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
-"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
-"जाना चाहिए। ये वेब सामग्री के आधार पर तैयार किए जाते हैं और इनमें कुछ "
-"गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा की शर्तों%2$s के अधीन "
-"है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
+"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। ये वेब सामग्री के आधार "
+"पर तैयार किए जाते हैं और इनमें कुछ गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा "
+"की शर्तों%2$s के अधीन है।"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16778,8 +16919,7 @@ msgstr "परिणामों में ब्लॉक की गई सा�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में "
-"मैनेज कर सकते हैं।"
+"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में मैनेज कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17128,8 +17268,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और "
-"एन्क्रिप्टेड स्टोरेज के साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
+"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और एन्क्रिप्टेड स्टोरेज के "
+"साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17142,9 +17282,7 @@ msgstr "अपनी सबसे हाल की 30 चैट तक को �
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच "
-"सुरक्षित रखें।"
+msgstr "एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17175,6 +17313,12 @@ msgstr "अपनी सेटिंग्स क्लाउड पर अन�
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Duck.ai से रूबरू हों"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17292,8 +17436,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या "
-"%5$sनया जोड़ें%6$s) क्लिक करें"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या %5$sनया जोड़ें%6$s) "
+"क्लिक करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17302,8 +17446,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर "
-"क्लिक करें (या %5$sनया जोड़ें%6$s)।"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर क्लिक करें (या %5$sनया "
+"जोड़ें%6$s)।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17322,8 +17466,8 @@ msgstr "नीचे स्क्रॉल करें और सूची म�
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह "
-"आपकी लोकेशन यानी स्थान का इस्तेमाल कर सके।"
+"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह आपकी लोकेशन "
+"यानी स्थान का इस्तेमाल कर सके।"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17383,12 +17527,11 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा "
-"करने के लिए यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक "
-"संक्षिप्त जवाब तैयार करता है। आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी "
-"नहीं, केवल मांग पर (जब आप 'Assist' पर क्लिक करें), कभी-कभी (जब यह बहुत "
-"प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू हो)। फिलहाल, Search Assist "
-"केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
+"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा करने के लिए "
+"यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक संक्षिप्त जवाब तैयार करता है। "
+"आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी नहीं, केवल मांग पर (जब आप 'Assist' पर "
+"क्लिक करें), कभी-कभी (जब यह बहुत प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू "
+"हो)। फिलहाल, Search Assist केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17396,8 +17539,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय "
-"जानकारी नहीं मिली। कुछ और सर्च करके देखें।"
+"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय जानकारी नहीं "
+"मिली। कुछ और सर्च करके देखें।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17406,10 +17549,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब "
-"तैयार करता है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि "
-"संबंधित सामग्री मिल सके, और फिर मिली जानकारी के आधार पर AI की मदद से एक "
-"संक्षिप्त उत्तर तैयार करता है।"
+"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब तैयार करता "
+"है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि संबंधित सामग्री मिल सके, "
+"और फिर मिली जानकारी के आधार पर AI की मदद से एक संक्षिप्त उत्तर तैयार करता है।"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17530,8 +17672,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे "
-"Wikipedia पर “ducks” को खोजा जाएगा।"
+"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे Wikipedia पर "
+"“ducks” को खोजा जाएगा।"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17550,8 +17692,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र "
-"में गोपनीय वेब खोज जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
+"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र में गोपनीय वेब खोज "
+"जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17559,8 +17701,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट "
-"अनुरोध का उपयोग होगा)"
+"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट अनुरोध का उपयोग "
+"होगा)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17572,11 +17714,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल "
-"स्टोरेज में रखा जाता है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके "
-"अपनी सेटिंग को क्लाउड में किसी रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते "
-"हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान योग्य जानकारी स्टोर नहीं की "
-"जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं जाएगा।"
+"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल स्टोरेज में रखा जाता "
+"है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके अपनी सेटिंग को क्लाउड में किसी "
+"रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान "
+"योग्य जानकारी स्टोर नहीं की जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं "
+"जाएगा।"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17679,8 +17821,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
-"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
+"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17689,8 +17831,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
-"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
+"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17699,8 +17841,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
-"रूप से स्टोर करें, और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
+"और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17709,8 +17851,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप "
-"से स्टोर करें, और उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप से स्टोर करें, और "
+"उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17725,8 +17867,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर "
-"किया गया। आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
+"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर किया गया। आपके "
+"अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -17876,9 +18018,7 @@ msgstr "Safari मेनू से %1$s'इस वेबसाइट के ल�
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज "
-"करें"
+msgstr "%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज करें"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17888,17 +18028,13 @@ msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट �
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
-"करें"
+msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
-"करें।"
+msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें।"
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17947,8 +18083,7 @@ msgstr "ड्रॉपडाउन मेनू से %1$sएड-ऑन प्
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) "
-"चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) चुनें"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17956,8 +18091,7 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) "
-"चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) चुनें"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18022,8 +18156,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी "
-"पसंद का कोई एक विकल्प) चुनें"
+"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी पसंद का कोई "
+"एक विकल्प) चुनें"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18145,8 +18279,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब "
-"देना है। ये निर्देश आगे चलकर आपके सभी वार्तालापों पर लागू होंगे।"
+"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब देना है। ये निर्देश आगे "
+"चलकर आपके सभी वार्तालापों पर लागू होंगे।"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18167,6 +18301,13 @@ msgstr "सर्बियन (सिरिलिक)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "सर्बियन (लैटिन)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18262,8 +18403,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी "
-"डिवाइसों पर सिंक रख सकें।"
+"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी डिवाइसों पर "
+"सिंक रख सकें।"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18321,6 +18462,14 @@ msgid "Share"
 msgstr "शेयर करें"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18362,9 +18511,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की "
-"सटीकता बेहतर हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं "
-"बताता है।"
+"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की सटीकता बेहतर "
+"हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं बताता है।"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18460,8 +18608,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और "
-"हानिकारक रिपोर्ट के लिए आवश्यक है)"
+"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और हानिकारक "
+"रिपोर्ट के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18470,14 +18618,26 @@ msgid "Share your thoughts on the search box."
 msgstr "खोज बॉक्स पर अपने विचार साझा करें।"
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"हमारे नो-लॉग, तेज़ VPN के साथ अपनी ऑनलाइन गतिविधि को सुरक्षित रखें। सेटअप "
-"करने में सरल और किसी भी समय चालू या बंद करने में आसान।"
+"हमारे नो-लॉग, तेज़ VPN के साथ अपनी ऑनलाइन गतिविधि को सुरक्षित रखें। सेटअप करने में सरल "
+"और किसी भी समय चालू या बंद करने में आसान।"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18598,8 +18758,7 @@ msgstr "DuckAssist <sup>बीटा</sup> दिखाएं"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर "
-"सकते हैं।)"
+"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर सकते हैं।)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18837,9 +18996,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
-"खोज गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की "
-"गोपनीयता प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
+"गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की गोपनीयता "
+"प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18847,9 +19006,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
-"खोज हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे "
-"खोज सुरक्षा प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
+"हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज सुरक्षा "
+"प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18887,8 +19046,7 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर "
-"दिखाता है"
+"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर दिखाता है"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19145,6 +19303,12 @@ msgid "Something went wrong"
 msgstr "कुछ गड़बड़ हुई है"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19184,9 +19348,7 @@ msgstr "कभी-कभी"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों "
-"में बताएं।"
+msgstr "माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों में बताएं।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19225,8 +19387,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी "
-"इमेज या फ़ॉर्मेट आज़माएं।"
+"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी इमेज या फ़ॉर्मेट "
+"आज़माएं।"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19235,8 +19397,7 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन "
-"किया गया है।"
+"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन किया गया है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19251,16 +19412,14 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने "
-"के लिए, %1$sयहाँ क्लिक करें%2$s।"
+"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने के लिए, %1$sयहाँ "
+"क्लिक करें%2$s।"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास "
-"करें।"
+msgstr "क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19315,8 +19474,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा "
-"हिस्सा चुनकर फिर से प्रयास करें।"
+"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा हिस्सा चुनकर फिर से "
+"प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19666,8 +19825,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक "
-"इमेज बनाने के लिए बाद में वापस आएं।"
+"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक इमेज बनाने "
+"के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19736,8 +19895,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' "
-"वाले कार्ड पर लिखने के लिए वाक्य सुझाएं?"
+"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' वाले कार्ड पर "
+"लिखने के लिए वाक्य सुझाएं?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19991,6 +20150,12 @@ msgid "Switch model"
 msgstr "मॉडल स्विच करें"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20068,8 +20233,8 @@ msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
 msgstr ""
-"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर "
-"विज़िबिलिटी ज़ीरो होगी"
+"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर विज़िबिलिटी ज़ीरो "
+"होगी"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20124,8 +20289,7 @@ msgstr "Sync & Backup चालू है!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा "
-"सकता।"
+"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा सकता।"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20174,26 +20338,25 @@ msgid ""
 msgstr ""
 "सिंक रिकवरी कोड\n"
 "\n"
-" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai "
-"चैट को सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक "
-"किया हुआ डेटा रिकवर कर सकते हैं।\n"
+" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai चैट को "
+"सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक किया हुआ डेटा "
+"रिकवर कर सकते हैं।\n"
 "\n"
 "इस जानकारी को सुरक्षित और गोपनीय रखें।\n"
-"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस "
-"कर सकता है।\n"
+"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस कर सकता "
+"है।\n"
 "\n"
 "%1$s\n"
 "\n"
 "यह कोड कैसे काम करता है?\n"
 "1. अपने ब्राउज़र में Duck.ai पर जाएं और Duck.ai सेटिंग खोलें।\n"
-"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" "
-"चुनें\n"
-"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड "
-"यहां पेस्ट करें\" कहा गया है\n"
+"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" चुनें\n"
+"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड यहां पेस्ट "
+"करें\" कहा गया है\n"
 "\n"
-"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक "
-"DuckDuckGo ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट "
-"कर दिया जाएगा और उसे रीस्टोर नहीं किया जा सकेगा।"
+"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक DuckDuckGo "
+"ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट कर दिया जाएगा और उसे "
+"रीस्टोर नहीं किया जा सकेगा।"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20250,6 +20413,13 @@ msgid "Synced Devices"
 msgstr "सिंक किए गए डिवाइस"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "सीरिया"
 
@@ -20280,6 +20450,12 @@ msgstr "टीबीडी"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "टीवी"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20313,8 +20489,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी हों, तेज़ी से एक्सेस के लिए इसे "
-"हमारे मुफ़्त ऐप में पाएं।"
+"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी हों, तेज़ी से एक्सेस के लिए इसे हमारे मुफ़्त ऐप "
+"में पाएं।"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20323,8 +20499,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी ब्राउज़ कर रहे हों, तेज़ी से "
-"एक्सेस के लिए इसे हमारे मुफ़्त ब्राउज़र में पाएं।"
+"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी ब्राउज़ कर रहे हों, तेज़ी से एक्सेस के लिए इसे "
+"हमारे मुफ़्त ब्राउज़र में पाएं।"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20568,9 +20744,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई "
-"जानकारी को किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम "
-"मामलों में इसमें पासवर्ड, या भुगतान विवरण शामिल होते हैं।"
+"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई जानकारी को "
+"किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम मामलों में इसमें पासवर्ड, "
+"या भुगतान विवरण शामिल होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20579,8 +20755,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी "
-"सेटिंग्स में कोई भी बदलाव करने की अनुमति देता है।"
+"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी सेटिंग्स में कोई भी "
+"बदलाव करने की अनुमति देता है।"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20610,8 +20786,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और "
-"सिर्फ़ आप ही इसे एक्सेस कर सकते हैं।"
+"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और सिर्फ़ आप ही इसे एक्सेस "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -20691,8 +20867,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी "
-"ब्राउज़र सेटिंग जांचें और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
+"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी ब्राउज़र सेटिंग जांचें "
+"और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20707,8 +20883,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से "
-"पहले कुछ मिनट इंतज़ार करें।"
+"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से पहले कुछ "
+"मिनट इंतज़ार करें।"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20727,9 +20903,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर "
-"ब्लॉक करके, संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका "
-"डिफ़ॉल्ट खोज इंजन बनाकर गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
+"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर ब्लॉक करके, "
+"संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका डिफ़ॉल्ट खोज इंजन बनाकर "
+"गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20767,8 +20943,7 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की "
-"कोशिश करें।"
+"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20777,8 +20952,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए "
-"वर्ज़न के साथ नई चैट शुरू करें।"
+"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए वर्ज़न के साथ नई "
+"चैट शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20817,9 +20992,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की "
-"गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
-"लिए %4$s देखें)।"
+"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की गई। "
+"AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20829,9 +21003,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई "
-"चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए "
-"%2$s देखें)."
+"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई चैट में गलत "
+"या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %2$s देखें)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20840,8 +21013,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक "
-"जानकारी भी प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
+"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक जानकारी भी "
+"प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20851,9 +21024,25 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के "
-"जरिए जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है "
-"(ज़्यादा जानकारी के लिए %4$s देखें)।"
+"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के जरिए "
+"जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
+"लिए %4$s देखें)।"
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20925,8 +21114,7 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
-"करें"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -20934,13 +21122,18 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
-"करें।"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें।"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "यह जानकारी उपयोगी नहीं है"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -20949,8 +21142,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"यह केवल एक सैंपल चैट है। इसका मेन्यू (तीन डॉट्स) खोलें, फिर इसे अपनी चैट्स "
-"में सबसे ऊपर रखने के लिए 'पिन करें' चुनें!"
+"यह केवल एक सैंपल चैट है। इसका मेन्यू (तीन डॉट्स) खोलें, फिर इसे अपनी चैट्स में सबसे ऊपर रखने के "
+"लिए 'पिन करें' चुनें!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20959,8 +21152,7 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"यह केवल एक सैंपल चैट है। इसे डिलीट करने के लिए साइड मेन्यू में Fire Button "
-"का इस्तेमाल करें!"
+"यह केवल एक सैंपल चैट है। इसे डिलीट करने के लिए साइड मेन्यू में Fire Button का इस्तेमाल करें!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20981,8 +21173,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य "
-"मॉडल प्रदाता 'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य मॉडल प्रदाता "
+"'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20991,8 +21183,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल "
-"प्रदाता 'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल प्रदाता "
+"'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21029,8 +21221,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के "
-"साथ सेव करता है, जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
+"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के साथ सेव करता है, "
+"जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21039,9 +21231,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
-"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
-"सकते हैं।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
+"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21051,10 +21242,21 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
-"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
-"सकते हैं। हालांकि, %1$s पर हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने "
-"वाले जवाब कभी नहीं दिखाता।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
+"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं। हालांकि, %1$s पर "
+"हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने वाले जवाब कभी नहीं दिखाता।"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21083,9 +21285,7 @@ msgstr "यह वीडियो अब तक यहां देखे जा
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता "
-"है।"
+msgstr "यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21095,9 +21295,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup "
-"डिस्कनेक्ट हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी "
-"चैट एक्सेस कर पाएंगे।"
+"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup डिस्कनेक्ट "
+"हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी चैट एक्सेस कर पाएंगे।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21106,16 +21305,15 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे "
-"पहले जैसा नहीं किया जा सकता है।"
+"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे पहले जैसा "
+"नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
 msgstr ""
-"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा "
-"सकता है।"
+"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21238,7 +21436,8 @@ msgstr "जारी रखने के लिए, आपको Duck.ai की 
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
+msgstr ""
+"जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21247,8 +21446,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप "
-"प्रिंट करना चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
+"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप प्रिंट करना "
+"चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21258,10 +21457,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत "
-"होगी जिसे आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर "
-"PDF के रूप में सेव किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync "
-"सेटअप करने के लिए किया था।"
+"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत होगी जिसे "
+"आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर PDF के रूप में सेव "
+"किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync सेटअप करने के लिए किया था।"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21270,8 +21468,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo "
-"ब्राउज़र को नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
+"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo ब्राउज़र को "
+"नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21279,8 +21477,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को "
-"माइक्रोफ़ोन का एक्सेस दें।"
+"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को माइक्रोफ़ोन का "
+"एक्सेस दें।"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21302,9 +21500,7 @@ msgstr "आज"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"प्राइवेट AI चैट आज़माने के लिए टॉगल करें या %1$sइसे %2$s मेन्यू में डिसेबल "
-"करें।%3$s"
+msgstr "प्राइवेट AI चैट आज़माने के लिए टॉगल करें या %1$sइसे %2$s मेन्यू में डिसेबल करें।%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21478,8 +21674,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ "
-"करते रहें और देखें हम कितनों को ब्लॉक करते हैं।"
+"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ करते रहें और देखें "
+"हम कितनों को ब्लॉक करते हैं।"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21526,9 +21722,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में "
-"कैसे पहुंचूं?\""
+msgstr "फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21537,8 +21731,7 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी "
-"सिनेमा हॉल तक कैसे पहुंचूं?\""
+"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी सिनेमा हॉल तक कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21700,6 +21893,12 @@ msgid "Try Free"
 msgstr "मुफ़्त में आज़माएं"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21780,8 +21979,7 @@ msgstr "अलग कीवर्ड आज़माएं।"
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी "
-"अक्षम करें।"
+"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी अक्षम करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21813,6 +22011,12 @@ msgstr "मुफ़्त में आज़माएं"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "मुफ़्त में आज़माएं"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21967,8 +22171,7 @@ msgstr "हाल ही में जोड़े गए ओपन-सोर्
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
 msgstr ""
-"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को "
-"आजमाएं"
+"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को आजमाएं"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -22008,8 +22211,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
-"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
+"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22018,8 +22221,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
-"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
+"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22058,6 +22261,12 @@ msgid "Turkmenistan"
 msgstr "तुर्कमेनिस्तान"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22068,6 +22277,12 @@ msgstr "Sync & Backup बंद करें"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Sync & Backup बंद करें"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22208,8 +22423,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और "
-"दिखाई देने वाले उत्तर के बीच थोड़ा समय लग सकता है।"
+"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और दिखाई देने वाले "
+"उत्तर के बीच थोड़ा समय लग सकता है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22339,8 +22554,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर "
-"%5$sसेट पेज%6$s पर क्लिक करें।"
+"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर %5$sसेट "
+"पेज%6$s पर क्लिक करें।"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22348,8 +22563,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: "
-"https://duckduckgo.com"
+"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22381,9 +22596,7 @@ msgstr "%1$sसर्च%2$s सेक्शन के नीचे, %3$sसर�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s "
-"चुनें"
+msgstr "स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s चुनें"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22467,8 +22680,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 "
-"गुना ज़्यादा उपयोग सीमाएं अनलॉक करें।"
+"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 गुना ज़्यादा "
+"उपयोग सीमाएं अनलॉक करें।"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22543,6 +22756,12 @@ msgid "Unmute"
 msgstr "अनम्यूट करें"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22576,6 +22795,12 @@ msgstr "अपडेट"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "ब्राउज़र अपडेट करें"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22614,8 +22839,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने "
-"के लिए DuckDuckGo ब्राउज़र को अपडेट करें"
+"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने के लिए "
+"DuckDuckGo ब्राउज़र को अपडेट करें"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22740,16 +22965,14 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज "
-"बनाने के लिए बाद में वापस आएं।"
+"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज बनाने के लिए "
+"बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में "
-"अपग्रेड करें"
+msgstr "Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में अपग्रेड करें"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22845,9 +23068,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को "
-"हैकर्स, स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। "
-"मुफ़्त। किसी खाते की ज़रूरत नहीं है।"
+"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को हैकर्स, "
+"स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। मुफ़्त। किसी खाते की ज़रूरत "
+"नहीं है।"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22902,8 +23125,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस "
-"कोड का इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस कोड का "
+"इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -22911,8 +23134,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने "
-"के लिए इस कोड का इस्तेमाल करें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने के लिए इस "
+"कोड का इस्तेमाल करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23062,8 +23285,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को "
-"Microsoft के विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को Microsoft के "
+"विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23072,8 +23295,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक "
-"TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक TripAdvisor के "
+"विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23085,8 +23308,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist "
-"सेटिंग%2$s पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist सेटिंग%2$s "
+"पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23095,8 +23318,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए "
-"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sDuckAssist "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23105,8 +23328,7 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का "
-"पालन करें।"
+"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23122,8 +23344,8 @@ msgid ""
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
 "अपने दूसरे ब्राउज़र में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > %3$sSync & "
-"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के "
-"साथ सिंक करें%8$s को चुनें।"
+"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के साथ सिंक "
+"करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23133,9 +23355,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & "
-"Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक "
-"करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & Backup के "
+"अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी "
+"रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23145,9 +23367,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai "
-"सेटिंग%2$s > %3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद "
-"%7$sकिसी दूसरे डिवाइस के साथ सिंक करें%8$s को चुनें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > "
+"%3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस "
+"के साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23157,10 +23379,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की "
-"सेटिंग खोलें। Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी "
-"दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड "
-"स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। "
+"Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" "
+"को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23213,8 +23434,8 @@ msgstr "वॉयस चैट समाप्त हो गई"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
-"के लिए नहीं किया जाता है।"
+"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए "
+"नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23358,8 +23579,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को "
-"YouTube अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
+"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को YouTube "
+"अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23379,10 +23600,9 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है "
-"क्योंकि हमें वहाँ से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र "
-"कंपनी है और इसका YouTube से कोई संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए "
-"जाते हैं।"
+"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है क्योंकि हमें वहाँ "
+"से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र कंपनी है और इसका YouTube से कोई "
+"संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए जाते हैं।"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23395,8 +23615,8 @@ msgstr "हम गुमनाम करते हैं"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को "
-"गुमनाम रख सकते हैं।"
+"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को गुमनाम रख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23408,9 +23628,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की "
-"रिपोर्ट करने के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम "
-"जांच कर सकें और समस्या का समाधान कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की रिपोर्ट करने "
+"के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम जांच कर सकें और समस्या "
+"का समाधान कर सकें।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23422,17 +23642,16 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की "
-"रिपोर्ट करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस "
-"मामले की जांच करके उसे ठीक कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की रिपोर्ट "
+"करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस मामले की जांच करके उसे "
+"ठीक कर सकें।"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल "
-"कर सकते हैं।"
+"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -23440,8 +23659,7 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक "
-"एन्क्रिप्टेड है।"
+"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक एन्क्रिप्टेड है।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23453,8 +23671,7 @@ msgstr "हम विज्ञापनों के साथ आपको फ�
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
 msgstr ""
-"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं "
-"करते हैं।"
+"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23471,8 +23688,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं "
-"करते हैं। हम आपको ट्रैक नहीं करते हैं। कभी भी।"
+"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं करते हैं। "
+"हम आपको ट्रैक नहीं करते हैं। कभी भी।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23486,8 +23703,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां "
-"वापस क्यों आए हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां वापस क्यों आए "
+"हैं:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23496,8 +23713,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस "
-"वजह से हमें आज़माना चाहते हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस वजह से हमें "
+"आज़माना चाहते हैं:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23537,9 +23754,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे "
-"विज्ञापनकर्ताओं को बेचने के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते "
-"हैं।"
+"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे विज्ञापनकर्ताओं को बेचने "
+"के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23559,14 +23775,22 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "कोई गतिविधि न होने के कारण चैट बंद कर दी गई है। फिर से कोशिश करना चाहते हैं?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके "
-"कि आपकी चैट्स का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
+"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके कि आपकी चैट्स "
+"का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23591,8 +23815,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, "
-"आपके डेटा का फायदा उठाकर नहीं।"
+"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, आपके डेटा का "
+"फायदा उठाकर नहीं।"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23601,23 +23825,27 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते "
-"हैं। आप अक्‍सर बाद में अपना विचार बदल सकते हैं।"
+"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते हैं। आप अक्‍सर "
+"बाद में अपना विचार बदल सकते हैं।"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते "
-"हैं।"
+msgstr "हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल "
-"हैं।"
+msgstr "हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23633,16 +23861,23 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा "
-"सके। %1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार "
-"तुरंत परिणामों में दिखाई ना दें।"
+"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा सके। "
+"%1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार तुरंत परिणामों में "
+"दिखाई ना दें।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले "
-"ट्रैकर्स को ब्लॉक कर देंगे।"
+"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले ट्रैकर्स को ब्लॉक कर देंगे।"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23651,9 +23886,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
-"हैं। अगर आपको यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क "
-"करें।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। अगर आपको "
+"यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क करें।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23662,8 +23896,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
-"हैं। कभी-कभी अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। कभी-कभी "
+"अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23678,8 +23912,7 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार "
-"मेहनत कर रहे हैं।"
+"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार मेहनत कर रहे हैं।"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23688,8 +23921,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज "
-"फिर से लोड करना होगा।"
+"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज फिर से लोड "
+"करना होगा।"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23789,9 +24022,7 @@ msgstr "साप्ताहिक उपयोग सीमा पूरी �
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
-"हैं।"
+msgstr "साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23800,8 +24031,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट "
-"करना जारी रख सकते हैं।"
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट करना "
+"जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23815,9 +24046,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
-"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं "
-"किया जाता।"
+"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं "
+"और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23826,9 +24056,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम "
-"उन्हें अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए "
-"नहीं किया जाता।"
+"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
+"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23838,17 +24067,16 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित "
-"करता है। यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं "
-"करता है या उनका उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
+"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित करता है। "
+"यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं करता है या उनका "
+"उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर "
-"सकते हैं।"
+"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23916,8 +24144,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई "
-"है। पेज को रीलोड करने की कोशिश करें।"
+"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई है। पेज को "
+"रीलोड करने की कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23952,14 +24180,19 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए "
-"कुछ विकल्प बताएं।"
+"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए कुछ विकल्प बताएं।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "एन्युटी के कुछ फायदे और कुछ नुकसान क्या हैं?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -23972,12 +24205,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र "
-"डाउनलोड करने के क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही "
-"संदर्भ लें। जवाब को स्पष्ट हिस्सों में बांटें और हर हिस्से के लिए शीर्षक "
-"दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर विशेष ध्यान दिया गया "
-"हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी अनुभव रखने "
-"वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
+"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र डाउनलोड करने के "
+"क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही संदर्भ लें। जवाब को स्पष्ट हिस्सों में "
+"बांटें और हर हिस्से के लिए शीर्षक दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर "
+"विशेष ध्यान दिया गया हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी "
+"अनुभव रखने वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24213,8 +24445,7 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग "
-"होता है?"
+"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग होता है?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24290,8 +24521,8 @@ msgstr "आप किस पर फीडबैक देना चाहें�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
-"प्रभावित नहीं करेगा।"
+"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को प्रभावित नहीं "
+"करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24317,8 +24548,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद "
-"ब्रांडों पर विचार करना चाहिए?"
+"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद ब्रांडों पर "
+"विचार करना चाहिए?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24519,15 +24750,22 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai के साथ, आपकी चैट को अनाम रखा जाता है और AI को प्रशिक्षित करने के लिए "
-"चैट का इस्तेमाल कभी नहीं किया जाता। '%1$s' मेन्यू में इसे कभी भी चालू या बंद "
-"करें।"
+"Duck.ai के साथ, आपकी चैट को अनाम रखा जाता है और AI को प्रशिक्षित करने के लिए चैट का "
+"इस्तेमाल कभी नहीं किया जाता। '%1$s' मेन्यू में इसे कभी भी चालू या बंद करें।"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "बिना ज़ीरो प्रोवाइडर विज़िबिलिटी के"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24776,8 +25014,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे "
-"दोबारा प्राप्त नहीं किया जा सकता है।"
+"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे दोबारा प्राप्त "
+"नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24797,8 +25035,7 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
-"सकती है।"
+"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24807,8 +25044,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके "
-"DuckDuckGo से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
+"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके DuckDuckGo "
+"से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24822,8 +25059,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या "
-"इसे कभी भी बंद कर सकते हैं।"
+"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या इसे कभी भी "
+"बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24832,22 +25069,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते "
-"हैं या इसे कभी भी बंद कर सकते हैं।"
+"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते हैं या इसे "
+"कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का "
-"भी इस्तेमाल कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का भी इस्तेमाल "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI "
-"Chat%2$s का भी इस्तेमाल कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI Chat%2$s "
+"का भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -24861,8 +25098,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में "
-"जाकर बदल सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
+"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में जाकर बदल "
+"सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24883,8 +25120,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है "
-"और चाहे तो पहली सेटिंग को डिलीट भी कर सकते हैं।"
+"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है और चाहे तो पहली "
+"सेटिंग को डिलीट भी कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24977,8 +25214,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको "
-"पहले किसी अन्य साइट को अनब्लॉक करना होगा।"
+"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको पहले किसी "
+"अन्य साइट को अनब्लॉक करना होगा।"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25029,14 +25266,21 @@ msgid "You have 1 attempt left."
 msgstr "आपका 1 प्रयास शेष है।"
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में "
-"2 गुना ज़्यादा उपयोग सीमाएं।"
+"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में 2 गुना "
+"ज़्यादा उपयोग सीमाएं।"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25045,8 +25289,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN "
-"और अन्य DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
+"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN और अन्य "
+"DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25068,9 +25312,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
-"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
-"चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
+"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25080,9 +25323,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
-"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
-"चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
+"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25110,9 +25352,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए "
-"भी Chrome की बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह "
-"कर सकता है:"
+"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए भी Chrome की "
+"बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25125,8 +25366,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम "
-"करने के लिए सुझाव पाएं।"
+"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम करने के लिए "
+"सुझाव पाएं।"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25175,9 +25416,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से "
-"कोशिश करें।"
+msgstr "आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25196,8 +25435,7 @@ msgstr "आज की वॉयस चैट सीमा पूरी हो �
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
 msgstr ""
-"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से "
-"कोशिश करें।"
+"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25206,9 +25444,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त "
-"हो गई है। सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन "
-"की गई चैट डिलीट नहीं की जाएंगी।"
+"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। "
+"सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन की गई चैट डिलीट नहीं की "
+"जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25218,9 +25456,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई "
-"है। सिंक फिर से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट "
-"कर दें। पिन की गई चैट डिलीट नहीं की जाएंगी।"
+"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। सिंक फिर "
+"से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट कर दें। पिन की गई चैट डिलीट "
+"नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25234,8 +25472,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस "
-"वजह से YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
+"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस वजह से "
+"YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25247,6 +25485,23 @@ msgstr "YouTube गोपनीयता चेतावनी"
 msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube स्टैंडर्ड"
+
+# smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25272,6 +25527,14 @@ msgid "Your actual location remains private."
 msgstr "आपकी असली लोकेशन गोपनीय रहती है।"
 
 # smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
 msgctxt "Body copy for the Delete Server Data confirmation modal"
 msgid ""
@@ -25279,9 +25542,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
-"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल "
-"स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
+"जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25291,9 +25553,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
-"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज "
-"में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
+"जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25318,8 +25579,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता "
-"है।DuckDuckGo के पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
+"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता है।DuckDuckGo के "
+"पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25327,8 +25588,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo "
-"के पास इस डेटा का कभी भी एक्सेस नहीं रहा है।"
+"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo के पास इस "
+"डेटा का कभी भी एक्सेस नहीं रहा है।"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25337,8 +25598,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी "
-"दिखाई दे सकती है।"
+"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25351,8 +25612,8 @@ msgstr "आपकी चैट अब सेव की जा रही है�
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता"
+"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI मॉडलों को "
+"प्रशिक्षित करने के लिए नहीं किया जाता"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25366,8 +25627,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
+"प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25375,8 +25636,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
+"प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25384,8 +25645,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
-"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25393,8 +25654,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
-"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25409,9 +25670,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI "
-"मॉडल्स को प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री "
-"सुरक्षित रखने के लिए इन चरणों का पालन करें।"
+"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI मॉडल्स को "
+"प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री सुरक्षित रखने के लिए इन चरणों "
+"का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25420,8 +25681,7 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें "
-"जहां आपने छोड़ा था।"
+"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें जहां आपने छोड़ा था।"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25453,8 +25713,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध "
-"नहीं है। [%2$sउदाहरण संदेश%3$s]"
+"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध नहीं है। "
+"[%2$sउदाहरण संदेश%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25469,8 +25729,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए "
-"नहीं किया जाता।"
+"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए नहीं किया "
+"जाता।"
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25499,10 +25759,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का "
-"उपयोग करके '512-बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल "
-"आपके ब्राउज़र को छोड़ देती है। हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स "
-"फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी आपके पासफ़्रेज़ को नहीं जानता है।"
+"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का उपयोग करके '512-"
+"बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल आपके ब्राउज़र को छोड़ देती है। "
+"हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी "
+"आपके पासफ़्रेज़ को नहीं जानता है।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25517,9 +25777,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान "
-"बताने वाला मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे "
-"जोड़ न सकें।"
+"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान बताने वाला "
+"मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे जोड़ न सकें।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25533,8 +25792,7 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा "
-"सकते हैं।"
+"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25566,8 +25824,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे "
-"परमानेंट करने के लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इनेबल करें।"
+"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे परमानेंट करने के "
+"लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इनेबल करें।"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25576,9 +25834,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे "
-"परमानेंट करने के लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर "
-"जानें%4$s"
+"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे परमानेंट करने के "
+"लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25598,9 +25855,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए "
-"Chrome के बजाय हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और "
-"यहां दिए गए काम कर सकता है:"
+"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए Chrome के बजाय "
+"हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और यहां दिए गए काम कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25609,8 +25865,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके "
-"फिर से कोशिश करें।"
+"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25619,8 +25875,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire "
-"Button की मदद से इस बातचीत को मिटाएं।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire Button की मदद "
+"से इस बातचीत को मिटाएं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25629,8 +25885,7 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट "
-"शुरू करें।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25645,8 +25900,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया "
-"इस चैट को अब कल जारी रखें।"
+"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया इस चैट को अब कल "
+"जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25949,8 +26204,7 @@ msgstr "ऑफ़िशियल वेबसाइट"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s "
-"अक्षर है)"
+"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s अक्षर है)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hi_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (यह डिवाइस)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -190,8 +190,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
-"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
+"स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -201,8 +202,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
-"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
+"स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -218,8 +220,9 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
-"अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल पर स्विच करें।"
+"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस "
+"ब्राउज़र में अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
+"पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -228,8 +231,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में फिर से कोशिश "
-"करें।"
+"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में "
+"फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -305,7 +308,9 @@ msgstr "%1$s रैंकिंग अभी तक उपलब्ध नही
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s बेसिक मॉडलों की तुलना में 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता है। %2$s"
+msgstr ""
+"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता है। "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -326,9 +331,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल प्रोवाइडर भी "
-"आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस चैट को अपने सर्वर पर सेव "
-"कर सकता है।"
+"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल "
+"प्रोवाइडर भी आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस "
+"चैट को अपने सर्वर पर सेव कर सकता है।"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -376,7 +381,8 @@ msgstr "%1$s उपयोग किया गया"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
-"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना तक तेज़ी से लिमिट्स का इस्तेमाल करता है %2$s"
+"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना तक तेज़ी से लिमिट्स का इस्तेमाल करता "
+"है %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -415,8 +421,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी रखने "
-"के लिए मॉडल बदल सकते हैं।"
+"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी "
+"रखने के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -427,8 +433,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को जारी रखने के "
-"लिए मॉडल बदल सकते हैं।"
+"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को "
+"जारी रखने के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -441,8 +447,8 @@ msgstr "%1$s शब्द"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, फिर %6$sठीक "
-"हैं%7$s पर क्लिक करें"
+"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, "
+"फिर %6$sठीक हैं%7$s पर क्लिक करें"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -450,8 +456,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति दें%7$s पर "
-"निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
+"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -461,8 +467,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
-"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें "
+"%6$sअनुमति दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -495,7 +501,7 @@ msgstr "%1$sजानें कि हम आपका स्‍थान कै
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sऔर जानें%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -503,14 +509,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर किया जाता है।"
+"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर "
+"किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर जानें।%2$s"
+"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर "
+"जानें।%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -522,7 +530,9 @@ msgstr "होम स्क्रीन पर DuckDuckGo ऐप आइकन �
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से कोशिश करें।"
+msgstr ""
+"%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -789,7 +799,7 @@ msgstr "ग्रुप %1$s में दूसरा"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "सेकंड ओपिनियन"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -873,7 +883,9 @@ msgstr "6 घंटे की उपयोग सीमा पूरी हो �
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
+msgstr ""
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -881,8 +893,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके चैटिंग जारी रख "
-"सकते हैं।"
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके "
+"चैटिंग जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -936,22 +948,26 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना कनेक्शन "
-"जांचें और फिर से कोशिश करें।"
+"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना "
+"कनेक्शन जांचें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
+msgstr ""
+"AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
+msgstr ""
+"Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -995,9 +1011,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा देता "
-"है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप जाएगा। जब यह सेटिंग बंद हो "
-"तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI Chat का उपयोग कर सकते हैं।"
+"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
+"सुविधा देता है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप "
+"जाएगा। जब यह सेटिंग बंद हो तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI "
+"Chat का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1058,10 +1075,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते हैं। "
-"हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और अक्सर उससे लिंक "
-"करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और Anthropic, और अन्य के चैट "
-"मॉडलों को सपोर्ट करती है।"
+"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते "
+"हैं। हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और "
+"अक्सर उससे लिंक करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और "
+"Anthropic, और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1246,8 +1263,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
-"पर स्विच करें।"
+"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या "
+"किसी मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1283,8 +1300,8 @@ msgstr "विज्ञापन"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग आपकी "
-"व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका "
+"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1292,8 +1309,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग "
-"आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और "
+"इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1344,7 +1361,8 @@ msgstr "DuckDuckGo एक्सटेंशन जोड़ें"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials जोड़ें:"
+"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials "
+"जोड़ें:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1474,7 +1492,7 @@ msgstr "होम स्क्रीन पर जोड़े"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "मेरी चैट में जोड़ें"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1578,7 +1596,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2–5 गुना तेज़ी से उपयोग सीमा तक पहुंच सकते हैं। %1$s"
+"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2–5 गुना तेज़ी से उपयोग सीमा तक पहुंच "
+"सकते हैं। %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1587,7 +1606,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
-"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2-5 गुना तेज़ी से लिमिट का इस्तेमाल कर सकते हैं। %1$s"
+"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2-5 गुना तेज़ी से लिमिट का इस्तेमाल "
+"कर सकते हैं। %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1629,7 +1649,9 @@ msgstr "जैसे ही वह डाउनलोड होकर खुल�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल क्लिक करें"
+msgstr ""
+"डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल "
+"क्लिक करें"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1766,8 +1788,8 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "सभी चैट DuckDuckGo द्वारा अनाम कर दी जाती हैं, और आपकी बातचीत का इस्तेमाल "
-"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं किया "
-"जाता है"
+"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं "
+"किया जाता है"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1800,8 +1822,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से रोका गया "
-"है।"
+"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से "
+"रोका गया है।"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1816,8 +1838,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) हटा दिया "
-"जाता है।"
+"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) "
+"हटा दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1842,7 +1864,7 @@ msgstr "सभी प्रकार"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "आपके सभी डिवाइस Sync से डिस्कनेक्ट हो गए हैं."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1856,8 +1878,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन एक्सेस की अनुमति "
-"दें।"
+"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन "
+"एक्सेस की अनुमति दें।"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1880,7 +1902,8 @@ msgstr "इस चैट के लिए गुमनाम फ़ाइल र
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
 msgstr ""
-"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को अनुमति दें"
+"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को "
+"अनुमति दें"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1890,10 +1913,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स के जवाबों को "
-"बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही भेजता है, जिनमें डेटा रिटेंशन की "
-"लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स और जवाबों पर अभी भी %3$sप्रोवाइडर की "
-"विज़िबिलिटी शून्य%4$s रहती है।"
+"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स "
+"के जवाबों को बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही "
+"भेजता है, जिनमें डेटा रिटेंशन की लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स "
+"और जवाबों पर अभी भी %3$sप्रोवाइडर की विज़िबिलिटी शून्य%4$s रहती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1901,8 +1924,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता है (Cloud "
-"Save का उपयोग करने के लिए आवश्यक है)"
+"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता "
+"है (Cloud Save का उपयोग करने के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2040,8 +2063,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
-"शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
+"%3$s और %4$s शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2050,8 +2073,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
-"शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
+"%3$s और %4$s शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2065,8 +2088,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। चुनें कि इसे कितनी "
-"बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
+"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। "
+"चुनें कि इसे कितनी बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2113,8 +2136,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे बतख संबंधी "
-"तथ्य बताएं"
+"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे "
+"बतख संबंधी तथ्य बताएं"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2214,8 +2237,8 @@ msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
 msgstr ""
-"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा नहीं किया "
-"जा सकता।"
+"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा "
+"नहीं किया जा सकता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2236,8 +2259,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, जिनमें पिन "
-"की गई चैट्स भी शामिल हैं।"
+"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, "
+"जिनमें पिन की गई चैट्स भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2246,8 +2269,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी चैट को भी "
-"डिलीट कर देगा।"
+"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी "
+"चैट को भी डिलीट कर देगा।"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2285,8 +2308,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा नहीं करते "
-"हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
+"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा "
+"नहीं करते हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2370,7 +2393,7 @@ msgstr "गोपनीय रूप से कुछ भी पूछें"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "गोपनीय रूप से कुछ भी पूछें"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2428,12 +2451,13 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ खोजों के लिए गुमनाम "
-"रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन सकते हैं कि Assist को कितनी बार "
-"दिखाना है: कभी नहीं (यह खोज परिणामों से Assist के UI को पूरी तरह हटा देता है), ऑन-"
-"डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ "
-"तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता "
-"है)। फिलहाल, AI की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
+"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ "
+"खोजों के लिए गुमनाम रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन "
+"सकते हैं कि Assist को कितनी बार दिखाना है: कभी नहीं (यह खोज परिणामों से "
+"Assist के UI को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप "
+"'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे "
+"बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फिलहाल, AI "
+"की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2445,11 +2469,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
-"क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके "
-"क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम "
-"शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद "
-"रखना ज़रूरी है कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, "
+"खोज संबंधी क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, "
+"यह वेब को स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री "
+"से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित "
+"नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद रखना ज़रूरी है कि "
+"जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
 "आधारित होते हैं।"
 
 # smartling.placeholder_format=C
@@ -2476,8 +2501,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"कैफ़े, एयरपोर्ट या होटल में, DuckDuckGo VPN आपके कनेक्शन को एन्क्रिप्ट करता है और वाई-फ़ाई "
-"पर आपके IP एड्रेस को छिपाता है।"
+"कैफ़े, एयरपोर्ट या होटल में, DuckDuckGo VPN आपके कनेक्शन को एन्क्रिप्ट करता "
+"है और वाई-फ़ाई पर आपके IP एड्रेस को छिपाता है।"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2552,8 +2577,8 @@ msgstr "चैट खत्म होने के बाद ऑडियो ह
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
 msgstr ""
-"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर नहीं किया जाता "
-"है।"
+"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर "
+"नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2595,14 +2620,16 @@ msgstr "स्वत: उत्तर"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां "
+"हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में "
+"अशुद्धियां हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2627,9 +2654,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, जानकारी को "
-"गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता है। फिलहाल, Assist केवल "
-"अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, "
+"जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता "
+"है। फिलहाल, Assist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2638,15 +2665,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए DuckAssist "
-"जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल DuckAssist केवल अंग्रेज़ी "
-"क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए "
+"DuckAssist जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल "
+"DuckAssist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू ऑटोप्ले करें।"
+msgstr ""
+"वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू "
+"ऑटोप्ले करें।"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2846,8 +2875,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस और पहचान "
-"बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर उसे अनाम बना देगा।"
+"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस "
+"और पहचान बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर "
+"उसे अनाम बना देगा।"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2977,8 +3007,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"हमारे सब्सक्रिप्शन के माध्यम से हानिकारक साइटों को ब्लॉक करें, अपना IP एड्रेस छिपाएं, और "
-"ज़्यादा प्रीमियम सुरक्षा पाएं।"
+"हमारे सब्सक्रिप्शन के माध्यम से हानिकारक साइटों को ब्लॉक करें, अपना IP "
+"एड्रेस छिपाएं, और ज़्यादा प्रीमियम सुरक्षा पाएं।"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3238,16 +3268,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने खोज इंजन, ट्रैकर "
-"ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल किया है।"
+"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने "
+"खोज इंजन, ट्रैकर ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s "
+"एक्सटेंशन%3$s में बंडल किया है।"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज इंजन, ट्रैकर "
-"ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल कर दिया है।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज "
+"इंजन, ट्रैकर ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s "
+"में बंडल कर दिया है।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3255,8 +3287,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख ब्राउज़र्स%2$s के लिए "
-"गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, सब कुछ एक ही डाउनलोड में।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख "
+"ब्राउज़र्स%2$s के लिए गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, "
+"सब कुछ एक ही डाउनलोड में।"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3363,11 +3396,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र में) में संग्रहित किया "
-"जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से (क्लाउड में रिमोट सर्वर पर) संग्रहित "
-"करने के लिए अनाम क्लाउड सेव का उपयोग कर सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी "
-"जानकारी क्लाउड में संग्रहित नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं "
-"होगा।"
+"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र "
+"में) में संग्रहित किया जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से "
+"(क्लाउड में रिमोट सर्वर पर) संग्रहित करने के लिए अनाम क्लाउड सेव का उपयोग कर "
+"सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी जानकारी क्लाउड में संग्रहित "
+"नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं होगा।"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3375,8 +3408,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
-"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
+"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3385,8 +3418,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
-"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
+"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3722,7 +3755,9 @@ msgstr "यूआरएल के दिखाई देने का तरी�
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर देता है"
+msgstr ""
+"जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर "
+"देता है"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3870,11 +3905,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम "
-"ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि मॉडलों को सपोर्ट "
-"करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat बटन और लिंक छिप जाएंगे। "
-"हालांकि, यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
-"Chat का इस्तेमाल कर सकते हैं।"
+"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के "
+"साथ गुमनाम ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि "
+"मॉडलों को सपोर्ट करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat "
+"बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर भी आप "
+"%1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Chat का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3930,7 +3965,8 @@ msgstr "गोपनीय ढंग से चैट करें"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय "
+"ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3938,7 +3974,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय "
+"ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4007,8 +4044,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर स्टोर की "
-"जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
+"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर "
+"स्टोर की जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4020,10 +4057,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए "
-"जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
-"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई "
-"चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
+"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते "
+"हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट "
+"हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और "
+"रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4046,9 +4084,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर अपलोड की गई "
-"सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर द्वारा गुमनाम रूप से किया "
-"जाता है।"
+"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर "
+"अपलोड की गई सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर "
+"द्वारा गुमनाम रूप से किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4056,7 +4094,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए स्टोरेज खाली करें।"
+"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए "
+"स्टोरेज खाली करें।"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4212,8 +4251,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"हानिकारक साइटों और स्कैम को ब्लॉक करने में मदद के लिए दुनिया भर में 40+ सर्वर लोकेशन में से "
-"चुनें।"
+"हानिकारक साइटों और स्कैम को ब्लॉक करने में मदद के लिए दुनिया भर में 40+ "
+"सर्वर लोकेशन में से चुनें।"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4231,8 +4270,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस ऐप का "
-"इस्तेमाल करना है"
+"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस "
+"ऐप का इस्तेमाल करना है"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4413,8 +4452,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को लंबे समय तक रख "
-"सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर उन्हें ऑटो-डिलीट कर सकते हैं।"
+"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को "
+"लंबे समय तक रख सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर "
+"उन्हें ऑटो-डिलीट कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4424,9 +4464,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए बिना, हाल की "
-"चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के बाद अपने-आप हटाया जा "
-"सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
+"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए "
+"बिना, हाल की चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के "
+"बाद अपने-आप हटाया जा सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4435,8 +4475,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी ब्लॉक लिस्ट को "
-"हमेशा के लिए सेव करें"
+"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी "
+"ब्लॉक लिस्ट को हमेशा के लिए सेव करें"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4445,9 +4485,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप प्रश्न "
-"%1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो OpenAI, Anthropic "
-"और अन्य के चैट मॉडलों को सपोर्ट करती है।"
+"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप "
+"प्रश्न %1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो "
+"OpenAI, Anthropic और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4489,8 +4529,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > प्राथमिकताएं%4$s "
-"(Mac पर) क्लिक करें"
+"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > "
+"प्राथमिकताएं%4$s (Mac पर) क्लिक करें"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4506,7 +4546,9 @@ msgstr "DuckDuckGo एकस्टेंशन को डाउनलोड क�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक करें"
+msgstr ""
+"DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक "
+"करें"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4521,8 +4563,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर %3$sगियर "
-"आइकन%4$s पर क्लिक करें)"
+"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर "
+"%3$sगियर आइकन%4$s पर क्लिक करें)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4539,7 +4581,9 @@ msgstr "ड्रॉपडाउन में %1$sसेटिंग्स%2$s �
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s करें।"
+msgstr ""
+"%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s "
+"करें।"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4552,7 +4596,8 @@ msgstr "%1$sहां%2$s पर क्लिक करें"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक करें"
+"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक "
+"करें"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4614,9 +4659,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटा देता है, लेकिन "
-"यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी खोज सेटिंग रीसेट करें%4$s पर "
-"क्लिक/टैप नहीं कर देते।"
+"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा "
+"हटा देता है, लेकिन यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी "
+"खोज सेटिंग रीसेट करें%4$s पर क्लिक/टैप नहीं कर देते।"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4627,8 +4672,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता है, लेकिन यह "
-"आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स रीसेट%4$s पर क्लिक/टैप नहीं करते।"
+"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता "
+"है, लेकिन यह आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स "
+"रीसेट%4$s पर क्लिक/टैप नहीं करते।"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4697,8 +4743,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर क्लिक करें और "
-"%3$sDuckDuckGo%4$s चुनें।"
+"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर "
+"क्लिक करें और %3$sDuckDuckGo%4$s चुनें।"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4706,8 +4752,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र के ऊपरी दाएं "
-"कोने में होता है।"
+"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र "
+"के ऊपरी दाएं कोने में होता है।"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4908,8 +4954,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा सुरक्षित रख "
-"सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
+"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा "
+"सुरक्षित रख सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5287,7 +5333,7 @@ msgstr "कॉपी करें"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "कॉपी करें"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5336,13 +5382,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "शेयर किया गया लिंक कॉपी करें"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "दूसरे डिवाइस से कोड कॉपी करें"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5351,6 +5397,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"दूसरे डिवाइस से कोड कॉपी करें. %1$sDuck.ai Settings › Chats › Sync & Backup "
+"› Sync With Another Device%2$s पर जाएँ और फिर से कोशिश करें."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5742,8 +5790,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट करना "
-"जारी रख सकते हैं।"
+"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट "
+"करना जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6033,7 +6081,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "शेयर किया गया लिंक डिलीट करें"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6054,6 +6102,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"लिंक को डिलीट करने से यह काम करना बंद कर देगा. जिन लोगों ने इसे खोला है और "
+"बातचीत को अपनी चैट में जोड़ा है, उनके पास इसकी अपनी कॉपी रहेगी."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6150,8 +6200,8 @@ msgstr "Duck.ai में डिक्टेशन"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए नहीं "
-"किया जाता है।"
+"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
+"के लिए नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6169,8 +6219,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता है, ताकि आप "
-"बिना टाइप किए भी Duck.ai में चैट कर सकें।"
+"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता "
+"है, ताकि आप बिना टाइप किए भी Duck.ai में चैट कर सकें।"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6315,7 +6365,7 @@ msgstr "खारिज करें"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "खारिज करें"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6489,8 +6539,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा नहीं है और "
-"AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा "
+"नहीं है और AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6499,8 +6549,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI फ़ीचर्स "
-"और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI "
+"फ़ीचर्स और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6616,8 +6666,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
-"जानकारी के साथ ईमेल लिखें।"
+"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
+"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6626,8 +6676,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
-"जानकारी के साथ ईमेल लिखें।"
+"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
+"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6648,8 +6698,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी में लोगों को "
-"आमंत्रित करने के लिए है।"
+"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी "
+"में लोगों को आमंत्रित करने के लिए है।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6658,8 +6708,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग बढ़ाने की मेरी "
-"रणनीतियों के बारे में लिखना है।"
+"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग "
+"बढ़ाने की मेरी रणनीतियों के बारे में लिखना है।"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6791,9 +6841,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। पेज का कंटेंट "
-"तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग में पेजों को ऑटोमैटिकली अटैच "
-"करने का विकल्प न चुना हो।"
+"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। "
+"पेज का कंटेंट तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग "
+"में पेजों को ऑटोमैटिकली अटैच करने का विकल्प न चुना हो।"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6803,8 +6853,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। कृपया अपनी "
-"ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) करें और फिर से कोशिश करें।"
+"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। "
+"कृपया अपनी ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) "
+"करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6813,8 +6864,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस चैट को अब "
-"कल जारी रखें।"
+"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस "
+"चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -6830,8 +6881,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन कंपनी हैं, "
-"जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने हाथ में लेना चाहते हैं।"
+"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन "
+"कंपनी हैं, जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने "
+"हाथ में लेना चाहते हैं।"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6846,8 +6898,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी आसान "
-"होगा: https://duck.ai"
+"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी "
+"आसान होगा: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6862,8 +6914,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम कोड "
-"%1$s को %2$s पर ईमेल करें"
+"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम "
+"कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6884,9 +6936,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता है। इसे बंद करने "
-"से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी %1$sduck.ai%2$s पर जा सकते हैं "
-"सीधे ही।"
+"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता "
+"है। इसे बंद करने से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी "
+"%1$sduck.ai%2$s पर जा सकते हैं सीधे ही।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6897,10 +6949,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा "
-"मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग को बंद करने से "
-"DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर "
-"भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Duck.ai का इस्तेमाल कर सकते हैं।"
+"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
+"सुविधा मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग "
+"को बंद करने से DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, "
+"यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
+"Duck.ai का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6915,8 +6968,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी रख "
-"सकते हैं।"
+"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी "
+"रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6930,8 +6983,8 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता संबंधी कोई जांच "
-"नहीं होती है।"
+"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता "
+"संबंधी कोई जांच नहीं होती है।"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -6965,9 +7018,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, बिना साइन "
-"अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, गोपनीयता "
-"केंद्रित AI, बिना खाता AI चैट"
+"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, "
+"बिना साइन अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, "
+"गोपनीयता केंद्रित AI, बिना खाता AI चैट"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6995,12 +7048,13 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास "
-"जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार दिखाना है: कभी नहीं "
-"(यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी "
-"दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब "
-"नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, "
-"DuckAssist सिर्फ़ अमेरिका (अंग्रेज़ी) में उपलब्ध है।"
+"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके "
+"बारे में खास जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार "
+"दिखाना है: कभी नहीं (यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा "
+"देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते "
+"हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई "
+"तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, DuckAssist सिर्फ़ अमेरिका "
+"(अंग्रेज़ी) में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7010,8 +7064,8 @@ msgid ""
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा है जो "
-"OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
+"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा "
+"है जो OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7021,8 +7075,8 @@ msgid ""
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा है जो "
-"OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
+"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा "
+"है जो OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7034,12 +7088,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
-"क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और संबंधित साइटों को "
-"स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे जुड़ी खास जानकारी को जनरेट करने "
-"के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल "
-"इसके जवाब Wikipedia और संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं "
-"की जाती है।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज "
+"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और "
+"संबंधित साइटों को स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे "
+"जुड़ी खास जानकारी को जनरेट करने के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी "
+"का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल इसके जवाब Wikipedia और "
+"संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7053,13 +7107,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज "
-"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके क्वेरी से जुड़ी "
-"सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने "
-"के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा "
-"एक या दो स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, ताकि "
-"आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है कि जवाब, दूसरे "
-"स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर आधारित होते हैं।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम "
+"रहकर, खोज संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को "
+"स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी "
+"जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल "
+"लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा एक या दो "
+"स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, "
+"ताकि आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है "
+"कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"आधारित होते हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7067,8 +7123,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते हैं और इनकी "
-"सटीकता की जांच नहीं की जाती है।"
+"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते "
+"हैं और इनकी सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7077,8 +7133,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। कृपया इस चैट को "
-"अब कल जारी रखें।"
+"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। "
+"कृपया इस चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7087,8 +7143,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
-"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
+"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7097,8 +7153,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
-"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
+"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7107,7 +7163,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
+"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7116,8 +7173,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस "
-"अनाम कोड %1$s को %2$s पर ईमेल करें"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो "
+"कृपया इस अनाम कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7126,7 +7183,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से कोशिश करें।"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7165,7 +7223,7 @@ msgstr "DuckDuckGo ब्राउज़र %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo हेल्प पेज"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7282,8 +7340,9 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी मेटाडेटा जैसी "
-"व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को एनोनिमाइज़ कर देता है।"
+"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी "
+"मेटाडेटा जैसी व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को "
+"एनोनिमाइज़ कर देता है।"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7291,8 +7350,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की %2$s से "
-"सहमत होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की "
+"%2$s से सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7301,8 +7360,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से सहमत "
-"होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से "
+"सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7311,9 +7370,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता है, जिसमें "
-"Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर आपको अन्य वेबसाइटों पर "
-"ट्रैक करने की कोशिश करते हैं।"
+"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता "
+"है, जिसमें Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर "
+"आपको अन्य वेबसाइटों पर ट्रैक करने की कोशिश करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7325,11 +7384,12 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो यह केवल "
-"आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो आपकी डिवाइस उसे हमें "
-"भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर बनाने के लिए करते हैं और फिर हम "
-"तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने "
-"इस तकनीक को कैसे डिज़ाइन किया है, इसके बारे में और जानें%2$s।"
+"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो "
+"यह केवल आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो "
+"आपकी डिवाइस उसे हमें भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर "
+"बनाने के लिए करते हैं और फिर हम तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही "
+"रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने इस तकनीक को कैसे डिज़ाइन "
+"किया है, इसके बारे में और जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7349,8 +7409,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक के बेहतर "
-"परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
+"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक "
+"के बेहतर परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7442,9 +7502,10 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक शब्दों की लंबी "
-"सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों का चयन करते हैं, यह सुनिश्चित "
-"करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर लंबा है।"
+"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक "
+"शब्दों की लंबी सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों "
+"का चयन करते हैं, यह सुनिश्चित करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर "
+"लंबा है।"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7515,8 +7576,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब तैयार "
-"होगा।"
+"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब "
+"तैयार होगा।"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7654,8 +7715,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना विचार बदल सकते "
-"हैं।"
+"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना "
+"विचार बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7698,8 +7759,9 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते हैं, लेकिन फिर "
-"भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते हैं।"
+"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते "
+"हैं, लेकिन फिर भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7861,8 +7923,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह आपके नए पासफ्रेज़ के "
-"तहत आपके डेटा को बचाएगा।"
+"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह "
+"आपके नए पासफ्रेज़ के तहत आपके डेटा को बचाएगा।"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7888,8 +7950,8 @@ msgstr "टेक्स्ट डालें"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s उपनाम "
-"%6$s: d%7$s"
+"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s "
+"उपनाम %6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7990,15 +8052,15 @@ msgstr "मैप का विस्तार करें"
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
-"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी की सचमुच "
-"परवाह है।"
+"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी "
+"की सचमुच परवाह है।"
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "समय-सीमा समाप्त"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8012,7 +8074,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "%1$s को समाप्त होगा"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8275,8 +8337,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार संंबंधी कार्यों में मदद "
-"मिलती है।"
+"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार "
+"संंबंधी कार्यों में मदद मिलती है।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8285,8 +8347,9 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की कोशिश में मदद "
-"मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे आपने शेयर किया है।"
+"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की "
+"कोशिश में मदद मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे "
+"आपने शेयर किया है।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8294,8 +8357,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी वेबसाइट में कॉपी "
-"पेस्ट करें।"
+"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी "
+"वेबसाइट में कॉपी पेस्ट करें।"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8384,7 +8447,9 @@ msgstr "इमेज खोज परिणामों से AI-जनरे�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr "इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर जानें%2$s"
+msgstr ""
+"इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर "
+"जानें%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8462,7 +8527,9 @@ msgstr "अपने नज़दीक के परिणामों को �
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती है।"
+msgstr ""
+"अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती "
+"है।"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8526,8 +8593,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई मेन्यू विकल्प चुनें "
-"या कोई बटन क्लिक करें।"
+"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई "
+"मेन्यू विकल्प चुनें या कोई बटन क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8675,8 +8742,8 @@ msgstr "व्यावसायिक रूप से शेयर और उ�
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
 msgstr ""
-"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट नहीं की "
-"जाएंगी।"
+"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट "
+"नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8757,8 +8824,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट देखें...</"
-"strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
+"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट "
+"देखें...</strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9044,15 +9111,14 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"प्राप्त करें DuckDuckGo VPN, एडवांस्ड Duck.ai, Personal Info Removal, और Identity "
-"Theft Restoration."
+"प्राप्त करें DuckDuckGo VPN, एडवांस्ड Duck.ai, Personal Info Removal, और "
+"Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"DuckDuckGo VPN, एडवांस्ड Duck.ai, और Identity Theft Restoration प्राप्त करें।"
+msgstr "DuckDuckGo VPN, एडवांस्ड Duck.ai, और Identity Theft Restoration प्राप्त करें।"
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9132,8 +9198,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, Personal Info Removal, और Identity Theft "
-"Restoration पाएं।"
+"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, Personal Info Removal, और Identity "
+"Theft Restoration पाएं।"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9142,7 +9208,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, और Identity Theft Restoration प्राप्त करें।"
+"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, और Identity Theft Restoration "
+"प्राप्त करें।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9151,8 +9218,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस प्राप्त करें, जिसमें "
-"हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
+"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस "
+"प्राप्त करें, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9163,8 +9231,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo सब्सक्रिप्शन के साथ, "
-"जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
+"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo "
+"सब्सक्रिप्शन के साथ, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी "
+"शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9208,8 +9277,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"हमारा तेज़, नो-लॉग VPN पाएं, साथ ही ज़्यादा चैट लिमिट वाले एडवांस्ड AI मॉडल का ऑप्शनल "
-"एक्सेस और कई प्रीमियम प्रोटेक्शन भी पाएं।"
+"हमारा तेज़, नो-लॉग VPN पाएं, साथ ही ज़्यादा चैट लिमिट वाले एडवांस्ड AI मॉडल "
+"का ऑप्शनल एक्सेस और कई प्रीमियम प्रोटेक्शन भी पाएं।"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9270,7 +9339,8 @@ msgstr "ऐप प्राप्त करें"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"DuckDuckGo ब्राउज़र मुफ़्त में डाउनलोड करें और %1$sYouTube पर विज्ञापन ब्लॉक करें।%2$s"
+"DuckDuckGo ब्राउज़र मुफ़्त में डाउनलोड करें और %1$sYouTube पर विज्ञापन ब्लॉक "
+"करें।%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9292,7 +9362,9 @@ msgstr "यह गाना यहां पाएंः"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr "आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद करें!"
+msgstr ""
+"आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद "
+"करें!"
 
 # smartling.placeholder_format=C
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
@@ -9329,9 +9401,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में जाएं और "
-"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › टेक्स्ट कोड कॉपी "
-"करें%4$sपर जाएं"
+"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में "
+"जाएं और %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › "
+"टेक्स्ट कोड कॉपी करें%4$sपर जाएं"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9340,8 +9412,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
-"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9351,8 +9423,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
-"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और इस कोड को स्कैन करें:"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और "
+"इस कोड को स्कैन करें:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9362,9 +9435,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
-"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या अपनी रिकवरी PDF "
-"पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या "
+"अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9373,6 +9446,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"%1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ "
+"सिंक करें%4$s पर जाएँ."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9387,8 +9462,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि \"स्थान "
-"सेवाएं\" चालू है।"
+"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि "
+"\"स्थान सेवाएं\" चालू है।"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9397,8 +9472,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे स्क्रॉल करके "
-"%3$sDuckDuckGo%4$s पर जाएं।"
+"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे "
+"स्क्रॉल करके %3$sDuckDuckGo%4$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9488,7 +9563,7 @@ msgstr "समझ गया"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "समझ गए"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10087,8 +10162,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist उत्तरों में मुख्य "
-"तथ्यों को हाइलाइट करता है।"
+"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist "
+"उत्तरों में मुख्य तथ्यों को हाइलाइट करता है।"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10115,8 +10190,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s दबाएं%3$s। %4$sफिर "
-"%5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
+"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s "
+"दबाएं%3$s। %4$sफिर %5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10130,8 +10205,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा गोपनीयता "
-"संरक्षण खो देंगे।"
+"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा "
+"गोपनीयता संरक्षण खो देंगे।"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10181,8 +10256,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं और इनका "
-"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते "
+"हैं और इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10324,8 +10399,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह व्यवहारकुशलता से "
-"बात करनी चाहिए और क्या कहना चाहिए?"
+"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह "
+"व्यवहारकुशलता से बात करनी चाहिए और क्या कहना चाहिए?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10447,8 +10522,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ कौन-सी हैं और "
-"क्यों?"
+"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ "
+"कौन-सी हैं और क्यों?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10483,8 +10558,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट > 'स्थान और "
-"गोपनीयता रीसेट करें' पर जाएं%2$s।"
+"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट "
+"> 'स्थान और गोपनीयता रीसेट करें' पर जाएं%2$s।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10494,8 +10569,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > सेटिंग्‍स > साइट सेटिंग्स "
-"> स्थान%2$s पर जाएं, और सुनिश्चित करें कि DuckDuckGo को स्थान एक्सेस की अनुमति है।"
+"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > "
+"सेटिंग्‍स > साइट सेटिंग्स > स्थान%2$s पर जाएं, और सुनिश्चित करें कि "
+"DuckDuckGo को स्थान एक्सेस की अनुमति है।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10510,8 +10586,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज इंजन%4$s "
-"की सूची में जोड़ना होगा"
+"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज "
+"इंजन%4$s की सूची में जोड़ना होगा"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10520,8 +10596,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, तो आप सीधे "
-"%1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
+"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, "
+"तो आप सीधे %1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10530,15 +10606,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर करने के लिए "
-"आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के रूप में अपने डिवाइस पर सेव "
-"कर सकते हैं।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर "
+"करने के लिए आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के "
+"रूप में अपने डिवाइस पर सेव कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें %2$s"
+msgstr ""
+"अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10548,15 +10626,17 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे %1$s या "
-"%2$s संस्करणों का उपयोग करें।"
+"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे "
+"%1$s या %2$s संस्करणों का उपयोग करें।"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ खोलें)"
+msgstr ""
+"अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ "
+"खोलें)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10685,7 +10765,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में सुधार करता है"
+"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में "
+"सुधार करता है"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10698,8 +10779,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों को रीडायरेक्ट करना "
-"आवश्यक है। %1$sऔर जानें%2$s।"
+"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों "
+"को रीडायरेक्ट करना आवश्यक है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10710,8 +10791,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य डिवाइस के "
-"साथ सिंक करें” चुनें।"
+"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य "
+"डिवाइस के साथ सिंक करें” चुनें।"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10726,8 +10807,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते हैं कि हम क्या "
-"जानकारी संग्रहित करते हैं।"
+"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते "
+"हैं कि हम क्या जानकारी संग्रहित करते हैं।"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11063,7 +11144,9 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश बताएं।"
+msgstr ""
+"क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश "
+"बताएं।"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11114,7 +11197,8 @@ msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा बार) ठीक है"
+"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा "
+"बार) ठीक है"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11133,9 +11217,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और Microsoft के विज्ञापन "
-"नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे मर्चेंट लैंडिंग पेज पर ले जाते हैं और "
-"विज्ञापनों के विपरीत, DuckDuckGo को इन परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
+"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और "
+"Microsoft के विज्ञापन नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे "
+"मर्चेंट लैंडिंग पेज पर ले जाते हैं और विज्ञापनों के विपरीत, DuckDuckGo को इन "
+"परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11144,8 +11229,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और अधिक सुरक्षित "
-"भी है।"
+"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और "
+"अधिक सुरक्षित भी है।"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11454,7 +11539,7 @@ msgstr "%1$sज़्यादा%2$s जानें"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "और जानें"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11630,7 +11715,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"यह आपको Duck.ai पर सर्च क्वेरी और प्रॉम्प्ट सबमिट करने के बीच स्विच करने की सुविधा देता है"
+"यह आपको Duck.ai पर सर्च क्वेरी और प्रॉम्प्ट सबमिट करने के बीच स्विच करने की "
+"सुविधा देता है"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11722,7 +11808,9 @@ msgstr "लिंक्स:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी लिस्ट दें।"
+msgstr ""
+"इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी "
+"लिस्ट दें।"
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12091,7 +12179,7 @@ msgstr "मैनेज करें"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "मैनेज करें"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12348,7 +12436,7 @@ msgstr "मेनू"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "इस पॉइंट के आगे के मेसेज सिर्फ़ आपको ही दिखाई देंगे."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12379,8 +12467,8 @@ msgstr "माइक्रोनेशिया"
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
 msgstr ""
-"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की अनुमति दें और फिर "
-"से प्रयास करें।"
+"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की "
+"अनुमति दें और फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12722,7 +12810,7 @@ msgstr "Duck.ai के बारे में और भी"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "ज़्यादा एक्शंस"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12922,7 +13010,7 @@ msgstr "म्यूटेड रेड"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "मेरे डिवाइस"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13164,10 +13252,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से "
-"DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को "
-"रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और "
-"नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और "
+"अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
+"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से "
+"पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी "
+"स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13989,8 +14078,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s आइकन "
-"> सेटिंग्स%5$s पर क्लिक करें"
+"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s "
+"आइकन > सेटिंग्स%5$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -13999,6 +14088,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी "
+"दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएँ"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14007,6 +14098,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी "
+"दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएँ और इस कोड को स्कैन करें:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14015,6 +14108,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी "
+"दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएँ. या अपनी रिकवरी PDF पर मौजूद QR "
+"कोड को स्कैन करें."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14042,8 +14138,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया %1$s पेज या उससे "
-"कम वाली फ़ाइलें अपलोड करें।"
+"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया "
+"%1$s पेज या उससे कम वाली फ़ाइलें अपलोड करें।"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14070,8 +14166,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल पैरामीटर%2$s पेज "
-"पर है।"
+"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल "
+"पैरामीटर%2$s पेज पर है।"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14086,7 +14182,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में फिर से प्रयास करें।"
+"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में "
+"फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14409,8 +14506,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में हो। हम आपको — "
-"अवधि में ट्रैक नहीं करते हैं।"
+"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में "
+"हो। हम आपको — अवधि में ट्रैक नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14424,8 +14521,8 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"हमारा तेज़, नो-लॉग VPN ज़्यादा लिमिट वाले स्मार्ट AI चैट्स और ज़्यादा प्रीमियम प्रोटेक्शन के "
-"साथ आता है। सब कुछ एक ही सब्सक्रिप्शन में।"
+"हमारा तेज़, नो-लॉग VPN ज़्यादा लिमिट वाले स्मार्ट AI चैट्स और ज़्यादा "
+"प्रीमियम प्रोटेक्शन के साथ आता है। सब कुछ एक ही सब्सक्रिप्शन में।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14433,8 +14530,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर नहीं "
-"करते हैं।"
+"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर "
+"नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14442,8 +14539,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, एनक्रिप्शन "
-"एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
+"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, "
+"एनक्रिप्शन एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14696,8 +14793,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, ब्राउज़र "
-"फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
+"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, "
+"ब्राउज़र फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14767,7 +14864,7 @@ msgstr "पिछला साल"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "पेस्ट करें"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14785,7 +14882,7 @@ msgstr "सिंक कोड पेस्ट करें"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "इसे नीचे पेस्ट करें"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14844,7 +14941,7 @@ msgstr "फ़ारसी"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14853,6 +14950,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal उन डेटा ब्रोकर साइट्स पर आपकी जानकारी ढूंढता है "
+"जो उसे बेच रही हैं. फिर हम इसे आपके लिए हटवाने का काम करते हैं."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14923,9 +15022,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो AI की मदद से "
-"दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। उन्हें बंद "
-"करने और Assist बटन छिपाने के लिए %1$sखोज सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो AI की मदद से दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर "
+"जवाब अक्सर मिलते हैं। उन्हें बंद करने और Assist बटन छिपाने के लिए %1$sखोज "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14934,9 +15034,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
-"के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इस फ़ीचर के काम करने के "
-"तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, %1$sDuckAssist सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो DuckAssist के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। "
+"इस फ़ीचर के काम करने के तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, "
+"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14946,9 +15047,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
-"अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इसे बंद करने और "
-"Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist Settings%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो DuckAssist अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते "
+"हैं। इसे बंद करने और Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist "
+"Settings%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14981,8 +15083,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, Mistral, "
-"वगैरह।"
+"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, "
+"Mistral, वगैरह।"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15001,7 +15103,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा उपलब्ध नहीं होगी।"
+"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा "
+"उपलब्ध नहीं होगी।"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15014,8 +15117,8 @@ msgstr "कोई विशिष्ट समस्या चुनें"
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए निर्देशों का "
-"पालन करें।"
+"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए "
+"निर्देशों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15104,8 +15207,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया निम्नलिखित "
-"चुनौती को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया "
+"निम्नलिखित चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15114,8 +15217,8 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया निम्नलिखित चुनौती "
-"को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया "
+"निम्नलिखित चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15148,8 +15251,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट सेशन डिलीट हो "
-"जाएगा।"
+"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट "
+"सेशन डिलीट हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15158,8 +15261,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
-"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या गैरकानूनी है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
+"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या "
+"गैरकानूनी है।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15168,8 +15272,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
-"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या नुकसानदेह है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
+"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या "
+"नुकसानदेह है।"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15322,8 +15427,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
-"प्रभावित नहीं करेगा।"
+"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या "
+"सुझावों को प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15386,7 +15491,8 @@ msgstr "खराब फॉर्मेटिंग"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
-"लोकप्रिय AI मॉडल उपलब्ध हैं। किसी अकाउंट की ज़रूरत नहीं है। चैट हमारे द्वारा अनाम की गईं।"
+"लोकप्रिय AI मॉडल उपलब्ध हैं। किसी अकाउंट की ज़रूरत नहीं है। चैट हमारे द्वारा "
+"अनाम की गईं।"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15896,8 +16002,8 @@ msgstr "मुझे प्रॉम्प्ट करें"
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
 msgstr ""
-"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के लिए प्रेरित "
-"करें।"
+"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के "
+"लिए प्रेरित करें।"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15916,7 +16022,8 @@ msgstr "खोजते और ब्राउज़ करते समय अ�
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
 msgstr ""
-"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को सुरक्षित रखें।"
+"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को "
+"सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15941,7 +16048,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का टेक्स्ट यहां डालें।]"
+"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का "
+"टेक्स्ट यहां डालें।]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16116,7 +16224,7 @@ msgstr "वेबसाइट पढ़ी जा रही है…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "क्या आप सूर्य ग्रहण के लिए तैयार हैं?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16159,16 +16267,16 @@ msgstr "रीज़निंग जटिल सवालों के बे�
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन यह 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता "
-"है। %1$s"
+"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन यह 2-5 गुना जल्दी उपयोग सीमा तक "
+"पहुंच जाता है। %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
-"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन इसमें लिमिट्स का इस्तेमाल 2-5 गुना तेज़ी से होता "
-"है। %1$s"
+"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन इसमें लिमिट्स का इस्तेमाल 2-5 "
+"गुना तेज़ी से होता है। %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16218,8 +16326,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
-"पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
+"स्थानीय स्तर पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16228,8 +16336,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
-"पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
+"स्थानीय स्तर पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16239,9 +16347,10 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
-"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि "
-"आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके।"
+"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स "
+"भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर "
+"पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया "
+"जा सके।"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16315,7 +16424,7 @@ msgstr "रिकवरी कोड"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "रिकवरी कोड"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16383,8 +16492,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट के आकार को "
-"घटाता है"
+"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट "
+"के आकार को घटाता है"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16525,8 +16634,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने ब्राउज़र के &quot;"
-"रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
+"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने "
+"ब्राउज़र के &quot;रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16572,7 +16681,7 @@ msgstr "%1$s हटाएं"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "डिवाइस हटाएँ"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16620,13 +16729,13 @@ msgstr "अनावश्यक विराम चिह्न हटाएं
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "इंटरनेट से अपनी जानकारी हटाएँ"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "ऑनलाइन अपनी जानकारी हटाएँ"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16634,8 +16743,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई देते "
-"हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप "
+"से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16643,8 +16752,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई "
-"देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर "
+"स्वचालित रूप से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित "
+"होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16702,9 +16812,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए DuckDuckGo को "
-"भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए आपकी अनाम प्रतिक्रिया भी "
-"%1$s के साथ शेयर की जाती है।"
+"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए "
+"DuckDuckGo को भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए "
+"आपकी अनाम प्रतिक्रिया भी %1$s के साथ शेयर की जाती है।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16712,8 +16822,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
-"पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई "
+"भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16722,9 +16832,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें आपने इस पेज लोड के "
-"दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
-"पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें "
+"आपने इस पेज लोड के दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने "
+"फ़ीडबैक में कोई भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16816,9 +16926,10 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। AI की मदद से दिए गए "
-"जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन हैं।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। AI की मदद से दिए गए जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16827,9 +16938,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। DuckAssist हमारी "
-"%1$sसेवा की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। DuckAssist हमारी %1$sसेवा की शर्तों%2$s के अधीन है।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16839,10 +16950,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। ये वेब सामग्री के आधार "
-"पर तैयार किए जाते हैं और इनमें कुछ गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा "
-"की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। ये वेब सामग्री के आधार पर तैयार किए जाते हैं और इनमें कुछ "
+"गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा की शर्तों%2$s के अधीन "
+"है।"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16919,7 +17031,8 @@ msgstr "परिणामों में ब्लॉक की गई सा�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में मैनेज कर सकते हैं।"
+"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में "
+"मैनेज कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17268,8 +17381,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और एन्क्रिप्टेड स्टोरेज के "
-"साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
+"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और "
+"एन्क्रिप्टेड स्टोरेज के साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17282,7 +17395,9 @@ msgstr "अपनी सबसे हाल की 30 चैट तक को �
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच सुरक्षित रखें।"
+msgstr ""
+"एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच "
+"सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17318,7 +17433,7 @@ msgstr "Duck.ai से रूबरू हों"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Duck.ai से रूबरू हों – DuckDuckGo की मुफ़्त, गोपनीय AI चैट।"
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17436,8 +17551,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या %5$sनया जोड़ें%6$s) "
-"क्लिक करें"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या "
+"%5$sनया जोड़ें%6$s) क्लिक करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17446,8 +17561,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर क्लिक करें (या %5$sनया "
-"जोड़ें%6$s)।"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर "
+"क्लिक करें (या %5$sनया जोड़ें%6$s)।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17466,8 +17581,8 @@ msgstr "नीचे स्क्रॉल करें और सूची म�
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह आपकी लोकेशन "
-"यानी स्थान का इस्तेमाल कर सके।"
+"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह "
+"आपकी लोकेशन यानी स्थान का इस्तेमाल कर सके।"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17527,11 +17642,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा करने के लिए "
-"यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक संक्षिप्त जवाब तैयार करता है। "
-"आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी नहीं, केवल मांग पर (जब आप 'Assist' पर "
-"क्लिक करें), कभी-कभी (जब यह बहुत प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू "
-"हो)। फिलहाल, Search Assist केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
+"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा "
+"करने के लिए यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक "
+"संक्षिप्त जवाब तैयार करता है। आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी "
+"नहीं, केवल मांग पर (जब आप 'Assist' पर क्लिक करें), कभी-कभी (जब यह बहुत "
+"प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू हो)। फिलहाल, Search Assist "
+"केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17539,8 +17655,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय जानकारी नहीं "
-"मिली। कुछ और सर्च करके देखें।"
+"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय "
+"जानकारी नहीं मिली। कुछ और सर्च करके देखें।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17549,9 +17665,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब तैयार करता "
-"है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि संबंधित सामग्री मिल सके, "
-"और फिर मिली जानकारी के आधार पर AI की मदद से एक संक्षिप्त उत्तर तैयार करता है।"
+"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब "
+"तैयार करता है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि "
+"संबंधित सामग्री मिल सके, और फिर मिली जानकारी के आधार पर AI की मदद से एक "
+"संक्षिप्त उत्तर तैयार करता है।"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17672,8 +17789,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे Wikipedia पर "
-"“ducks” को खोजा जाएगा।"
+"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे "
+"Wikipedia पर “ducks” को खोजा जाएगा।"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17692,8 +17809,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र में गोपनीय वेब खोज "
-"जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
+"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र "
+"में गोपनीय वेब खोज जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17701,8 +17818,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट अनुरोध का उपयोग "
-"होगा)"
+"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट "
+"अनुरोध का उपयोग होगा)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17714,11 +17831,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल स्टोरेज में रखा जाता "
-"है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके अपनी सेटिंग को क्लाउड में किसी "
-"रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान "
-"योग्य जानकारी स्टोर नहीं की जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं "
-"जाएगा।"
+"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल "
+"स्टोरेज में रखा जाता है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके "
+"अपनी सेटिंग को क्लाउड में किसी रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते "
+"हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान योग्य जानकारी स्टोर नहीं की "
+"जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं जाएगा।"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17821,8 +17938,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17831,8 +17948,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17841,8 +17958,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17851,8 +17968,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप से स्टोर करें, और "
-"उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप "
+"से स्टोर करें, और उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17867,8 +17984,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर किया गया। आपके "
-"अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
+"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर "
+"किया गया। आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18018,7 +18135,9 @@ msgstr "Safari मेनू से %1$s'इस वेबसाइट के ल�
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज करें"
+msgstr ""
+"%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज "
+"करें"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18028,13 +18147,17 @@ msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट �
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें"
+msgstr ""
+"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
+"करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें।"
+msgstr ""
+"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
+"करें।"
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18083,7 +18206,8 @@ msgstr "ड्रॉपडाउन मेनू से %1$sएड-ऑन प्
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) "
+"चुनें"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18091,7 +18215,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) "
+"चुनें"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18156,8 +18281,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी पसंद का कोई "
-"एक विकल्प) चुनें"
+"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी "
+"पसंद का कोई एक विकल्प) चुनें"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18279,8 +18404,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब देना है। ये निर्देश आगे "
-"चलकर आपके सभी वार्तालापों पर लागू होंगे।"
+"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब "
+"देना है। ये निर्देश आगे चलकर आपके सभी वार्तालापों पर लागू होंगे।"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18307,7 +18432,7 @@ msgstr "सर्बियन (लैटिन)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "सर्वर डेटा डिलीट कर दिया गया"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18403,8 +18528,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी डिवाइसों पर "
-"सिंक रख सकें।"
+"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी "
+"डिवाइसों पर सिंक रख सकें।"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18467,7 +18592,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "शेयर करें"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18511,8 +18636,9 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की सटीकता बेहतर "
-"हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं बताता है।"
+"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की "
+"सटीकता बेहतर हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं "
+"बताता है।"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18608,8 +18734,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और हानिकारक "
-"रिपोर्ट के लिए आवश्यक है)"
+"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और "
+"हानिकारक रिपोर्ट के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18621,13 +18747,13 @@ msgstr "खोज बॉक्स पर अपने विचार साझ�
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "शेयर किए गए चैट लिंक"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "शेयर किए गए चैट लिंक"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18636,8 +18762,8 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"हमारे नो-लॉग, तेज़ VPN के साथ अपनी ऑनलाइन गतिविधि को सुरक्षित रखें। सेटअप करने में सरल "
-"और किसी भी समय चालू या बंद करने में आसान।"
+"हमारे नो-लॉग, तेज़ VPN के साथ अपनी ऑनलाइन गतिविधि को सुरक्षित रखें। सेटअप "
+"करने में सरल और किसी भी समय चालू या बंद करने में आसान।"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18758,7 +18884,8 @@ msgstr "DuckAssist <sup>बीटा</sup> दिखाएं"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर सकते हैं।)"
+"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर "
+"सकते हैं।)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18996,9 +19123,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
-"गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की गोपनीयता "
-"प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
+"खोज गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की "
+"गोपनीयता प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19006,9 +19133,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
-"हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज सुरक्षा "
-"प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
+"खोज हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे "
+"खोज सुरक्षा प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19046,7 +19173,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर दिखाता है"
+"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर "
+"दिखाता है"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19306,7 +19434,7 @@ msgstr "कुछ गड़बड़ हुई है"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "इस शेयर की गई चैट को लोड करने में कुछ गड़बड़ हुई है."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19348,7 +19476,9 @@ msgstr "कभी-कभी"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों में बताएं।"
+msgstr ""
+"माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों "
+"में बताएं।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19387,8 +19517,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी इमेज या फ़ॉर्मेट "
-"आज़माएं।"
+"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी "
+"इमेज या फ़ॉर्मेट आज़माएं।"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19397,7 +19527,8 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन किया गया है।"
+"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन "
+"किया गया है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19412,14 +19543,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने के लिए, %1$sयहाँ "
-"क्लिक करें%2$s।"
+"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने "
+"के लिए, %1$sयहाँ क्लिक करें%2$s।"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास करें।"
+msgstr ""
+"क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19474,8 +19607,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा हिस्सा चुनकर फिर से "
-"प्रयास करें।"
+"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा "
+"हिस्सा चुनकर फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19825,8 +19958,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक इमेज बनाने "
-"के लिए बाद में वापस आएं।"
+"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक "
+"इमेज बनाने के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19895,8 +20028,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' वाले कार्ड पर "
-"लिखने के लिए वाक्य सुझाएं?"
+"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' "
+"वाले कार्ड पर लिखने के लिए वाक्य सुझाएं?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20153,7 +20286,7 @@ msgstr "मॉडल स्विच करें"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "मॉडल स्विच करें"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20233,8 +20366,8 @@ msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
 msgstr ""
-"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर विज़िबिलिटी ज़ीरो "
-"होगी"
+"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर "
+"विज़िबिलिटी ज़ीरो होगी"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20289,7 +20422,8 @@ msgstr "Sync & Backup चालू है!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा सकता।"
+"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा "
+"सकता।"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20338,25 +20472,26 @@ msgid ""
 msgstr ""
 "सिंक रिकवरी कोड\n"
 "\n"
-" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai चैट को "
-"सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक किया हुआ डेटा "
-"रिकवर कर सकते हैं।\n"
+" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai "
+"चैट को सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक "
+"किया हुआ डेटा रिकवर कर सकते हैं।\n"
 "\n"
 "इस जानकारी को सुरक्षित और गोपनीय रखें।\n"
-"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस कर सकता "
-"है।\n"
+"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस "
+"कर सकता है।\n"
 "\n"
 "%1$s\n"
 "\n"
 "यह कोड कैसे काम करता है?\n"
 "1. अपने ब्राउज़र में Duck.ai पर जाएं और Duck.ai सेटिंग खोलें।\n"
-"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" चुनें\n"
-"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड यहां पेस्ट "
-"करें\" कहा गया है\n"
+"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" "
+"चुनें\n"
+"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड "
+"यहां पेस्ट करें\" कहा गया है\n"
 "\n"
-"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक DuckDuckGo "
-"ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट कर दिया जाएगा और उसे "
-"रीस्टोर नहीं किया जा सकेगा।"
+"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक "
+"DuckDuckGo ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट "
+"कर दिया जाएगा और उसे रीस्टोर नहीं किया जा सकेगा।"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20417,7 +20552,7 @@ msgstr "सिंक किए गए डिवाइस"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "%1$s को सिंक किया गया"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20455,7 +20590,7 @@ msgstr "टीवी"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "टेबल"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20489,8 +20624,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी हों, तेज़ी से एक्सेस के लिए इसे हमारे मुफ़्त ऐप "
-"में पाएं।"
+"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी हों, तेज़ी से एक्सेस के लिए इसे "
+"हमारे मुफ़्त ऐप में पाएं।"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20499,8 +20634,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी ब्राउज़ कर रहे हों, तेज़ी से एक्सेस के लिए इसे "
-"हमारे मुफ़्त ब्राउज़र में पाएं।"
+"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी ब्राउज़ कर रहे हों, तेज़ी से "
+"एक्सेस के लिए इसे हमारे मुफ़्त ब्राउज़र में पाएं।"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20744,9 +20879,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई जानकारी को "
-"किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम मामलों में इसमें पासवर्ड, "
-"या भुगतान विवरण शामिल होते हैं।"
+"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई "
+"जानकारी को किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम "
+"मामलों में इसमें पासवर्ड, या भुगतान विवरण शामिल होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20755,8 +20890,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी सेटिंग्स में कोई भी "
-"बदलाव करने की अनुमति देता है।"
+"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी "
+"सेटिंग्स में कोई भी बदलाव करने की अनुमति देता है।"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20786,8 +20921,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और सिर्फ़ आप ही इसे एक्सेस "
-"कर सकते हैं।"
+"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और "
+"सिर्फ़ आप ही इसे एक्सेस कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -20867,8 +21002,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी ब्राउज़र सेटिंग जांचें "
-"और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
+"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी "
+"ब्राउज़र सेटिंग जांचें और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20883,8 +21018,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से पहले कुछ "
-"मिनट इंतज़ार करें।"
+"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से "
+"पहले कुछ मिनट इंतज़ार करें।"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20903,9 +21038,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर ब्लॉक करके, "
-"संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका डिफ़ॉल्ट खोज इंजन बनाकर "
-"गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
+"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर "
+"ब्लॉक करके, संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका "
+"डिफ़ॉल्ट खोज इंजन बनाकर गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20943,7 +21078,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की कोशिश करें।"
+"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20952,8 +21088,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए वर्ज़न के साथ नई "
-"चैट शुरू करें।"
+"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए "
+"वर्ज़न के साथ नई चैट शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20992,8 +21128,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की गई। "
-"AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %4$s देखें)।"
+"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की "
+"गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
+"लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21003,8 +21140,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई चैट में गलत "
-"या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %2$s देखें)."
+"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई "
+"चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए "
+"%2$s देखें)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21013,8 +21151,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक जानकारी भी "
-"प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
+"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक "
+"जानकारी भी प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21024,15 +21162,15 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के जरिए "
-"जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
-"लिए %4$s देखें)।"
+"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के "
+"जरिए जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है "
+"(ज़्यादा जानकारी के लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "यह डिवाइस"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21043,6 +21181,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"यह डिवाइस अब दूसरे डिवाइस पर आपके सिंक किए गए डेटा को ऐक्सेस नहीं कर पाएगा. "
+"पिछली %1$s चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21114,7 +21254,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
+"करें"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21122,7 +21263,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें।"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21133,7 +21275,7 @@ msgstr "यह जानकारी उपयोगी नहीं है"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "यह शेयर की गई चैट की एक कॉपी है."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21142,8 +21284,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"यह केवल एक सैंपल चैट है। इसका मेन्यू (तीन डॉट्स) खोलें, फिर इसे अपनी चैट्स में सबसे ऊपर रखने के "
-"लिए 'पिन करें' चुनें!"
+"यह केवल एक सैंपल चैट है। इसका मेन्यू (तीन डॉट्स) खोलें, फिर इसे अपनी चैट्स "
+"में सबसे ऊपर रखने के लिए 'पिन करें' चुनें!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21152,7 +21294,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"यह केवल एक सैंपल चैट है। इसे डिलीट करने के लिए साइड मेन्यू में Fire Button का इस्तेमाल करें!"
+"यह केवल एक सैंपल चैट है। इसे डिलीट करने के लिए साइड मेन्यू में Fire Button "
+"का इस्तेमाल करें!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21173,8 +21316,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य मॉडल प्रदाता "
-"'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य "
+"मॉडल प्रदाता 'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21183,8 +21326,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल प्रदाता "
-"'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल "
+"प्रदाता 'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21221,8 +21364,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के साथ सेव करता है, "
-"जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
+"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के "
+"साथ सेव करता है, जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21231,8 +21374,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
-"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
+"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21242,21 +21386,22 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
-"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं। हालांकि, %1$s पर "
-"हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने वाले जवाब कभी नहीं दिखाता।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
+"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
+"सकते हैं। हालांकि, %1$s पर हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने "
+"वाले जवाब कभी नहीं दिखाता।"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "यह शेयर की गई चैट नहीं खोली जा सकी. हो सकता है कि लिंक अधूरा हो."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "यह शेयर किया गया चैट लिंक अब उपलब्ध नहीं है."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21285,7 +21430,9 @@ msgstr "यह वीडियो अब तक यहां देखे जा
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता है।"
+msgstr ""
+"यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता "
+"है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21295,8 +21442,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup डिस्कनेक्ट "
-"हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी चैट एक्सेस कर पाएंगे।"
+"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup "
+"डिस्कनेक्ट हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी "
+"चैट एक्सेस कर पाएंगे।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21305,15 +21453,16 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे पहले जैसा "
-"नहीं किया जा सकता है।"
+"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे "
+"पहले जैसा नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
 msgstr ""
-"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा सकता है।"
+"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा "
+"सकता है।"
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21436,8 +21585,7 @@ msgstr "जारी रखने के लिए, आपको Duck.ai की 
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
+msgstr "जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21446,8 +21594,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप प्रिंट करना "
-"चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
+"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप "
+"प्रिंट करना चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21457,9 +21605,10 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत होगी जिसे "
-"आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर PDF के रूप में सेव "
-"किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync सेटअप करने के लिए किया था।"
+"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत "
+"होगी जिसे आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर "
+"PDF के रूप में सेव किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync "
+"सेटअप करने के लिए किया था।"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21468,8 +21617,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo ब्राउज़र को "
-"नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
+"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo "
+"ब्राउज़र को नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21477,8 +21626,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को माइक्रोफ़ोन का "
-"एक्सेस दें।"
+"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को "
+"माइक्रोफ़ोन का एक्सेस दें।"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21500,7 +21649,9 @@ msgstr "आज"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "प्राइवेट AI चैट आज़माने के लिए टॉगल करें या %1$sइसे %2$s मेन्यू में डिसेबल करें।%3$s"
+msgstr ""
+"प्राइवेट AI चैट आज़माने के लिए टॉगल करें या %1$sइसे %2$s मेन्यू में डिसेबल "
+"करें।%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21674,8 +21825,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ करते रहें और देखें "
-"हम कितनों को ब्लॉक करते हैं।"
+"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ "
+"करते रहें और देखें हम कितनों को ब्लॉक करते हैं।"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21722,7 +21873,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में कैसे पहुंचूं?\""
+msgstr ""
+"फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में "
+"कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21731,7 +21884,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी सिनेमा हॉल तक कैसे पहुंचूं?\""
+"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी "
+"सिनेमा हॉल तक कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21896,7 +22050,7 @@ msgstr "मुफ़्त में आज़माएं"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "मुफ़्त में आज़माएँ!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21979,7 +22133,8 @@ msgstr "अलग कीवर्ड आज़माएं।"
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी अक्षम करें।"
+"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी "
+"अक्षम करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22016,7 +22171,7 @@ msgstr "मुफ़्त में आज़माएं"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "मुफ़्त में आज़माएँ!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22171,7 +22326,8 @@ msgstr "हाल ही में जोड़े गए ओपन-सोर्
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
 msgstr ""
-"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को आजमाएं"
+"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को "
+"आजमाएं"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -22211,8 +22367,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
-"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
+"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22221,8 +22377,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
-"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
+"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22264,7 +22420,7 @@ msgstr "तुर्कमेनिस्तान"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "बंद करें"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22282,7 +22438,7 @@ msgstr "Sync & Backup बंद करें"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Sync & Backup बंद करें और सर्वर डेटा डिलीट करें?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22423,8 +22579,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और दिखाई देने वाले "
-"उत्तर के बीच थोड़ा समय लग सकता है।"
+"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और "
+"दिखाई देने वाले उत्तर के बीच थोड़ा समय लग सकता है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22554,8 +22710,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर %5$sसेट "
-"पेज%6$s पर क्लिक करें।"
+"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर "
+"%5$sसेट पेज%6$s पर क्लिक करें।"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22563,8 +22719,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: https://duckduckgo."
-"com"
+"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22596,7 +22752,9 @@ msgstr "%1$sसर्च%2$s सेक्शन के नीचे, %3$sसर�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s चुनें"
+msgstr ""
+"स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s "
+"चुनें"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22680,8 +22838,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 गुना ज़्यादा "
-"उपयोग सीमाएं अनलॉक करें।"
+"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 "
+"गुना ज़्यादा उपयोग सीमाएं अनलॉक करें।"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22759,7 +22917,7 @@ msgstr "अनम्यूट करें"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "बिना शीर्षक वाली चैट"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22800,7 +22958,7 @@ msgstr "ब्राउज़र अपडेट करें"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "इस शेयर की गई चैट को देखने के लिए Duck.ai को अपडेट करें."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22839,8 +22997,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने के लिए "
-"DuckDuckGo ब्राउज़र को अपडेट करें"
+"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने "
+"के लिए DuckDuckGo ब्राउज़र को अपडेट करें"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22965,14 +23123,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज बनाने के लिए "
-"बाद में वापस आएं।"
+"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज "
+"बनाने के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में अपग्रेड करें"
+msgstr ""
+"Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में "
+"अपग्रेड करें"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23068,9 +23228,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को हैकर्स, "
-"स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। मुफ़्त। किसी खाते की ज़रूरत "
-"नहीं है।"
+"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को "
+"हैकर्स, स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। "
+"मुफ़्त। किसी खाते की ज़रूरत नहीं है।"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23125,8 +23285,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस कोड का "
-"इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस "
+"कोड का इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23134,8 +23294,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने के लिए इस "
-"कोड का इस्तेमाल करें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने "
+"के लिए इस कोड का इस्तेमाल करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23285,8 +23445,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को Microsoft के "
-"विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को "
+"Microsoft के विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23295,8 +23455,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक TripAdvisor के "
-"विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक "
+"TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23308,8 +23468,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist सेटिंग%2$s "
-"पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23318,8 +23478,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sDuckAssist "
-"सेटिंग%2$s पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए "
+"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23328,7 +23488,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का पालन करें।"
+"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का "
+"पालन करें।"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23344,8 +23505,8 @@ msgid ""
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
 "अपने दूसरे ब्राउज़र में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > %3$sSync & "
-"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के साथ सिंक "
-"करें%8$s को चुनें।"
+"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के "
+"साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23355,9 +23516,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & Backup के "
-"अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी "
-"रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & "
+"Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक "
+"करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23367,9 +23528,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > "
-"%3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस "
-"के साथ सिंक करें%8$s को चुनें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai "
+"सेटिंग%2$s > %3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद "
+"%7$sकिसी दूसरे डिवाइस के साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23379,9 +23540,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। "
-"Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" "
-"को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की "
+"सेटिंग खोलें। Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी "
+"दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड "
+"स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23434,8 +23596,8 @@ msgstr "वॉयस चैट समाप्त हो गई"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए "
-"नहीं किया जाता है।"
+"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
+"के लिए नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23579,8 +23741,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को YouTube "
-"अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
+"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को "
+"YouTube अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23600,9 +23762,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है क्योंकि हमें वहाँ "
-"से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र कंपनी है और इसका YouTube से कोई "
-"संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए जाते हैं।"
+"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है "
+"क्योंकि हमें वहाँ से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र "
+"कंपनी है और इसका YouTube से कोई संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए "
+"जाते हैं।"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23615,8 +23778,8 @@ msgstr "हम गुमनाम करते हैं"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को गुमनाम रख "
-"सकते हैं।"
+"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को "
+"गुमनाम रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23628,9 +23791,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की रिपोर्ट करने "
-"के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम जांच कर सकें और समस्या "
-"का समाधान कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की "
+"रिपोर्ट करने के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम "
+"जांच कर सकें और समस्या का समाधान कर सकें।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23642,16 +23805,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की रिपोर्ट "
-"करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस मामले की जांच करके उसे "
-"ठीक कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की "
+"रिपोर्ट करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस "
+"मामले की जांच करके उसे ठीक कर सकें।"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल कर सकते हैं।"
+"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -23659,7 +23823,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक एन्क्रिप्टेड है।"
+"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक "
+"एन्क्रिप्टेड है।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23671,7 +23836,8 @@ msgstr "हम विज्ञापनों के साथ आपको फ�
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
 msgstr ""
-"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं करते हैं।"
+"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं "
+"करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23688,8 +23854,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं करते हैं। "
-"हम आपको ट्रैक नहीं करते हैं। कभी भी।"
+"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं "
+"करते हैं। हम आपको ट्रैक नहीं करते हैं। कभी भी।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23703,8 +23869,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां वापस क्यों आए "
-"हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां "
+"वापस क्यों आए हैं:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23713,8 +23879,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस वजह से हमें "
-"आज़माना चाहते हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस "
+"वजह से हमें आज़माना चाहते हैं:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23754,8 +23920,9 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे विज्ञापनकर्ताओं को बेचने "
-"के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते हैं।"
+"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे "
+"विज्ञापनकर्ताओं को बेचने के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23781,6 +23948,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"हम डेटा ब्रोकर साइटों से आपकी व्यक्तिगत जानकारी ढूंढते हैं और हटाते हैं. "
+"Plus, VPN और बहुत कुछ पाएँ."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23789,8 +23958,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके कि आपकी चैट्स "
-"का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
+"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके "
+"कि आपकी चैट्स का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23815,8 +23984,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, आपके डेटा का "
-"फायदा उठाकर नहीं।"
+"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, "
+"आपके डेटा का फायदा उठाकर नहीं।"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23825,8 +23994,8 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते हैं। आप अक्‍सर "
-"बाद में अपना विचार बदल सकते हैं।"
+"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते "
+"हैं। आप अक्‍सर बाद में अपना विचार बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -23835,17 +24004,23 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"हम आपकी निजी जानकारी के लिए डेटा ब्रोकर साइटों को नियमित तौर से स्कैन करते "
+"हैं, और इस्तेमाल में आसान डैशबोर्ड पर अपनी प्रगति आपके साथ शेयर करते हैं."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते हैं।"
+msgstr ""
+"हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल हैं।"
+msgstr ""
+"हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23861,15 +24036,16 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा सके। "
-"%1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार तुरंत परिणामों में "
-"दिखाई ना दें।"
+"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा "
+"सके। %1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार "
+"तुरंत परिणामों में दिखाई ना दें।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले ट्रैकर्स को ब्लॉक कर देंगे।"
+"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले "
+"ट्रैकर्स को ब्लॉक कर देंगे।"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -23878,6 +24054,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"हम आपके ईमेल, नाम, पते और अन्य जानकारी के लिए डेटा ब्रोकर साइटों को स्कैन "
+"करेंगे, और आपके बारे में मिलने वाली किसी भी जानकारी को हटवाने का काम करेंगे."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23886,8 +24064,9 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। अगर आपको "
-"यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क करें।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
+"हैं। अगर आपको यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23896,8 +24075,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। कभी-कभी "
-"अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
+"हैं। कभी-कभी अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23912,7 +24091,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार मेहनत कर रहे हैं।"
+"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार "
+"मेहनत कर रहे हैं।"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23921,8 +24101,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज फिर से लोड "
-"करना होगा।"
+"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज "
+"फिर से लोड करना होगा।"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24022,7 +24202,9 @@ msgstr "साप्ताहिक उपयोग सीमा पूरी �
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
+msgstr ""
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24031,8 +24213,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट करना "
-"जारी रख सकते हैं।"
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट "
+"करना जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24046,8 +24228,9 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं "
-"और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
+"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं "
+"किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24056,8 +24239,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
-"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम "
+"उन्हें अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए "
+"नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24067,16 +24251,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित करता है। "
-"यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं करता है या उनका "
-"उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
+"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित "
+"करता है। यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं "
+"करता है या उनका उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर सकते हैं।"
+"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24144,8 +24329,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई है। पेज को "
-"रीलोड करने की कोशिश करें।"
+"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई "
+"है। पेज को रीलोड करने की कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24180,7 +24365,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए कुछ विकल्प बताएं।"
+"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए "
+"कुछ विकल्प बताएं।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24192,7 +24378,7 @@ msgstr "एन्युटी के कुछ फायदे और कुछ 
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Duck.ai के क्या फ़ायदे हैं?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24205,11 +24391,12 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र डाउनलोड करने के "
-"क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही संदर्भ लें। जवाब को स्पष्ट हिस्सों में "
-"बांटें और हर हिस्से के लिए शीर्षक दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर "
-"विशेष ध्यान दिया गया हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी "
-"अनुभव रखने वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
+"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र "
+"डाउनलोड करने के क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही "
+"संदर्भ लें। जवाब को स्पष्ट हिस्सों में बांटें और हर हिस्से के लिए शीर्षक "
+"दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर विशेष ध्यान दिया गया "
+"हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी अनुभव रखने "
+"वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24445,7 +24632,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग होता है?"
+"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग "
+"होता है?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24521,8 +24709,8 @@ msgstr "आप किस पर फीडबैक देना चाहें�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को प्रभावित नहीं "
-"करेगा।"
+"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
+"प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24548,8 +24736,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद ब्रांडों पर "
-"विचार करना चाहिए?"
+"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद "
+"ब्रांडों पर विचार करना चाहिए?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24750,8 +24938,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai के साथ, आपकी चैट को अनाम रखा जाता है और AI को प्रशिक्षित करने के लिए चैट का "
-"इस्तेमाल कभी नहीं किया जाता। '%1$s' मेन्यू में इसे कभी भी चालू या बंद करें।"
+"Duck.ai के साथ, आपकी चैट को अनाम रखा जाता है और AI को प्रशिक्षित करने के लिए "
+"चैट का इस्तेमाल कभी नहीं किया जाता। '%1$s' मेन्यू में इसे कभी भी चालू या बंद "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24766,6 +24955,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"यह डेटा ब्रोकर साइटों से आपके ईमेल, नाम, पते और अन्य जानकारी को हटाने के लिए "
+"सीधे आपके डिवाइस से काम करता है."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25014,8 +25205,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे दोबारा प्राप्त "
-"नहीं किया जा सकता है।"
+"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे "
+"दोबारा प्राप्त नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25035,7 +25226,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
+"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25044,8 +25236,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके DuckDuckGo "
-"से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
+"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके "
+"DuckDuckGo से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25059,8 +25251,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या इसे कभी भी "
-"बंद कर सकते हैं।"
+"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या "
+"इसे कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25069,22 +25261,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते हैं या इसे "
-"कभी भी बंद कर सकते हैं।"
+"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते "
+"हैं या इसे कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का भी इस्तेमाल "
-"कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का "
+"भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI Chat%2$s "
-"का भी इस्तेमाल कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI "
+"Chat%2$s का भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25098,8 +25290,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में जाकर बदल "
-"सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
+"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में "
+"जाकर बदल सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25120,8 +25312,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है और चाहे तो पहली "
-"सेटिंग को डिलीट भी कर सकते हैं।"
+"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है "
+"और चाहे तो पहली सेटिंग को डिलीट भी कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25214,8 +25406,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको पहले किसी "
-"अन्य साइट को अनब्लॉक करना होगा।"
+"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको "
+"पहले किसी अन्य साइट को अनब्लॉक करना होगा।"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25270,7 +25462,7 @@ msgstr "आपका 1 प्रयास शेष है।"
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "आपके पास कोई शेयर किए गए चैट लिंक नहीं हैं."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25279,8 +25471,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में 2 गुना "
-"ज़्यादा उपयोग सीमाएं।"
+"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में "
+"2 गुना ज़्यादा उपयोग सीमाएं।"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25289,8 +25481,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN और अन्य "
-"DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
+"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN "
+"और अन्य DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25312,8 +25504,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
-"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
+"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
+"चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25323,8 +25516,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
-"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
+"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
+"चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25352,8 +25546,9 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए भी Chrome की "
-"बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह कर सकता है:"
+"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए "
+"भी Chrome की बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह "
+"कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25366,8 +25561,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम करने के लिए "
-"सुझाव पाएं।"
+"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम "
+"करने के लिए सुझाव पाएं।"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25416,7 +25611,9 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से कोशिश करें।"
+msgstr ""
+"आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25435,7 +25632,8 @@ msgstr "आज की वॉयस चैट सीमा पूरी हो �
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
 msgstr ""
-"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से कोशिश करें।"
+"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25444,9 +25642,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। "
-"सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन की गई चैट डिलीट नहीं की "
-"जाएंगी।"
+"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त "
+"हो गई है। सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन "
+"की गई चैट डिलीट नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25456,9 +25654,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। सिंक फिर "
-"से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट कर दें। पिन की गई चैट डिलीट "
-"नहीं की जाएंगी।"
+"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई "
+"है। सिंक फिर से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट "
+"कर दें। पिन की गई चैट डिलीट नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25472,8 +25670,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस वजह से "
-"YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
+"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस "
+"वजह से YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25494,14 +25692,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
+msgstr "आपकी सबसे हाल की %1$s चैट इन ब्राउज़र के लोकल स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "आपकी Duck.ai चैट एंड-टू-एंड एनक्रिप्शन के साथ सिंक की जा रही हैं."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25533,6 +25731,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"आपका बैकअप DuckDuckGo के सर्वर से डिलीट कर दिया जाएगा. सभी डिवाइस सिंक से "
+"डिस्कनेक्ट हो जाएँगे."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25542,8 +25742,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
-"जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
+"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल "
+"स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25553,8 +25754,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
-"जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
+"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज "
+"में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25579,8 +25781,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता है।DuckDuckGo के "
-"पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
+"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता "
+"है।DuckDuckGo के पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25588,8 +25790,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo के पास इस "
-"डेटा का कभी भी एक्सेस नहीं रहा है।"
+"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo "
+"के पास इस डेटा का कभी भी एक्सेस नहीं रहा है।"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25598,8 +25800,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
-"सकती है।"
+"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी "
+"दिखाई दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25612,8 +25814,8 @@ msgstr "आपकी चैट अब सेव की जा रही है�
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता"
+"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25627,8 +25829,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25636,8 +25838,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25645,8 +25847,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
+"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25654,8 +25856,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
+"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25670,9 +25872,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI मॉडल्स को "
-"प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री सुरक्षित रखने के लिए इन चरणों "
-"का पालन करें।"
+"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI "
+"मॉडल्स को प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री "
+"सुरक्षित रखने के लिए इन चरणों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25681,7 +25883,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें जहां आपने छोड़ा था।"
+"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें "
+"जहां आपने छोड़ा था।"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25713,8 +25916,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध नहीं है। "
-"[%2$sउदाहरण संदेश%3$s]"
+"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध "
+"नहीं है। [%2$sउदाहरण संदेश%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25729,8 +25932,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए नहीं किया "
-"जाता।"
+"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए "
+"नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25759,10 +25962,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का उपयोग करके '512-"
-"बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल आपके ब्राउज़र को छोड़ देती है। "
-"हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी "
-"आपके पासफ़्रेज़ को नहीं जानता है।"
+"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का "
+"उपयोग करके '512-बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल "
+"आपके ब्राउज़र को छोड़ देती है। हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स "
+"फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी आपके पासफ़्रेज़ को नहीं जानता है।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25777,8 +25980,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान बताने वाला "
-"मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे जोड़ न सकें।"
+"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान "
+"बताने वाला मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे "
+"जोड़ न सकें।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25792,7 +25996,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा सकते हैं।"
+"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25824,8 +26029,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे परमानेंट करने के "
-"लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इनेबल करें।"
+"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे "
+"परमानेंट करने के लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इनेबल करें।"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25834,8 +26039,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे परमानेंट करने के "
-"लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
+"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे "
+"परमानेंट करने के लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर "
+"जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25855,8 +26061,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए Chrome के बजाय "
-"हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और यहां दिए गए काम कर सकता है:"
+"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए "
+"Chrome के बजाय हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और "
+"यहां दिए गए काम कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25865,8 +26072,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके फिर से "
-"कोशिश करें।"
+"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके "
+"फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25875,8 +26082,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire Button की मदद "
-"से इस बातचीत को मिटाएं।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire "
+"Button की मदद से इस बातचीत को मिटाएं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25885,7 +26092,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट शुरू करें।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट "
+"शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25900,8 +26108,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया इस चैट को अब कल "
-"जारी रखें।"
+"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया "
+"इस चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26204,7 +26412,8 @@ msgstr "ऑफ़िशियल वेबसाइट"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s अक्षर है)"
+"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s "
+"अक्षर है)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -41,6 +42,14 @@ msgstr "% potpuno cijepljenih"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% cijepljenih"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -87,7 +96,8 @@ msgstr "AI modeli %1$s i %2$s"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr "%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
+msgstr ""
+"%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -300,7 +310,8 @@ msgstr "Ljestvica %1$s još nije dostupna"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s doseže uporabna ograničenja 2 do 5 puta ranije nego osnovni modeli. %2$s"
+msgstr ""
+"%1$s doseže uporabna ograničenja 2 do 5 puta ranije nego osnovni modeli. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -371,7 +382,8 @@ msgstr "%1$s rabljeno"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s troši uporabna ograničenja do 2 do 5 puta brže od osnovnih modela %2$s"
+msgstr ""
+"%1$s troši uporabna ograničenja do 2 do 5 puta brže od osnovnih modela %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -488,6 +500,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sSaznaj kako čuvamo privatnost tvoje lokacije%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -508,7 +527,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
+msgstr ""
+"%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -780,6 +800,12 @@ msgid "2nd in Group %s"
 msgstr "2. mjesto u skupini %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -941,7 +967,8 @@ msgstr "Dostupna je nova verzija AI Chata! Osvježi ovu stranicu za nastavak."
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
+msgstr ""
+"Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1464,6 +1491,12 @@ msgid "Add to Home Screen"
 msgstr "Dodaj na početni zaslon"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Dodaci"
@@ -1827,6 +1860,13 @@ msgstr "Sve veličine"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Sve vrste"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2349,6 +2389,12 @@ msgid "Ask anything privately"
 msgstr "Privatno pitaj bilo što"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2530,7 +2576,8 @@ msgstr "Nakon završetka čavrljanja, zvuk ne pohranjujemo ni mi ni OpenAI."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
+msgstr ""
+"Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2981,7 +3028,8 @@ msgstr "Blokiraj ovu stranicu iz svih rezultata"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
+msgstr ""
+"Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3709,7 +3757,8 @@ msgstr "Promjena načina prikaza URL-ova rezultata"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
+msgstr ""
+"Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4538,7 +4587,8 @@ msgstr "Klikni %1$sPostavke%2$s u padajućem izborniku."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
+msgstr ""
+"Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5183,7 +5233,8 @@ msgstr "Nastavi blokirati oglase"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "Nedavna čavrljanja nastavi ovdje. Možeš ih i izbrisati pomoću Fire Buttona."
+msgstr ""
+"Nedavna čavrljanja nastavi ovdje. Možeš ih i izbrisati pomoću Fire Buttona."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5287,6 +5338,12 @@ msgid "Copy"
 msgstr "Kopiraj"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5326,6 +5383,28 @@ msgstr "Kopiraj ili spremi ovu šifru"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Kopiraj kôd za oporavak"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5377,7 +5456,8 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
+msgstr ""
+"Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6009,6 +6089,14 @@ msgid "Delete recent chats?"
 msgstr "Izbrisati nedavna čavrljanja?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6019,6 +6107,14 @@ msgstr "Izbrisati ovo čavrljanje?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Izbrisana čavrljanja"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6215,7 +6311,8 @@ msgstr "Onemogući i isključi"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
+msgstr ""
+"Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6274,6 +6371,13 @@ msgstr "Odbaci"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Odbaci"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6778,7 +6882,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
+msgstr ""
+"Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7102,7 +7207,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
+msgstr ""
+"DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7129,6 +7235,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo preglednik %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7255,8 +7368,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš "
-"Duck.ai-jeve %2$s."
+"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš Duck.ai-"
+"jeve %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7264,7 +7377,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
+msgstr ""
+"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7477,7 +7591,8 @@ msgstr "Slika se uređuje..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
+msgstr ""
+"Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7890,7 +8005,8 @@ msgstr "Ekvatorska Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
+msgstr ""
+"Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7955,10 +8071,25 @@ msgstr ""
 "DuckDuckGo kvalitetu."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Isteklo"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8240,8 +8371,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje "
-"web-mjesto."
+"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje web-"
+"mjesto."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8377,7 +8508,8 @@ msgstr "Pronađi <b>%1$s</b> u mapi za preuzimanje"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
+msgstr ""
+"Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8598,7 +8730,8 @@ msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
+msgstr ""
+"Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9229,7 +9362,8 @@ msgstr "Preuzmi aplikaciju"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "Nabavi besplatni preglednik DuckDuckGo %1$si blokiraj oglase na YouTubeu.%2$s"
+msgstr ""
+"Nabavi besplatni preglednik DuckDuckGo %1$si blokiraj oglase na YouTubeu.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9326,6 +9460,14 @@ msgstr ""
 "Idi na %1$sDuck.ai Postavke%2$s u svom drugom pregledniku ili u aplikaciji "
 "DuckDuckGo i idi na %3$sČavrljanja › Sync & Backup › Sinkroniziraj s drugim "
 "uređajem%4$s. Ili skeniraj QR kôd na svom PDF-u za oporavak."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9436,6 +9578,12 @@ msgstr "U redu"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Shvatio/la sam"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9801,7 +9949,8 @@ msgstr "Pomozi nam poboljšati DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
+msgstr ""
+"Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10238,7 +10387,8 @@ msgstr "Kako funkcionira"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
+msgstr ""
+"Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10497,7 +10647,8 @@ msgstr "Ako nas ipak želiš podržati, %1$spomozi proširiti DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
+msgstr ""
+"Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10805,7 +10956,8 @@ msgstr "Lako pregledavanje rezultata pretraživanja za slike i videozapise"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Infinite Scroll for Images, Videos, and Shopping"
-msgstr "Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
+msgstr ""
+"Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is accurate
@@ -11405,6 +11557,12 @@ msgstr "Saznaj %1$sViše%2$s"
 msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Saznaj %1$sViše%2$s"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -12040,6 +12198,13 @@ msgid "Manage"
 msgstr "Upravljanje"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12291,6 +12456,12 @@ msgid "Menu"
 msgstr "Izbornik"
 
 # smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
 msgstr "Metričke (kilogram, metar, celzijus)"
@@ -12318,7 +12489,8 @@ msgstr "Mikronezija"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
+msgstr ""
+"Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12659,6 +12831,12 @@ msgid "More about Duck.ai"
 msgstr "Više o Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Više na"
@@ -12851,6 +13029,12 @@ msgstr "Utišano"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Zagasito crvena"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13922,6 +14106,30 @@ msgstr ""
 "> Postavke%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14671,6 +14879,12 @@ msgid "Past year"
 msgstr "Prošla godina"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14681,6 +14895,12 @@ msgstr "Zalijepi"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Zalijepi šifru za sinkronizaciju"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14734,6 +14954,20 @@ msgstr "Trajno zatvoreno"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Perzijski"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14947,7 +15181,8 @@ msgstr "Prikvačeno"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Prikvačena čavrljanja pojavit će se na vrhu tvojih nedavnih čavrljanja."
+msgstr ""
+"Prikvačena čavrljanja pojavit će se na vrhu tvojih nedavnih čavrljanja."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15002,7 +15237,8 @@ msgstr "Ispuni sljedeći upit i potvrdi da je ovo pretraživanje izvršio čovje
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
+msgstr ""
+"Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15997,6 +16233,12 @@ msgid "Reading website…"
 msgstr "Čitanje mrežne lokacije..."
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16189,6 +16431,12 @@ msgstr "Oporavak"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Kôd za oporavak"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16398,8 +16646,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb "
-"&quot;Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
+"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb &quot;"
+"Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
 "pregledniku."
 
 # smartling.placeholder_format=C
@@ -16410,7 +16658,8 @@ msgstr "Zapamti moj izbor"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
+msgstr ""
+"Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16441,6 +16690,12 @@ msgstr "Ukloni %1$s"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "Ukloni %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16483,6 +16738,18 @@ msgstr "Ukloni odabir teksta"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Ukloni nepotrebne interpunkcijske znakove"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17142,7 +17409,8 @@ msgstr "Spremi do 30 svojih najnovijih čavrljanja lokalno na svom uređaju."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
+msgstr ""
+"Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17173,6 +17441,12 @@ msgstr "Spremi svoje postavke anonimno u oblak"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Pozdravi Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17327,7 +17601,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
+msgstr ""
+"Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17620,7 +17895,8 @@ msgstr "Pretraži putem DuckDuckGoa"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr "Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
+msgstr ""
+"Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -17670,7 +17946,8 @@ msgstr "Drugo mišljenje"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
+msgstr ""
+"Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17719,7 +17996,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
+msgstr ""
+"Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17911,7 +18189,8 @@ msgstr "Odaberi %1$sDuckDuckGo%2$s u padajućem izborniku zadanih tražilica"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr ""
+"Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18030,7 +18309,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr ""
+"Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18170,6 +18450,13 @@ msgid "Serbian (Latin)"
 msgstr "Srpski (latinica)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18270,7 +18557,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
+msgstr ""
+"Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18322,6 +18610,14 @@ msgid "Share"
 msgstr "Podijeli"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18336,7 +18632,8 @@ msgstr "Podijeli"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
+msgstr ""
+"Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18471,6 +18768,18 @@ msgid "Share your thoughts on the search box."
 msgstr "Podijeli svoje mišljenje o okviru za pretraživanje."
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
@@ -18599,7 +18908,8 @@ msgstr "Prikaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
+msgstr ""
+"Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18926,7 +19236,8 @@ msgstr "Prikazuje poruku dobrodošlice na vrhu stranice rezultata pretraživanja
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
+msgstr ""
+"Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18998,12 +19309,14 @@ msgstr "Nazivi web-mjesta"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
+msgstr ""
+"Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
+msgstr ""
+"Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19147,6 +19460,12 @@ msgid "Something went wrong"
 msgstr "Nešto nije bilo kako treba"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19188,7 +19507,8 @@ msgstr "Ponekad"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
+msgstr ""
+"Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19236,7 +19556,8 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
+msgstr ""
+"Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19316,7 +19637,8 @@ msgstr "Izvorni tekst je izbrisan"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
+msgstr ""
+"Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19521,19 +19843,22 @@ msgstr "Ostani na DuckDuckGou"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
+msgstr ""
+"Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr ""
+"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr ""
+"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19571,14 +19896,15 @@ msgstr "Zaustavi generiranje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
+msgstr ""
+"Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
 msgstr ""
-"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim "
-"web-mjestima."
+"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim web-"
+"mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19993,6 +20319,12 @@ msgid "Switch model"
 msgstr "Prebacivanje na drugi model"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20250,6 +20582,13 @@ msgid "Synced Devices"
 msgstr "Sinkronizirani uređaji"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Sirija"
 
@@ -20280,6 +20619,12 @@ msgstr "TBD"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20601,7 +20946,8 @@ msgstr "Priložene datoteke prelaze ukupno ograničenje veličine od %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
+msgstr ""
+"Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20863,6 +21209,22 @@ msgstr ""
 "(pogledajte %4$s za više informacija)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20946,6 +21308,12 @@ msgid "This information isn’t useful"
 msgstr "Ove informacije nisu korisne"
 
 # smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
@@ -21012,7 +21380,8 @@ msgstr "Za pravilno funkcioniranje ove stranice potreban je Javascript."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
+msgstr ""
+"Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21063,6 +21432,18 @@ msgstr ""
 "inteligencijom: %1$s."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21083,7 +21464,8 @@ msgstr "Ovaj je prijevod pogrešan"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
+msgstr ""
+"Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21253,8 +21635,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš "
-"ispisati.%3$sKlikni na ikonu za ispis.%4$s"
+"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš ispisati."
+"%3$sKlikni na ikonu za ispis.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21308,7 +21690,8 @@ msgstr "Danas"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "Prebaci se na privatni AI chat ili ga %1$sonemogući u izborniku %2$s.%3$s"
+msgstr ""
+"Prebaci se na privatni AI chat ili ga %1$sonemogući u izborniku %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21356,7 +21739,8 @@ msgstr "Previše oglasa"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr "Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
+msgstr ""
+"Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21704,6 +22088,12 @@ msgid "Try Free"
 msgstr "Isprobaj besplatno"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21798,7 +22188,8 @@ msgstr "Pokušaj omogućiti anonimnu lokaciju za točnije rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
+msgstr ""
+"Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21817,6 +22208,12 @@ msgstr "Isprobaj besplatno"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Isprobaj besplatno"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22064,6 +22461,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22074,6 +22477,12 @@ msgstr "Isključi Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Isključi Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22144,7 +22553,8 @@ msgstr "Uključi %1$sPreciznu lokaciju%2$s za preciznije rezultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
+msgstr ""
+"Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22314,7 +22724,8 @@ msgstr "Nije moguće poslati povratne informacije"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
+msgstr ""
+"Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -22366,7 +22777,8 @@ msgstr "Pod %1$sOtvori s%2$s odaberi %3$sOdređenu stranicu ili stranice%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
+msgstr ""
+"Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22388,13 +22800,15 @@ msgstr "Pod %1$sTraži%2$s, klikni %3$sUpravljaj tražilicama...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
+msgstr ""
+"Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
+msgstr ""
+"Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22494,7 +22908,8 @@ msgstr "Otključaj uz pretplatu na DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
+msgstr ""
+"Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22548,6 +22963,12 @@ msgid "Unmute"
 msgstr "Uključi zvuk"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22581,6 +23002,12 @@ msgstr "Ažuriraj"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Ažuriraj preglednik"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22734,7 +23161,8 @@ msgctxt ""
 "Description prompting Plus subscribers to upgrade to Pro for higher image "
 "generation limits"
 msgid "Upgrade to Pro to unlock 2x higher limits"
-msgstr "Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
+msgstr ""
+"Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
 
 # smartling.placeholder_format=C
 #. Description shown to Plus subscribers who have reached their image generation limit, encouraging them to upgrade to Pro.
@@ -23166,8 +23594,8 @@ msgid ""
 msgstr ""
 "Posjeti Duck.ai u svom drugom pregledniku ili u aplikaciji DuckDuckGo i "
 "otvori Postavke Duck.ai. Odaberi „Uključi“ pod Sync & Backup i odaberi "
-"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery "
-"PDF-u."
+"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery PDF-"
+"u."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23446,7 +23874,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
+msgstr ""
+"Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23563,6 +23992,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Prekinuli smo čavrljanje zbog neaktivnosti. Želiš li pokušati ponovno?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23609,6 +24046,14 @@ msgstr ""
 "rezultate, bliže tvojoj lokaciji. Uvijek se kasnije možeš predomisliti."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23647,6 +24092,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Blokirat ćemo programe/alate za praćenje koji pokušavaju prikupiti tvoje "
 "podatke dok surfaš internetom."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23913,8 +24366,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem "
-"Duck.ai. Pokušaj ponovo učitati stranicu."
+"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem Duck."
+"ai. Pokušaj ponovo učitati stranicu."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23928,7 +24381,8 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr "Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
+msgstr ""
+"Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -23959,6 +24413,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Koje su prednosti i mane anuiteta?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24212,8 +24672,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra "
-"URL-a označenog apleta?"
+"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra URL-"
+"a označenog apleta?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24288,7 +24748,8 @@ msgstr "O čemu želiš pružiti povratne informacije?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
+msgstr ""
+"Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24320,7 +24781,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
+msgstr ""
+"Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24338,7 +24800,8 @@ msgstr "Gdje gledati <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
+msgstr ""
+"Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24525,6 +24988,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Bez nulte vidljivosti pružatelja usluga"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24772,7 +25243,8 @@ msgstr "Da, novi korisnik!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
+msgstr ""
+"Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24863,13 +25335,15 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
+msgstr ""
+"Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
+msgstr ""
+"Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24908,7 +25382,8 @@ msgstr "Možeš nastaviti razgovarati koristeći svoje mjesečno ograničenje."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
+msgstr ""
+"Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25024,6 +25499,13 @@ msgid "You have 1 attempt left."
 msgstr "Preostao ti je još 1 pokušaj."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25082,7 +25564,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
+msgstr ""
+"Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25187,12 +25670,14 @@ msgstr "Dosegao si maksimalno trajanje glasovnog čavrljanja za jednu sesiju."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
+msgstr ""
+"Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
+msgstr ""
+"Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25244,6 +25729,23 @@ msgid "YouTube Standard"
 msgstr "Standardna YouTube licenca"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Tvoja DuckDuckGo povijest pretraživanja je privatna"
@@ -25265,6 +25767,14 @@ msgstr "Tvoja stvarna lokacija ostaje privatna"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Tvoja stvarna lokacija ostaje privatna."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25353,7 +25863,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
+msgstr ""
+"Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25414,8 +25925,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u "
-"Duck.ai."
+"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25601,7 +26112,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
+msgstr ""
+"Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25941,7 +26453,8 @@ msgstr "službenu web lokaciju"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
+msgstr ""
+"ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -49,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Ovaj uređaj)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -96,8 +95,7 @@ msgstr "AI modeli %1$s i %2$s"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
+msgstr "%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -310,8 +308,7 @@ msgstr "Ljestvica %1$s još nije dostupna"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s doseže uporabna ograničenja 2 do 5 puta ranije nego osnovni modeli. %2$s"
+msgstr "%1$s doseže uporabna ograničenja 2 do 5 puta ranije nego osnovni modeli. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -382,8 +379,7 @@ msgstr "%1$s rabljeno"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s troši uporabna ograničenja do 2 do 5 puta brže od osnovnih modela %2$s"
+msgstr "%1$s troši uporabna ograničenja do 2 do 5 puta brže od osnovnih modela %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -504,7 +500,7 @@ msgstr "%1$sSaznaj kako čuvamo privatnost tvoje lokacije%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sSaznaj više%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -527,8 +523,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
+msgstr "%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -803,7 +798,7 @@ msgstr "2. mjesto u skupini %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "Drugo mišljenje"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -967,8 +962,7 @@ msgstr "Dostupna je nova verzija AI Chata! Osvježi ovu stranicu za nastavak."
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
+msgstr "Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1494,7 +1488,7 @@ msgstr "Dodaj na početni zaslon"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Dodaj u moja čavrljanja"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1866,7 +1860,7 @@ msgstr "Sve vrste"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Svi tvoji uređaji isključeni su iz sinkronizacije."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2392,7 +2386,7 @@ msgstr "Privatno pitaj bilo što"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Privatno pitaj bilo što"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2576,8 +2570,7 @@ msgstr "Nakon završetka čavrljanja, zvuk ne pohranjujemo ni mi ni OpenAI."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
+msgstr "Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3028,8 +3021,7 @@ msgstr "Blokiraj ovu stranicu iz svih rezultata"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
+msgstr "Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3757,8 +3749,7 @@ msgstr "Promjena načina prikaza URL-ova rezultata"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
+msgstr "Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4587,8 +4578,7 @@ msgstr "Klikni %1$sPostavke%2$s u padajućem izborniku."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
+msgstr "Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5233,8 +5223,7 @@ msgstr "Nastavi blokirati oglase"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Nedavna čavrljanja nastavi ovdje. Možeš ih i izbrisati pomoću Fire Buttona."
+msgstr "Nedavna čavrljanja nastavi ovdje. Možeš ih i izbrisati pomoću Fire Buttona."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5341,7 +5330,7 @@ msgstr "Kopiraj"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopiraj"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5390,13 +5379,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Kopiraj podijeljenu poveznicu"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Kopiraj kôd s drugog uređaja"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5405,6 +5394,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Kopiraj kôd s drugog uređaja. Idi na %1$sDuck.ai postavke › Čavrljanja › "
+"Sync & Backup › Sinkroniziraj s drugim uređajem%2$s i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5456,8 +5447,7 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
+msgstr "Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6094,7 +6084,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Izbriši podijeljenu poveznicu"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6115,6 +6105,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Brisanjem poveznice ona prestaje funkcionirati. Osobe koje su je otvorile i "
+"dodale razgovor u svoje razgovore zadržat će vlastitu kopiju."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6311,8 +6303,7 @@ msgstr "Onemogući i isključi"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
+msgstr "Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6377,7 +6368,7 @@ msgstr "Odbaci"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Odbaci"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6882,8 +6873,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
+msgstr "Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7207,8 +7197,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
+msgstr "DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7241,7 +7230,7 @@ msgstr "DuckDuckGo preglednik %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo stranice pomoći"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7368,8 +7357,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš Duck.ai-"
-"jeve %2$s."
+"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš "
+"Duck.ai-jeve %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7377,8 +7366,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
+msgstr "DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7591,8 +7579,7 @@ msgstr "Slika se uređuje..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
+msgstr "Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -8005,8 +7992,7 @@ msgstr "Ekvatorska Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
+msgstr "Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8075,7 +8061,7 @@ msgstr ""
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Isteklo"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8089,7 +8075,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Istječe %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8371,8 +8357,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje web-"
-"mjesto."
+"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje "
+"web-mjesto."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8508,8 +8494,7 @@ msgstr "Pronađi <b>%1$s</b> u mapi za preuzimanje"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
+msgstr "Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8730,8 +8715,7 @@ msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
+msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9362,8 +9346,7 @@ msgstr "Preuzmi aplikaciju"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"Nabavi besplatni preglednik DuckDuckGo %1$si blokiraj oglase na YouTubeu.%2$s"
+msgstr "Nabavi besplatni preglednik DuckDuckGo %1$si blokiraj oglase na YouTubeu.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9468,6 +9451,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Idi na %1$sDuck.ai postavke%2$s › %3$sČavrljanja › Sync & Backup › "
+"Sinkroniziraj s drugim uređajem%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9583,7 +9568,7 @@ msgstr "Shvatio/la sam"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "U redu"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9949,8 +9934,7 @@ msgstr "Pomozi nam poboljšati DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
+msgstr "Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10387,8 +10371,7 @@ msgstr "Kako funkcionira"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
+msgstr "Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10647,8 +10630,7 @@ msgstr "Ako nas ipak želiš podržati, %1$spomozi proširiti DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
+msgstr "Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10956,8 +10938,7 @@ msgstr "Lako pregledavanje rezultata pretraživanja za slike i videozapise"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Infinite Scroll for Images, Videos, and Shopping"
-msgstr ""
-"Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
+msgstr "Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is accurate
@@ -11562,7 +11543,7 @@ msgstr "Saznaj %1$sViše%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Saznaj više"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -12202,7 +12183,7 @@ msgstr "Upravljanje"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Upravljanje"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12459,7 +12440,7 @@ msgstr "Izbornik"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Poruke nakon ove točke vidljive su samo tebi."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12489,8 +12470,7 @@ msgstr "Mikronezija"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
+msgstr "Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12834,7 +12814,7 @@ msgstr "Više o Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Više radnji"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13034,7 +13014,7 @@ msgstr "Zagasito crvena"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Moji uređaji"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14112,6 +14092,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Na drugom uređaju idi na %1$sDuck.ai postavke%2$s › %3$sČavrljanja › Sync & "
+"Backup › Sinkroniziraj s drugim uređajem%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14120,6 +14102,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Na drugom uređaju idi na %1$sDuck.ai postavke%2$s › %3$sČavrljanja › Sync & "
+"Backup › Sinkroniziraj s drugim uređajem%4$s i skeniraj ovaj kôd:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14128,6 +14112,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Na drugom uređaju idi na %1$sDuck.ai postavke%2$s › %3$sČavrljanja › Sync & "
+"Backup › Sinkroniziraj s drugim uređajem%4$s. Ili skeniraj QR kôd na svom "
+"PDF-u za oporavak."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14882,7 +14869,7 @@ msgstr "Prošla godina"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Zalijepi"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14900,7 +14887,7 @@ msgstr "Zalijepi šifru za sinkronizaciju"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Zalijepi ga u nastavku"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14959,7 +14946,7 @@ msgstr "Perzijski"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14968,6 +14955,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal pronalazi tvoje podatke na mrežnim lokacijama "
+"posrednika podataka koje ih prodaju. Zatim radimo na tome da ih uklonimo za "
+"tebe."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15181,8 +15171,7 @@ msgstr "Prikvačeno"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Prikvačena čavrljanja pojavit će se na vrhu tvojih nedavnih čavrljanja."
+msgstr "Prikvačena čavrljanja pojavit će se na vrhu tvojih nedavnih čavrljanja."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15237,8 +15226,7 @@ msgstr "Ispuni sljedeći upit i potvrdi da je ovo pretraživanje izvršio čovje
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
+msgstr "Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -16236,7 +16224,7 @@ msgstr "Čitanje mrežne lokacije..."
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Spreman za pomrčinu Sunca?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16436,7 +16424,7 @@ msgstr "Kôd za oporavak"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Kôd za oporavak"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16646,8 +16634,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb &quot;"
-"Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
+"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb "
+"&quot;Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
 "pregledniku."
 
 # smartling.placeholder_format=C
@@ -16658,8 +16646,7 @@ msgstr "Zapamti moj izbor"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
+msgstr "Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16695,7 +16682,7 @@ msgstr "Ukloni %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Ukloni uređaj"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16743,13 +16730,13 @@ msgstr "Ukloni nepotrebne interpunkcijske znakove"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Ukloni svoje podatke s interneta"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Ukloni svoje podatke s interneta"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17409,8 +17396,7 @@ msgstr "Spremi do 30 svojih najnovijih čavrljanja lokalno na svom uređaju."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
+msgstr "Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17446,7 +17432,7 @@ msgstr "Pozdravi Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Pozdravi Duck.ai – besplatno, privatno AI čavrljanje tvrtke DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17601,8 +17587,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
+msgstr "Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17895,8 +17880,7 @@ msgstr "Pretraži putem DuckDuckGoa"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
+msgstr "Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -17946,8 +17930,7 @@ msgstr "Drugo mišljenje"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
+msgstr "Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17996,8 +17979,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
+msgstr "Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18189,8 +18171,7 @@ msgstr "Odaberi %1$sDuckDuckGo%2$s u padajućem izborniku zadanih tražilica"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr "Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18309,8 +18290,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr "Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18454,7 +18434,7 @@ msgstr "Srpski (latinica)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Podaci poslužitelja su izbrisani"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18557,8 +18537,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
+msgstr "Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18615,7 +18594,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Podijeli"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18632,8 +18611,7 @@ msgstr "Podijeli"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
+msgstr "Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18771,13 +18749,13 @@ msgstr "Podijeli svoje mišljenje o okviru za pretraživanje."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Podijeljene poveznice za čavrljanje"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Podijeljene poveznice za čavrljanje"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18908,8 +18886,7 @@ msgstr "Prikaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
+msgstr "Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19236,8 +19213,7 @@ msgstr "Prikazuje poruku dobrodošlice na vrhu stranice rezultata pretraživanja
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
+msgstr "Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19309,14 +19285,12 @@ msgstr "Nazivi web-mjesta"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
+msgstr "Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
+msgstr "Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19463,7 +19437,7 @@ msgstr "Nešto nije bilo kako treba"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Došlo je do pogreške prilikom učitavanja ovog podijeljenog čavrljanja."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19507,8 +19481,7 @@ msgstr "Ponekad"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
+msgstr "Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19556,8 +19529,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
+msgstr "Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19637,8 +19609,7 @@ msgstr "Izvorni tekst je izbrisan"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
+msgstr "Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19843,22 +19814,19 @@ msgstr "Ostani na DuckDuckGou"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19896,15 +19864,14 @@ msgstr "Zaustavi generiranje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
+msgstr "Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
 msgstr ""
-"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim web-"
-"mjestima."
+"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim "
+"web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20322,7 +20289,7 @@ msgstr "Prebacivanje na drugi model"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Prebacivanje na drugi model"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20586,7 +20553,7 @@ msgstr "Sinkronizirani uređaji"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Sinkronizirano %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20624,7 +20591,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tablica"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20946,8 +20913,7 @@ msgstr "Priložene datoteke prelaze ukupno ograničenje veličine od %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
+msgstr "Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21212,7 +21178,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Ovaj uređaj"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21223,6 +21189,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Ovaj uređaj više neće moći pristupiti tvojim sinkroniziranim podacima na "
+"drugim uređajima. Posljednjih %1$s čavrljanja i dalje će ostati dostupno u "
+"lokalnoj pohrani."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21311,7 +21280,7 @@ msgstr "Ove informacije nisu korisne"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Ovo je kopija podijeljenog razgovora."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21380,8 +21349,7 @@ msgstr "Za pravilno funkcioniranje ove stranice potreban je Javascript."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
+msgstr "Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21435,13 +21403,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Ovo podijeljeno čavrljanje ne može se otvoriti. Poveznica je možda nepotpuna."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Ova poveznica na podijeljeno čavrljanje više nije dostupna."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21464,8 +21432,7 @@ msgstr "Ovaj je prijevod pogrešan"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
+msgstr "Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21635,8 +21602,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš ispisati."
-"%3$sKlikni na ikonu za ispis.%4$s"
+"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš "
+"ispisati.%3$sKlikni na ikonu za ispis.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21690,8 +21657,7 @@ msgstr "Danas"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"Prebaci se na privatni AI chat ili ga %1$sonemogući u izborniku %2$s.%3$s"
+msgstr "Prebaci se na privatni AI chat ili ga %1$sonemogući u izborniku %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21739,8 +21705,7 @@ msgstr "Previše oglasa"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr ""
-"Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
+msgstr "Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22091,7 +22056,7 @@ msgstr "Isprobaj besplatno"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Isprobaj besplatno!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22188,8 +22153,7 @@ msgstr "Pokušaj omogućiti anonimnu lokaciju za točnije rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
+msgstr "Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22213,7 +22177,7 @@ msgstr "Isprobaj besplatno"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Isprobaj besplatno!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22464,7 +22428,7 @@ msgstr "Turkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Isključi"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22482,7 +22446,7 @@ msgstr "Isključi Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Isključi Sync & Backup i izbriši podatke poslužitelja?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22553,8 +22517,7 @@ msgstr "Uključi %1$sPreciznu lokaciju%2$s za preciznije rezultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
+msgstr "Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22724,8 +22687,7 @@ msgstr "Nije moguće poslati povratne informacije"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
+msgstr "Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -22777,8 +22739,7 @@ msgstr "Pod %1$sOtvori s%2$s odaberi %3$sOdređenu stranicu ili stranice%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
+msgstr "Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22800,15 +22761,13 @@ msgstr "Pod %1$sTraži%2$s, klikni %3$sUpravljaj tražilicama...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
+msgstr "Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
+msgstr "Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22908,8 +22867,7 @@ msgstr "Otključaj uz pretplatu na DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
+msgstr "Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22966,7 +22924,7 @@ msgstr "Uključi zvuk"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Neimenovano čavrljanje"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23007,7 +22965,7 @@ msgstr "Ažuriraj preglednik"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Ažuriraj Duck.ai za prikaz ovog podijeljenog čavrljanja."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23161,8 +23119,7 @@ msgctxt ""
 "Description prompting Plus subscribers to upgrade to Pro for higher image "
 "generation limits"
 msgid "Upgrade to Pro to unlock 2x higher limits"
-msgstr ""
-"Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
+msgstr "Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
 
 # smartling.placeholder_format=C
 #. Description shown to Plus subscribers who have reached their image generation limit, encouraging them to upgrade to Pro.
@@ -23594,8 +23551,8 @@ msgid ""
 msgstr ""
 "Posjeti Duck.ai u svom drugom pregledniku ili u aplikaciji DuckDuckGo i "
 "otvori Postavke Duck.ai. Odaberi „Uključi“ pod Sync & Backup i odaberi "
-"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery PDF-"
-"u."
+"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery "
+"PDF-u."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23874,8 +23831,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
+msgstr "Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23998,6 +23954,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Pronalazimo i uklanjamo tvoje osobne podatke s web-mjesta posrednika "
+"podataka. Osim toga, tu je VPN i druge opcije."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24052,6 +24010,9 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Redovito skeniramo web-mjesta posrednika podataka u potrazi za tvojim "
+"osobnim podacima i dijelimo svoj napredak s tobom na upravljačkoj ploči "
+"jednostavnoj za upotrebu."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24100,6 +24061,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Skenirat ćemo web-mjesta posrednika podataka u potrazi za tvojom e-adresom, "
+"imenom, adresom i drugim podacima te raditi na uklanjanju svega što o tebi "
+"pronađemo."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24366,8 +24330,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem Duck."
-"ai. Pokušaj ponovo učitati stranicu."
+"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem "
+"Duck.ai. Pokušaj ponovo učitati stranicu."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24381,8 +24345,7 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr ""
-"Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
+msgstr "Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24418,7 +24381,7 @@ msgstr "Koje su prednosti i mane anuiteta?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Koje su prednosti Duck.ai-ja?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24672,8 +24635,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra URL-"
-"a označenog apleta?"
+"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra "
+"URL-a označenog apleta?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24748,8 +24711,7 @@ msgstr "O čemu želiš pružiti povratne informacije?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
+msgstr "Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24781,8 +24743,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
+msgstr "Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24800,8 +24761,7 @@ msgstr "Gdje gledati <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
+msgstr "Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24996,6 +24956,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Radi izravno s tvog uređaja na uklanjanju tvoje e-adrese, imena, adrese i "
+"ostalog s web-mjesta posrednika podataka."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25243,8 +25205,7 @@ msgstr "Da, novi korisnik!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
+msgstr "Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25335,15 +25296,13 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
+msgstr "Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
+msgstr "Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25382,8 +25341,7 @@ msgstr "Možeš nastaviti razgovarati koristeći svoje mjesečno ograničenje."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
+msgstr "Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25503,7 +25461,7 @@ msgstr "Preostao ti je još 1 pokušaj."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Nemaš podijeljenih poveznica čavrljanja."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25564,8 +25522,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
+msgstr "Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25670,14 +25627,12 @@ msgstr "Dosegao si maksimalno trajanje glasovnog čavrljanja za jednu sesiju."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
+msgstr "Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
+msgstr "Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25737,13 +25692,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Tvojih %1$s najnovijih razgovora bit će dostupno u lokalnoj pohrani u ovim "
+"preglednicima:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Tvoja Duck.ai čavrljanja sinkroniziraju se uz end-to-end enkripciju."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25775,6 +25732,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Tvoja sigurnosna kopija bit će izbrisana s DuckDuckGo poslužitelja. Svi "
+"uređaji bit će isključeni iz sinkronizacije."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25863,8 +25822,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
+msgstr "Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25925,8 +25883,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u Duck."
-"ai."
+"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26112,8 +26070,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
+msgstr "Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26453,8 +26410,7 @@ msgstr "službenu web lokaciju"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
+msgstr "ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hu_HU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% teljesen beoltva"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% beoltva"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -182,9 +190,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
-"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
-"válts a Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
+"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
+"Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -194,9 +202,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
-"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
-"válts a Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
+"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
+"Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -490,7 +498,15 @@ msgstr "%1$sTudj meg többet%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
+msgstr ""
+"%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
+
+# smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -505,13 +521,15 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
+msgstr ""
+"%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
+msgstr ""
+"%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -781,6 +799,12 @@ msgid "2nd in Group %s"
 msgstr "2. a(z) %1$s csoportban"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -862,7 +886,8 @@ msgstr "Elérted a 6 órás használati limitet."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
+msgstr ""
+"Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -987,9 +1012,8 @@ msgstr ""
 "Az AI Chat segítségével névtelen beszélgetéseket folytathatsz harmadik felek "
 "mesterséges intelligencián alapuló csevegési modelljeivel. Ennek "
 "kikapcsolása elrejti az AI Chat funkciót a DuckDuckGo Search "
-"szolgáltatásban. Ha a beállítás ki van kapcsolva, a "
-"%1$sduckduckgo.com/aichat%2$s oldalra látogatva továbbra is elérheted az AI "
-"Chatet."
+"szolgáltatásban. Ha a beállítás ki van kapcsolva, a %1$sduckduckgo.com/"
+"aichat%2$s oldalra látogatva továbbra is elérheted az AI Chatet."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1053,9 +1077,8 @@ msgstr ""
 "Az AI-alapú válaszokra jelenleg nem tehetők fel közvetlenül további "
 "kérdések. Azonban ha újabb kérdést szeretnél feltenni, az OpenAI, az "
 "Anthropic, valamint más szolgáltatók csevegési modelljeit is támogató "
-"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a "
-"%1$sDuck.ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak "
-"linkjét."
+"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a %1$sDuck."
+"ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak linkjét."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1470,6 +1493,12 @@ msgid "Add to Home Screen"
 msgstr "Hozzáadás a kezdőlaphoz"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Kiegészítők"
@@ -1835,6 +1864,13 @@ msgid "All types"
 msgstr "Minden típus"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1864,7 +1900,8 @@ msgstr "Adatvédelmet tiszteletben tartó hirdetések engedélyezése"
 #. Title of the upload consent prompt shown before the first image/file upload in a chat with a zero-provider-visibility model, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow anonymous file review for this chat?"
-msgstr "Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
+msgstr ""
+"Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
 
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
@@ -2358,6 +2395,12 @@ msgid "Ask anything privately"
 msgstr "Kérdezz bármit privát módon"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2419,9 +2462,9 @@ msgstr ""
 "felhasználói felületét a keresési eredményekből), Igény szerint (csak az "
 "Asszisztens gombra kattintás esetén jelennek meg az AI-alapú válaszok), Néha "
 "(csak akkor jelenik meg AI-alapú válasz, ha nagyon releváns), illetve "
-"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az "
-"AI-alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában "
-"érhetők el."
+"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az AI-"
+"alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában érhetők "
+"el."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2528,18 +2571,21 @@ msgstr "Hang"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr ""
+"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr ""
+"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
+msgstr ""
+"A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2788,7 +2834,8 @@ msgstr "Vonalkód"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr "Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
+msgstr ""
+"Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2991,7 +3038,8 @@ msgstr "Webhely blokkolása minden találatból"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
+msgstr ""
+"Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3725,7 +3773,8 @@ msgstr "Módosítja az eredmények URL-jeinek megjelenítési módját"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
+msgstr ""
+"Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3937,8 +3986,8 @@ msgstr "Privát csevegés"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített "
-"Duck.ai segítségével."
+"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített Duck."
+"ai segítségével."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4466,8 +4515,8 @@ msgid ""
 msgstr ""
 "Kattints a „Több” lehetőségre, ha többet meg szeretnél tudni egy témáról, és "
 "tegyél fel kapcsolódó kérdéseket az OpenAI, az Anthropic és további "
-"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a "
-"%1$sDuck.ai%2$s használatával."
+"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a %1$sDuck."
+"ai%2$s használatával."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4494,13 +4543,15 @@ msgstr "Kattints a %1$sHozzáadás%2$s lehetőségre"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr "Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
+msgstr ""
+"Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr "Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
+msgstr ""
+"Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4534,7 +4585,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
+msgstr ""
+"Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4615,7 +4667,8 @@ msgstr "Kattints a %1$sBeállítás alapértelmezettként%2$s lehetőségre lent
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr "Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
+msgstr ""
+"Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -5316,6 +5369,12 @@ msgid "Copy"
 msgstr "Másolás"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5324,7 +5383,8 @@ msgstr "Másolás"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
+msgstr ""
+"Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5355,6 +5415,28 @@ msgstr "Kód másolása vagy mentése"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Helyreállítási kód másolása"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6040,6 +6122,14 @@ msgid "Delete recent chats?"
 msgstr "Törlöd a legutóbbi csevegéseket?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6050,6 +6140,14 @@ msgstr "Csevegés törlése?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Törölt csevegések"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6307,6 +6405,13 @@ msgstr "Bezárás"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Bezárás"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6721,7 +6826,8 @@ msgstr "Dobd ide a fotókat vagy PDF-fájlokat"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
+msgstr ""
+"A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6814,7 +6920,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
+msgstr ""
+"A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6857,8 +6964,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el "
-"e-mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
+"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el e-"
+"mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
 "%2$s"
 
 # smartling.placeholder_format=C
@@ -6866,7 +6973,8 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
+msgstr ""
+"A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6880,9 +6988,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű "
-"MI-modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, "
-"de továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
+"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű MI-"
+"modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, de "
+"továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6966,8 +7074,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes "
-"AI-csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
+"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes AI-"
+"csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
 "Anthropic, Llama, Mistral, nyílt forráskódú AI modellek, adatvédelemre "
 "összpontosító AI, fiók nélküli AI-csevegés"
 
@@ -7015,8 +7123,8 @@ msgid ""
 msgstr ""
 "A DuckAssist nem tud utólagos kérdésekre válaszolni, viszont kínálatunkban "
 "többek között az OpenAI és az Anthropic csevegési modelljeit támogató "
-"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy "
-"mesterségesintelligencia-alapú privát csevegési szolgáltatás."
+"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy mesterségesintelligencia-"
+"alapú privát csevegési szolgáltatás."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7144,7 +7252,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
+msgstr ""
+"A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7171,6 +7280,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo böngésző %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7288,8 +7404,8 @@ msgid ""
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
 "A DuckDuckGo automatikusan anonimizálja ezeket a jelentéseket az olyan "
-"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az "
-"e-mail-címek, a telefonszámok és az azonosításra alkalmas metaadatok."
+"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az e-mail-"
+"címek, a telefonszámok és az azonosításra alkalmas metaadatok."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7574,7 +7690,8 @@ msgstr "Emeld ki a fontos információkat a válaszokban"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr "Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
+msgstr ""
+"Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7675,7 +7792,8 @@ msgstr "Diktálás engedélyezése a Duck.ai felületén"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
+msgstr ""
+"Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7793,13 +7911,15 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
+msgstr ""
+"Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
+msgstr ""
+"Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7813,7 +7933,8 @@ msgstr ""
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr "Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
+msgstr ""
+"Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7849,13 +7970,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
+msgstr ""
+"Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
+msgstr ""
+"Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8014,10 +8137,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "Profi termékek azoknak, akiknek fontos az adatvédelem."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Lejárt"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8551,8 +8689,8 @@ msgstr ""
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
 msgstr ""
-"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új "
-"Duck.ai felületre"
+"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új Duck."
+"ai felületre"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8663,7 +8801,8 @@ msgstr "Ingyenes és privát csevegések, általunk anonimizálva"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
+msgstr ""
+"Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8915,13 +9054,15 @@ msgstr "Általános célú mesterséges intelligencia, beépített erős moderá
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Általános célú mesterséges intelligencia, beépített gyenge moderálással"
+msgstr ""
+"Általános célú mesterséges intelligencia, beépített gyenge moderálással"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr "Általános célú mesterséges intelligencia, beépített közepes moderálással"
+msgstr ""
+"Általános célú mesterséges intelligencia, beépített közepes moderálással"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9156,9 +9297,9 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett "
-"AI-csevegést, a személyes adatok eltávolítására szolgáló Personal Info "
-"Removal, és a személyazonosság helyreállításához használható Identity Theft "
+"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett AI-"
+"csevegést, a személyes adatok eltávolítására szolgáló Personal Info Removal, "
+"és a személyazonosság helyreállításához használható Identity Theft "
 "Restoration funkciókat."
 
 # smartling.placeholder_format=C
@@ -9168,8 +9309,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett "
-"AI-csevegést, és a személyazonosság helyreállításához használható Identity "
+"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett AI-"
+"csevegést, és a személyazonosság helyreállításához használható Identity "
 "Theft Restoration funkciókat."
 
 # smartling.placeholder_format=C
@@ -9192,9 +9333,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez "
-"DuckDuckGo-előfizetéssel, amely a VPN-megoldásunk mellett további prémium "
-"adatvédelmi szolgáltatásokat is tartalmaz."
+"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez DuckDuckGo-"
+"előfizetéssel, amely a VPN-megoldásunk mellett további prémium adatvédelmi "
+"szolgáltatásokat is tartalmaz."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9223,7 +9364,8 @@ msgstr "Kérj számítógépes segítséget"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr "DuckDuckGo-előfizetéssel magasabb felhasználási limiteket vehetsz igénybe."
+msgstr ""
+"DuckDuckGo-előfizetéssel magasabb felhasználási limiteket vehetsz igénybe."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9407,10 +9549,19 @@ msgstr ""
 "található QR-kódot."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
+msgstr ""
+"Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9516,6 +9667,12 @@ msgstr "Értem"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Megvan"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9881,7 +10038,8 @@ msgstr "Segíts nekünk a DuckDuckGo fejlesztésében"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
+msgstr ""
+"A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10577,7 +10735,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
+msgstr ""
+"Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10778,7 +10937,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr "A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
+msgstr ""
+"A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11507,6 +11667,12 @@ msgid "Learn %sMore%s"
 msgstr "Tudj meg %1$stöbbet%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -12074,7 +12240,8 @@ msgstr "Ügyelj rá, hogy minden szó helyesen legyen írva."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
+msgstr ""
+"Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12140,6 +12307,13 @@ msgstr "Rosszindulatú program"
 #. Text for generic link to send the user to a page to manage their settings.
 msgid "Manage"
 msgstr "Kezelés"
+
+# smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12391,6 +12565,12 @@ msgstr "Menü"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menü"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12761,6 +12941,12 @@ msgid "More about Duck.ai"
 msgstr "A Duck.ai további tudnivalói"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Bővebben itt:"
@@ -12955,6 +13141,12 @@ msgstr "Lenémítva"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Tompa vörös"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14026,6 +14218,30 @@ msgstr ""
 "%3$skattints a(z) %4$s ikon > Beállítások%5$s lehetőségre"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14094,7 +14310,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
+msgstr ""
+"Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14457,9 +14674,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, "
-"titkosítás-végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS "
-"és Android%2$s rendszerhez is elérhető."
+"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, titkosítás-"
+"végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS és "
+"Android%2$s rendszerhez is elérhető."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14780,6 +14997,12 @@ msgid "Past year"
 msgstr "Elmúlt évben"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14790,6 +15013,12 @@ msgstr "Beillesztés"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Szinkronizálási kód beillesztése"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14843,6 +15072,20 @@ msgstr "Véglegesen bezárt"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "perzsa"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15056,7 +15299,8 @@ msgstr "Kitűzött"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "A kitűzött csevegések a legutóbbi csevegések felső részében jelennek meg."
+msgstr ""
+"A kitűzött csevegések a legutóbbi csevegések felső részében jelennek meg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15097,7 +15341,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
+msgstr ""
+"A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15105,7 +15350,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
+msgstr ""
+"A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15316,8 +15562,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a "
-"YouTube-javaslataidat."
+"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a YouTube-"
+"javaslataidat."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -16108,6 +16354,12 @@ msgid "Reading website…"
 msgstr "Webhely olvasása…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16129,13 +16381,15 @@ msgstr "Érvelő mesterséges intelligencia, magas szintű beépített moderáci
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr "Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
+msgstr ""
+"Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr "Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
+msgstr ""
+"Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
@@ -16147,13 +16401,15 @@ msgstr "Érveléssel jobb válaszok kaphatók az összetett kérdésekre."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Az érvelés alaposabb, de 2–5-ször hamarabb éri el a használati limitet. %1$s"
+msgstr ""
+"Az érvelés alaposabb, de 2–5-ször hamarabb éri el a használati limitet. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Az érvelés alaposabb, de 2–5-ször gyorsabban fogyasztja a limitet. %1$s"
+msgstr ""
+"Az érvelés alaposabb, de 2–5-ször gyorsabban fogyasztja a limitet. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16296,6 +16552,12 @@ msgstr "Helyreállítás"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Helyreállítási kód"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16516,7 +16778,8 @@ msgstr "Választott beállítás megjegyzése"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
+msgstr ""
+"Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16547,6 +16810,12 @@ msgstr "%1$s eltávolítása"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "%1$s eltávolítása"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16589,6 +16858,18 @@ msgstr "Szövegkijelölés eltávolítása"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Távolítsd el a felesleges írásjeleket"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16782,8 +17063,8 @@ msgid ""
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
 "A válaszok kizárólag tájékoztatási célokat szolgálnak, és nem minősülnek "
-"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az "
-"AI-alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
+"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az AI-"
+"alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16878,7 +17159,8 @@ msgstr "A találatok nem tartalmazzák a blokkolt webhelyeket."
 #. Informational banner shown at the top of the Maps search results panel when the user has blocked Yelp or TripAdvisor in their settings. Explains why ratings, reviews, and other details may be missing from place listings.
 msgctxt "Exclusion message at top of maps vertical"
 msgid "Results exclude information from blocked sites."
-msgstr "A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
+msgstr ""
+"A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
 
 # smartling.placeholder_format=C
 #. Message that appears when results exclude blocked sites
@@ -17284,6 +17566,12 @@ msgid "Say hello to Duck.ai"
 msgstr "Üdvözöl a Duck.ai"
 
 # smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai!"
@@ -17465,7 +17753,8 @@ msgstr "Keresés"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr "A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
+msgstr ""
+"A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
 
 # smartling.placeholder_format=C
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
@@ -17877,7 +18166,8 @@ msgstr "Fényképek megtekintése"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "See Privacy Policy and Terms of Service"
-msgstr "Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
+msgstr ""
+"Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
 
 # smartling.placeholder_format=C
 #. Text of the secondary button in the modal that allows the user to open the terms and privacy policy page.
@@ -17943,7 +18233,8 @@ msgstr "További információ: %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr "További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
+msgstr ""
+"További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -17999,8 +18290,8 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a "
-"%3$shttps://duckduckgo.com%4$s címet a beviteli mezőbe"
+"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a %3$shttps://duckduckgo."
+"com%4$s címet a beviteli mezőbe"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18048,7 +18339,8 @@ msgstr "Válaszd a %1$sDuckDuckGót%2$s a keresőszolgáltatók listáján"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
+msgstr ""
+"Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18059,7 +18351,8 @@ msgstr "Válaszd a %1$sDuckDuckGo%2$s lehetőséget."
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
+msgstr ""
+"Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18102,7 +18395,8 @@ msgstr "Válaszd ki a %1$sKeresőmotor%2$s lehetőséget"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
+msgstr ""
+"Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18127,7 +18421,8 @@ msgstr "Válaszd ki a %1$sBeállítások%2$s opciót a legördülő menüből."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
+msgstr ""
+"Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18304,6 +18599,13 @@ msgid "Serbian (Latin)"
 msgstr "szerb (latin)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18458,6 +18760,14 @@ msgid "Share"
 msgstr "Megosztás"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18472,7 +18782,8 @@ msgstr "Megosztás"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
+msgstr ""
+"Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18499,8 +18810,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az "
-"AI-modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
+"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az AI-"
+"modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
 "pontos tartózkodási helyedet."
 
 # smartling.placeholder_format=C
@@ -18586,7 +18897,8 @@ msgstr "Beszélgetés megosztása a DuckDuckGóval"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr "Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
+msgstr ""
+"Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -18605,6 +18917,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Oszd meg a véleményed a keresőmezővel kapcsolatban."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18853,7 +19177,8 @@ msgstr "Minden találat megjelenítése"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
+msgstr ""
+"Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19016,12 +19341,14 @@ msgstr "A legtöbbször meglátogatott hivatkozások megjelenítése új lapon"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
+msgstr ""
+"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
+msgstr ""
+"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19039,7 +19366,8 @@ msgstr "Oldalszám megjelenítése a találati oldalak töréseinél"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
+msgstr ""
+"A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19067,7 +19395,8 @@ msgstr "Üdvözlőüzenet megjelenítése a keresési találati oldal tetején"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
+msgstr ""
+"Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19144,7 +19473,8 @@ msgstr "Az oldalkeresés átmenetileg nem érhető el. Dolgozunk a megoldáson."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
+msgstr ""
+"Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19286,6 +19616,12 @@ msgstr "Valami más"
 msgctxt "duckai_migration"
 msgid "Something went wrong"
 msgstr "Hiba történt"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -20134,6 +20470,12 @@ msgid "Switch model"
 msgstr "Másik modellre váltás"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20394,6 +20736,13 @@ msgid "Synced Devices"
 msgstr "Szinkronizált eszközök"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Szíria"
 
@@ -20424,6 +20773,12 @@ msgstr "Döntésre vár"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "Tv"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20568,7 +20923,8 @@ msgstr "Koppints a címsorban található %1$sengedélyek ikonra%2$s"
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Tap the vertical dots in the DuckDuckGo app."
-msgstr "Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
+msgstr ""
+"Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a teacher in its responses.
@@ -20737,18 +21093,21 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
+msgstr ""
+"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
+msgstr ""
+"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
+msgstr ""
+"A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20960,7 +21319,8 @@ msgstr "Ezen a héten"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr "Ez a csevegés a Duck.ai-ban marad, és megőrzi számodra privát jellegét."
+msgstr ""
+"Ez a csevegés a Duck.ai-ban marad, és megőrzi számodra privát jellegét."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21007,6 +21367,22 @@ msgstr ""
 "Ezt a beszélgetést a DuckDuckGo AI Chat (%1$s) generálta a(z) %2$s %3$s "
 "modelljének használatával. Az AI-csevegésekben pontatlan vagy bántó "
 "információk jelenhetnek meg (további tudnivalók: %4$s)."
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21078,8 +21454,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
-"GIF-fájlt"
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
+"fájlt"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21087,13 +21463,19 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
-"GIF-fájlt."
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
+"fájlt."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Nem hasznos információ"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21192,9 +21574,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
-"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
-"mesterséges intelligencia segítségével generált válaszok."
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
+"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
+"intelligencia segítségével generált válaszok."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21204,10 +21586,22 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
-"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
-"mesterséges intelligencia segítségével generált válaszok. Ugyanakkor van egy "
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
+"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
+"intelligencia segítségével generált válaszok. Ugyanakkor van egy "
 "kezdőoldalunk, amely soha nem jelenít meg AI-alapú válaszokat: %1$s."
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21236,7 +21630,8 @@ msgstr "Ez a videó még nem tekinthető meg itt. Megnézheted itt: %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
+msgstr ""
+"Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21414,8 +21809,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "A szinkronizált adatok visszaállításához szükség lesz a szinkronizálás első "
-"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód "
-"PDF-fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
+"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód PDF-"
+"fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
 "eszközre."
 
 # smartling.placeholder_format=C
@@ -21801,7 +22196,8 @@ msgstr "Próbálkozz ezzel: %1$s"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr "Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
+msgstr ""
+"Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -21857,6 +22253,12 @@ msgstr "Próbáld ki ingyen"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Ingyenes próba"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21946,14 +22348,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
+msgstr ""
+"A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
+msgstr ""
+"Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21972,6 +22376,12 @@ msgstr "Próbáld ki ingyen"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Próbáld ki ingyen"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21999,7 +22409,8 @@ msgstr "Próbáld ki ingyen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
+msgstr ""
+"Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22038,7 +22449,8 @@ msgstr "Próbáld ki a böngészőnket,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
+msgstr ""
+"Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22223,6 +22635,12 @@ msgid "Turkmenistan"
 msgstr "Türkmenisztán"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22233,6 +22651,12 @@ msgstr "Sync & Backup kikapcsolása"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Sync & Backup kikapcsolása"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22303,7 +22727,8 @@ msgstr "A pontosabb találatokhoz kapcsold be a %1$sPontos hely%2$s funkciót"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
+msgstr ""
+"Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22536,7 +22961,8 @@ msgstr "Az %1$sÁltalános > Kezdőlap%2$s alatt írd be: https://duckduckgo.com
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr "A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
+msgstr ""
+"A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22645,8 +23071,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb "
-"MI-érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
+"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb MI-"
+"érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22668,8 +23094,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el "
-"DuckDuckGo-előfizetéssel"
+"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el DuckDuckGo-"
+"előfizetéssel"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22723,6 +23149,12 @@ msgid "Unmute"
 msgstr "Némítás kikapcsolása"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22756,6 +23188,12 @@ msgstr "Frissítés"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Böngésző frissítése"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23301,9 +23739,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: "
-"%1$sDuck.ai-beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd "
-"válaszd a %7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
+"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: %1$sDuck.ai-"
+"beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd válaszd a "
+"%7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23342,8 +23780,8 @@ msgstr ""
 "Látogass el a Duck.ai oldalra a másik böngésződben vagy a DuckDuckGo "
 "alkalmazásban, és nyisd meg a Duck.ai beállításait. Válaszd a „Bekapcsolás” "
 "lehetőséget a Sync & Backup alatt, és válaszd a „Szinkronizálás másik "
-"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található "
-"QR-kódot."
+"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található QR-"
+"kódot."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23396,8 +23834,8 @@ msgstr "A hangcsevegés véget ért"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel "
-"MI-modellek betanítására."
+"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel MI-"
+"modellek betanítására."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23541,9 +23979,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott "
-"YouTube-hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube "
-"ajánlásait."
+"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott YouTube-"
+"hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube ajánlásait."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23612,14 +24049,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr "Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
+msgstr ""
+"Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
+msgstr ""
+"Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23661,7 +24100,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
+msgstr ""
+"Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23732,6 +24172,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Inaktivitás miatt befejeztük a csevegést. Szeretnéd újra megpróbálni?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23778,6 +24226,14 @@ msgstr ""
 "érdekében. Később bármikor meggondolhatod magad."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23813,7 +24269,16 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
+msgstr ""
+"Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23994,8 +24459,8 @@ msgid ""
 "anonymized by us and not used to train AI models."
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! Minden itt folytatott beszélgetésed privát, "
-"anonimizáljuk azokat, és nem használjuk fel "
-"mesterségesintelligencia-modellek tanítására."
+"anonimizáljuk azokat, és nem használjuk fel mesterségesintelligencia-"
+"modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24007,14 +24472,15 @@ msgid ""
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! A csevegést a(z) %1$s %2$s technológiája "
 "szolgáltatja. Minden itt folytatott beszélgetésed privát, melyeket a "
-"DuckDuckGo soha nem tárol, és nem használ fel a "
-"mesterségesintelligencia-modellek tanítására."
+"DuckDuckGo soha nem tárol, és nem használ fel a mesterségesintelligencia-"
+"modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
+msgstr ""
+"Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24113,7 +24579,8 @@ msgstr ""
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
+msgstr ""
+"Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24130,6 +24597,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Milyen előnyei és hátrányai vannak a járadékoknak?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24494,7 +24967,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
+msgstr ""
+"Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24512,7 +24986,8 @@ msgstr "Hol nézhető meg a(z) <strong>%1$s</strong>?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
+msgstr ""
+"A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24699,6 +25174,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Nulla szolgáltatói láthatóság nélkül"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24985,7 +25468,8 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr "A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
+msgstr ""
+"A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -25045,7 +25529,8 @@ msgstr "Ezt a %1$sKeresési beállítások%2$s oldalon bármikor módosíthatod"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
+msgstr ""
+"A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25084,7 +25569,8 @@ msgstr "A havi limit felhasználásával folytathatod a csevegést."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
+msgstr ""
+"Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25198,6 +25684,13 @@ msgstr "Még %1$s próbálkozásod maradt."
 msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Még 1 próbálkozásod maradt."
+
+# smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25350,7 +25843,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
+msgstr ""
+"Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25420,6 +25914,23 @@ msgid "YouTube Standard"
 msgstr "YouTube Standard"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "A DuckDuckGo-keresési előzményeid privátak"
@@ -25441,6 +25952,14 @@ msgstr "A tényleges tartózkodási helyed titokban marad"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "A tényleges tartózkodási helyed titokban marad."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25592,19 +26111,22 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
+msgstr ""
+"A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
 msgctxt "Description for the joiner-device success screen"
 msgid "Your chats will now sync between these devices."
-msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr ""
+"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the success screen after a successful pairing.
 msgctxt "Description for the success screen"
 msgid "Your chats will now sync between these devices."
-msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr ""
+"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Description explaining why delegation is needed for image generation.
@@ -25754,7 +26276,8 @@ msgstr ""
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr "A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
+msgstr ""
+"A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25814,7 +26337,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
+msgstr ""
+"Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26117,8 +26641,8 @@ msgstr "hivatalos webhely"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt "
-"%3$s-karakter)."
+"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt %3$s-"
+"karakter)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hu_HU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Ez az eszköz)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -190,9 +190,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
-"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
-"Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
+"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
+"válts a Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -202,9 +202,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
-"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
-"Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
+"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
+"válts a Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -498,15 +498,14 @@ msgstr "%1$sTudj meg többet%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
+msgstr "%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sTovábbi információ%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -521,15 +520,13 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
+msgstr "%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
+msgstr "%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -802,7 +799,7 @@ msgstr "2. a(z) %1$s csoportban"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2. vélemény"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -886,8 +883,7 @@ msgstr "Elérted a 6 órás használati limitet."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
+msgstr "Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1012,8 +1008,9 @@ msgstr ""
 "Az AI Chat segítségével névtelen beszélgetéseket folytathatsz harmadik felek "
 "mesterséges intelligencián alapuló csevegési modelljeivel. Ennek "
 "kikapcsolása elrejti az AI Chat funkciót a DuckDuckGo Search "
-"szolgáltatásban. Ha a beállítás ki van kapcsolva, a %1$sduckduckgo.com/"
-"aichat%2$s oldalra látogatva továbbra is elérheted az AI Chatet."
+"szolgáltatásban. Ha a beállítás ki van kapcsolva, a "
+"%1$sduckduckgo.com/aichat%2$s oldalra látogatva továbbra is elérheted az AI "
+"Chatet."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1077,8 +1074,9 @@ msgstr ""
 "Az AI-alapú válaszokra jelenleg nem tehetők fel közvetlenül további "
 "kérdések. Azonban ha újabb kérdést szeretnél feltenni, az OpenAI, az "
 "Anthropic, valamint más szolgáltatók csevegési modelljeit is támogató "
-"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a %1$sDuck."
-"ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak linkjét."
+"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a "
+"%1$sDuck.ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak "
+"linkjét."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1496,7 +1494,7 @@ msgstr "Hozzáadás a kezdőlaphoz"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Hozzáadás a Saját csevegésekhez"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1868,7 +1866,7 @@ msgstr "Minden típus"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Minden eszközöd le lett választva a szinkronizálásról."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1900,8 +1898,7 @@ msgstr "Adatvédelmet tiszteletben tartó hirdetések engedélyezése"
 #. Title of the upload consent prompt shown before the first image/file upload in a chat with a zero-provider-visibility model, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow anonymous file review for this chat?"
-msgstr ""
-"Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
+msgstr "Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
 
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
@@ -2398,7 +2395,7 @@ msgstr "Kérdezz bármit privát módon"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Kérdezz bármit privátban"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2462,9 +2459,9 @@ msgstr ""
 "felhasználói felületét a keresési eredményekből), Igény szerint (csak az "
 "Asszisztens gombra kattintás esetén jelennek meg az AI-alapú válaszok), Néha "
 "(csak akkor jelenik meg AI-alapú válasz, ha nagyon releváns), illetve "
-"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az AI-"
-"alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában érhetők "
-"el."
+"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az "
+"AI-alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában "
+"érhetők el."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2571,21 +2568,18 @@ msgstr "Hang"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2834,8 +2828,7 @@ msgstr "Vonalkód"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
-"Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
+msgstr "Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -3038,8 +3031,7 @@ msgstr "Webhely blokkolása minden találatból"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
+msgstr "Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3773,8 +3765,7 @@ msgstr "Módosítja az eredmények URL-jeinek megjelenítési módját"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
+msgstr "Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3986,8 +3977,8 @@ msgstr "Privát csevegés"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített Duck."
-"ai segítségével."
+"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített "
+"Duck.ai segítségével."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4515,8 +4506,8 @@ msgid ""
 msgstr ""
 "Kattints a „Több” lehetőségre, ha többet meg szeretnél tudni egy témáról, és "
 "tegyél fel kapcsolódó kérdéseket az OpenAI, az Anthropic és további "
-"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a %1$sDuck."
-"ai%2$s használatával."
+"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a "
+"%1$sDuck.ai%2$s használatával."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4543,15 +4534,13 @@ msgstr "Kattints a %1$sHozzáadás%2$s lehetőségre"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr ""
-"Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
+msgstr "Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr ""
-"Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
+msgstr "Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4585,8 +4574,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
+msgstr "Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4667,8 +4655,7 @@ msgstr "Kattints a %1$sBeállítás alapértelmezettként%2$s lehetőségre lent
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
+msgstr "Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -5372,7 +5359,7 @@ msgstr "Másolás"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Másolás"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5383,8 +5370,7 @@ msgstr "Másolás"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
+msgstr "Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5422,13 +5408,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Megosztott hivatkozás másolása"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Másold ki a kódot egy másik eszközről"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5437,6 +5423,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Másold ki a kódot egy másik eszközről. Lépj a %1$sDuck.ai Beállítások › "
+"Csevegések › Sync & Backup › Szinkronizálás másik eszközzel%2$s menüpontra, "
+"majd próbálkozz újra."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6127,7 +6116,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Megosztott link törlése"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6148,6 +6137,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"A link törlése leállítja annak működését. Azok, akik megnyitották és "
+"hozzáadták a beszélgetést a csevegéseikhez, megtartják a saját példányukat."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6411,7 +6402,7 @@ msgstr "Bezárás"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Bezárás"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6826,8 +6817,7 @@ msgstr "Dobd ide a fotókat vagy PDF-fájlokat"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
+msgstr "A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6920,8 +6910,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
+msgstr "A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6964,8 +6953,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el e-"
-"mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
+"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el "
+"e-mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
 "%2$s"
 
 # smartling.placeholder_format=C
@@ -6973,8 +6962,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
+msgstr "A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6988,9 +6976,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű MI-"
-"modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, de "
-"továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
+"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű "
+"MI-modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, "
+"de továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7074,8 +7062,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes AI-"
-"csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
+"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes "
+"AI-csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
 "Anthropic, Llama, Mistral, nyílt forráskódú AI modellek, adatvédelemre "
 "összpontosító AI, fiók nélküli AI-csevegés"
 
@@ -7123,8 +7111,8 @@ msgid ""
 msgstr ""
 "A DuckAssist nem tud utólagos kérdésekre válaszolni, viszont kínálatunkban "
 "többek között az OpenAI és az Anthropic csevegési modelljeit támogató "
-"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy mesterségesintelligencia-"
-"alapú privát csevegési szolgáltatás."
+"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy "
+"mesterségesintelligencia-alapú privát csevegési szolgáltatás."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7252,8 +7240,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
+msgstr "A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7286,7 +7273,7 @@ msgstr "DuckDuckGo böngésző %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo súgóoldalak"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7404,8 +7391,8 @@ msgid ""
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
 "A DuckDuckGo automatikusan anonimizálja ezeket a jelentéseket az olyan "
-"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az e-mail-"
-"címek, a telefonszámok és az azonosításra alkalmas metaadatok."
+"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az "
+"e-mail-címek, a telefonszámok és az azonosításra alkalmas metaadatok."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7690,8 +7677,7 @@ msgstr "Emeld ki a fontos információkat a válaszokban"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr ""
-"Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
+msgstr "Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7792,8 +7778,7 @@ msgstr "Diktálás engedélyezése a Duck.ai felületén"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
+msgstr "Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7911,15 +7896,13 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
+msgstr "Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
+msgstr "Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7933,8 +7916,7 @@ msgstr ""
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
+msgstr "Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7970,15 +7952,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
+msgstr "Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
+msgstr "Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8141,7 +8121,7 @@ msgstr "Profi termékek azoknak, akiknek fontos az adatvédelem."
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Lejárt"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8155,7 +8135,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Lejár: %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8689,8 +8669,8 @@ msgstr ""
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
 msgstr ""
-"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új Duck."
-"ai felületre"
+"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új "
+"Duck.ai felületre"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8801,8 +8781,7 @@ msgstr "Ingyenes és privát csevegések, általunk anonimizálva"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
+msgstr "Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9054,15 +9033,13 @@ msgstr "Általános célú mesterséges intelligencia, beépített erős moderá
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Általános célú mesterséges intelligencia, beépített gyenge moderálással"
+msgstr "Általános célú mesterséges intelligencia, beépített gyenge moderálással"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Általános célú mesterséges intelligencia, beépített közepes moderálással"
+msgstr "Általános célú mesterséges intelligencia, beépített közepes moderálással"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9297,9 +9274,9 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett AI-"
-"csevegést, a személyes adatok eltávolítására szolgáló Personal Info Removal, "
-"és a személyazonosság helyreállításához használható Identity Theft "
+"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett "
+"AI-csevegést, a személyes adatok eltávolítására szolgáló Personal Info "
+"Removal, és a személyazonosság helyreállításához használható Identity Theft "
 "Restoration funkciókat."
 
 # smartling.placeholder_format=C
@@ -9309,8 +9286,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett AI-"
-"csevegést, és a személyazonosság helyreállításához használható Identity "
+"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett "
+"AI-csevegést, és a személyazonosság helyreállításához használható Identity "
 "Theft Restoration funkciókat."
 
 # smartling.placeholder_format=C
@@ -9333,9 +9310,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez DuckDuckGo-"
-"előfizetéssel, amely a VPN-megoldásunk mellett további prémium adatvédelmi "
-"szolgáltatásokat is tartalmaz."
+"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez "
+"DuckDuckGo-előfizetéssel, amely a VPN-megoldásunk mellett további prémium "
+"adatvédelmi szolgáltatásokat is tartalmaz."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9364,8 +9341,7 @@ msgstr "Kérj számítógépes segítséget"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
-"DuckDuckGo-előfizetéssel magasabb felhasználási limiteket vehetsz igénybe."
+msgstr "DuckDuckGo-előfizetéssel magasabb felhasználási limiteket vehetsz igénybe."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9555,13 +9531,14 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Lépj a %1$sDuck.ai-beállítások%2$s › %3$sCsevegések › Sync & Backup › "
+"Szinkronizálás másik eszközzel%4$s menüpontra."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
+msgstr "Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9672,7 +9649,7 @@ msgstr "Megvan"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Értem"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10038,8 +10015,7 @@ msgstr "Segíts nekünk a DuckDuckGo fejlesztésében"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
+msgstr "A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10735,8 +10711,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
+msgstr "Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10937,8 +10912,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr ""
-"A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
+msgstr "A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11670,7 +11644,7 @@ msgstr "Tudj meg %1$stöbbet%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "További információk"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -12240,8 +12214,7 @@ msgstr "Ügyelj rá, hogy minden szó helyesen legyen írva."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
+msgstr "Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12313,7 +12286,7 @@ msgstr "Kezelés"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Kezelés"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12570,7 +12543,7 @@ msgstr "Menü"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Az ezen a ponton túli üzenetek csak számodra láthatók."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12944,7 +12917,7 @@ msgstr "A Duck.ai további tudnivalói"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "További műveletek"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13146,7 +13119,7 @@ msgstr "Tompa vörös"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Saját eszközök"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14224,6 +14197,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Egy másik eszközön lépj a %1$sDuck.ai-beállítások%2$s › %3$sCsevegések › "
+"Sync & Backup › Szinkronizálás másik eszközzel%4$smenüpontra"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14232,6 +14207,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Egy másik eszközön lépj a %1$sDuck.ai-beállítások%2$s › %3$sCsevegések › "
+"Sync & Backup › Szinkronizálás másik eszközzel%4$s menüpontra, és olvasd be "
+"ezt a kódot:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14240,6 +14218,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Egy másik eszközön lépj a %1$sDuck.ai-beállítások%2$s › %3$sCsevegések › "
+"Sync & Backup › Szinkronizálás másik eszközzel%4$smenüpontra. Vagy olvasd be "
+"a helyreállítási PDF-ben található QR-kódot."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14310,8 +14291,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
+msgstr "Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14674,9 +14654,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, titkosítás-"
-"végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS és "
-"Android%2$s rendszerhez is elérhető."
+"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, "
+"titkosítás-végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS "
+"és Android%2$s rendszerhez is elérhető."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -15000,7 +14980,7 @@ msgstr "Elmúlt évben"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Beillesztés"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -15018,7 +14998,7 @@ msgstr "Szinkronizálási kód beillesztése"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Illeszd be alább"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -15077,7 +15057,7 @@ msgstr "perzsa"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -15086,6 +15066,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"A Personal Information Removal megtalálja az adataidat az azokat értékesítő "
+"adatbróker-oldalakon. Ezután azon dolgozunk, hogy eltávolítsuk azokat a "
+"nevedben."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15299,8 +15282,7 @@ msgstr "Kitűzött"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"A kitűzött csevegések a legutóbbi csevegések felső részében jelennek meg."
+msgstr "A kitűzött csevegések a legutóbbi csevegések felső részében jelennek meg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15341,8 +15323,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
+msgstr "A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15350,8 +15331,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
+msgstr "A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15562,8 +15542,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a YouTube-"
-"javaslataidat."
+"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a "
+"YouTube-javaslataidat."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -16357,7 +16337,7 @@ msgstr "Webhely olvasása…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Készen állsz a napfogyatkozásra?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16381,15 +16361,13 @@ msgstr "Érvelő mesterséges intelligencia, magas szintű beépített moderáci
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr ""
-"Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
+msgstr "Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr ""
-"Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
+msgstr "Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
@@ -16401,15 +16379,13 @@ msgstr "Érveléssel jobb válaszok kaphatók az összetett kérdésekre."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Az érvelés alaposabb, de 2–5-ször hamarabb éri el a használati limitet. %1$s"
+msgstr "Az érvelés alaposabb, de 2–5-ször hamarabb éri el a használati limitet. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Az érvelés alaposabb, de 2–5-ször gyorsabban fogyasztja a limitet. %1$s"
+msgstr "Az érvelés alaposabb, de 2–5-ször gyorsabban fogyasztja a limitet. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16557,7 +16533,7 @@ msgstr "Helyreállítási kód"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Helyreállítási kód"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16778,8 +16754,7 @@ msgstr "Választott beállítás megjegyzése"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
+msgstr "Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16815,7 +16790,7 @@ msgstr "%1$s eltávolítása"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Eszköz eltávolítása"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16863,13 +16838,13 @@ msgstr "Távolítsd el a felesleges írásjeleket"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Adataid eltávolítása az internetről"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Adataid eltávolítása online"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17063,8 +17038,8 @@ msgid ""
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
 "A válaszok kizárólag tájékoztatási célokat szolgálnak, és nem minősülnek "
-"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az AI-"
-"alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
+"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az "
+"AI-alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17159,8 +17134,7 @@ msgstr "A találatok nem tartalmazzák a blokkolt webhelyeket."
 #. Informational banner shown at the top of the Maps search results panel when the user has blocked Yelp or TripAdvisor in their settings. Explains why ratings, reviews, and other details may be missing from place listings.
 msgctxt "Exclusion message at top of maps vertical"
 msgid "Results exclude information from blocked sites."
-msgstr ""
-"A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
+msgstr "A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
 
 # smartling.placeholder_format=C
 #. Message that appears when results exclude blocked sites
@@ -17569,7 +17543,7 @@ msgstr "Üdvözöl a Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Üdvözöl a Duck.ai – ingyenes, privát AI-csevegés a DuckDuckGo kínálatában."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17753,8 +17727,7 @@ msgstr "Keresés"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr ""
-"A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
+msgstr "A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
 
 # smartling.placeholder_format=C
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
@@ -18166,8 +18139,7 @@ msgstr "Fényképek megtekintése"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "See Privacy Policy and Terms of Service"
-msgstr ""
-"Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
+msgstr "Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
 
 # smartling.placeholder_format=C
 #. Text of the secondary button in the modal that allows the user to open the terms and privacy policy page.
@@ -18233,8 +18205,7 @@ msgstr "További információ: %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr ""
-"További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
+msgstr "További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -18290,8 +18261,8 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a %3$shttps://duckduckgo."
-"com%4$s címet a beviteli mezőbe"
+"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a "
+"%3$shttps://duckduckgo.com%4$s címet a beviteli mezőbe"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18339,8 +18310,7 @@ msgstr "Válaszd a %1$sDuckDuckGót%2$s a keresőszolgáltatók listáján"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
+msgstr "Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18351,8 +18321,7 @@ msgstr "Válaszd a %1$sDuckDuckGo%2$s lehetőséget."
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
+msgstr "Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18395,8 +18364,7 @@ msgstr "Válaszd ki a %1$sKeresőmotor%2$s lehetőséget"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
+msgstr "Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18421,8 +18389,7 @@ msgstr "Válaszd ki a %1$sBeállítások%2$s opciót a legördülő menüből."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
+msgstr "Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18603,7 +18570,7 @@ msgstr "szerb (latin)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Szerveradatok törölve"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18765,7 +18732,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Megosztás"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18782,8 +18749,7 @@ msgstr "Megosztás"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
+msgstr "Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18810,8 +18776,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az AI-"
-"modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
+"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az "
+"AI-modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
 "pontos tartózkodási helyedet."
 
 # smartling.placeholder_format=C
@@ -18897,8 +18863,7 @@ msgstr "Beszélgetés megosztása a DuckDuckGóval"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr ""
-"Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
+msgstr "Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -18922,13 +18887,13 @@ msgstr "Oszd meg a véleményed a keresőmezővel kapcsolatban."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Megosztott csevegési linkek"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Megosztott csevegési linkek"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19177,8 +19142,7 @@ msgstr "Minden találat megjelenítése"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
+msgstr "Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19341,14 +19305,12 @@ msgstr "A legtöbbször meglátogatott hivatkozások megjelenítése új lapon"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
+msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
+msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19366,8 +19328,7 @@ msgstr "Oldalszám megjelenítése a találati oldalak töréseinél"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
+msgstr "A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19395,8 +19356,7 @@ msgstr "Üdvözlőüzenet megjelenítése a keresési találati oldal tetején"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
+msgstr "Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19473,8 +19433,7 @@ msgstr "Az oldalkeresés átmenetileg nem érhető el. Dolgozunk a megoldáson."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
+msgstr "Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19621,7 +19580,7 @@ msgstr "Hiba történt"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Hiba történt a megosztott csevegés betöltése során."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -20473,7 +20432,7 @@ msgstr "Másik modellre váltás"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Másik modellre váltás"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20740,7 +20699,7 @@ msgstr "Szinkronizált eszközök"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Szinkronizálva: %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20778,7 +20737,7 @@ msgstr "Tv"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Táblázat"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20923,8 +20882,7 @@ msgstr "Koppints a címsorban található %1$sengedélyek ikonra%2$s"
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Tap the vertical dots in the DuckDuckGo app."
-msgstr ""
-"Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
+msgstr "Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a teacher in its responses.
@@ -21093,21 +21051,18 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
+msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
+msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
+msgstr "A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21319,8 +21274,7 @@ msgstr "Ezen a héten"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
-"Ez a csevegés a Duck.ai-ban marad, és megőrzi számodra privát jellegét."
+msgstr "Ez a csevegés a Duck.ai-ban marad, és megőrzi számodra privát jellegét."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21372,7 +21326,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Ez az eszköz"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21383,6 +21337,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Ez az eszköz többé nem fog hozzáférni a szinkronizált adataidhoz a többi "
+"eszközödön. Az utolsó %1$s csevegés továbbra is elérhető marad a helyi "
+"tárhelyen."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21454,8 +21411,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
-"fájlt"
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
+"GIF-fájlt"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21463,8 +21420,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
-"fájlt."
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
+"GIF-fájlt."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21475,7 +21432,7 @@ msgstr "Nem hasznos információ"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Ez egy megosztott csevegés másolata."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21574,9 +21531,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
-"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
-"intelligencia segítségével generált válaszok."
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
+"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
+"mesterséges intelligencia segítségével generált válaszok."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21586,9 +21543,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
-"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
-"intelligencia segítségével generált válaszok. Ugyanakkor van egy "
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
+"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
+"mesterséges intelligencia segítségével generált válaszok. Ugyanakkor van egy "
 "kezdőoldalunk, amely soha nem jelenít meg AI-alapú válaszokat: %1$s."
 
 # smartling.placeholder_format=C
@@ -21596,12 +21553,14 @@ msgstr ""
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
 msgstr ""
+"Ezt a megosztott csevegést nem sikerült megnyitni. Lehet, hogy a link "
+"hiányos."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Ez a megosztott csevegési link már nem érhető el."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21630,8 +21589,7 @@ msgstr "Ez a videó még nem tekinthető meg itt. Megnézheted itt: %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
+msgstr "Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21809,8 +21767,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "A szinkronizált adatok visszaállításához szükség lesz a szinkronizálás első "
-"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód PDF-"
-"fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
+"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód "
+"PDF-fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
 "eszközre."
 
 # smartling.placeholder_format=C
@@ -22196,8 +22154,7 @@ msgstr "Próbálkozz ezzel: %1$s"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr ""
-"Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
+msgstr "Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -22258,7 +22215,7 @@ msgstr "Ingyenes próba"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Próbáld ki ingyen!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22348,16 +22305,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
+msgstr "A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
+msgstr "Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22381,7 +22336,7 @@ msgstr "Próbáld ki ingyen"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Próbáld ki ingyen!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22409,8 +22364,7 @@ msgstr "Próbáld ki ingyen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
+msgstr "Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22449,8 +22403,7 @@ msgstr "Próbáld ki a böngészőnket,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
+msgstr "Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22638,7 +22591,7 @@ msgstr "Türkmenisztán"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Kikapcsolás"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22656,7 +22609,7 @@ msgstr "Sync & Backup kikapcsolása"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Kikapcsolod a Sync & Backup funkciót és törlöd a szerveradatokat?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22727,8 +22680,7 @@ msgstr "A pontosabb találatokhoz kapcsold be a %1$sPontos hely%2$s funkciót"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
+msgstr "Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22961,8 +22913,7 @@ msgstr "Az %1$sÁltalános > Kezdőlap%2$s alatt írd be: https://duckduckgo.com
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr ""
-"A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
+msgstr "A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23071,8 +23022,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb MI-"
-"érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
+"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb "
+"MI-érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23094,8 +23045,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el DuckDuckGo-"
-"előfizetéssel"
+"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el "
+"DuckDuckGo-előfizetéssel"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23152,7 +23103,7 @@ msgstr "Némítás kikapcsolása"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Névtelen csevegés"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23193,7 +23144,7 @@ msgstr "Böngésző frissítése"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Frissítsd a Duck.ai-t a megosztott csevegés megtekintéséhez."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23739,9 +23690,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: %1$sDuck.ai-"
-"beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd válaszd a "
-"%7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
+"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: "
+"%1$sDuck.ai-beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd "
+"válaszd a %7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23780,8 +23731,8 @@ msgstr ""
 "Látogass el a Duck.ai oldalra a másik böngésződben vagy a DuckDuckGo "
 "alkalmazásban, és nyisd meg a Duck.ai beállításait. Válaszd a „Bekapcsolás” "
 "lehetőséget a Sync & Backup alatt, és válaszd a „Szinkronizálás másik "
-"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található QR-"
-"kódot."
+"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található "
+"QR-kódot."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23834,8 +23785,8 @@ msgstr "A hangcsevegés véget ért"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel MI-"
-"modellek betanítására."
+"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel "
+"MI-modellek betanítására."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23979,8 +23930,9 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott YouTube-"
-"hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube ajánlásait."
+"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott "
+"YouTube-hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube "
+"ajánlásait."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24049,16 +24001,14 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
+msgstr "Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
+msgstr "Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24100,8 +24050,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
+msgstr "Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24178,6 +24127,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Megkeressük és eltávolítjuk a személyes adataidat az adatbrókeroldalakról. "
+"Emellett VPN-t és még sok mást is kapsz."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24232,6 +24183,9 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Rendszeresen átvizsgáljuk az adatbrókeroldalakat a személyes adataid után "
+"kutatva, és a folyamat előrehaladását egy könnyen használható vezérlőpulton "
+"osztjuk meg veled."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24269,8 +24223,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
+msgstr "Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24279,6 +24232,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Átvizsgáljuk az adatbrókeroldalakat az e-mail-címed, a neved, a címed és "
+"egyéb adataid után keresve, és igyekszünk eltávolítani mindent, amit rólad "
+"találunk."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24459,8 +24415,8 @@ msgid ""
 "anonymized by us and not used to train AI models."
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! Minden itt folytatott beszélgetésed privát, "
-"anonimizáljuk azokat, és nem használjuk fel mesterségesintelligencia-"
-"modellek tanítására."
+"anonimizáljuk azokat, és nem használjuk fel "
+"mesterségesintelligencia-modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24472,15 +24428,14 @@ msgid ""
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! A csevegést a(z) %1$s %2$s technológiája "
 "szolgáltatja. Minden itt folytatott beszélgetésed privát, melyeket a "
-"DuckDuckGo soha nem tárol, és nem használ fel a mesterségesintelligencia-"
-"modellek tanítására."
+"DuckDuckGo soha nem tárol, és nem használ fel a "
+"mesterségesintelligencia-modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
+msgstr "Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24579,8 +24534,7 @@ msgstr ""
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
+msgstr "Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24602,7 +24556,7 @@ msgstr "Milyen előnyei és hátrányai vannak a járadékoknak?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Mik a Duck.ai előnyei?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24967,8 +24921,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
+msgstr "Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24986,8 +24939,7 @@ msgstr "Hol nézhető meg a(z) <strong>%1$s</strong>?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
+msgstr "A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25182,6 +25134,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Közvetlenül az eszközödről működik, hogy eltávolítsa az e-mail-címedet, a "
+"nevedet, a lakcímedet és egyebeket az adatbrókeroldalakról."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25468,8 +25422,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
+msgstr "A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -25529,8 +25482,7 @@ msgstr "Ezt a %1$sKeresési beállítások%2$s oldalon bármikor módosíthatod"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
+msgstr "A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25569,8 +25521,7 @@ msgstr "A havi limit felhasználásával folytathatod a csevegést."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
+msgstr "Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25690,7 +25641,7 @@ msgstr "Még 1 próbálkozásod maradt."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Nincsenek megosztott csevegési linkjeid."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25843,8 +25794,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
+msgstr "Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25922,13 +25872,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"A legfrissebb %1$s csevegésed elérhető lesz a következő böngészők helyi "
+"tárhelyein:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Duck.ai-csevegéseid végpontok közötti titkosítással szinkronizálódnak."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25960,6 +25912,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"A biztonsági mentés törlődik a DuckDuckGo szerveréről. Minden eszköz le lesz "
+"választva a szinkronizálásról."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26111,22 +26065,19 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
+msgstr "A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
 msgctxt "Description for the joiner-device success screen"
 msgid "Your chats will now sync between these devices."
-msgstr ""
-"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the success screen after a successful pairing.
 msgctxt "Description for the success screen"
 msgid "Your chats will now sync between these devices."
-msgstr ""
-"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Description explaining why delegation is needed for image generation.
@@ -26276,8 +26227,7 @@ msgstr ""
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
+msgstr "A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26337,8 +26287,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
+msgstr "Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26641,8 +26590,8 @@ msgstr "hivatalos webhely"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt %3$s-"
-"karakter)."
+"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt "
+"%3$s-karakter)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hy_AM/LC_MESSAGES/duckduckgo.po
+++ b/locales/hy_AM/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1185,6 +1203,11 @@ msgstr "Ավելացնել %s֊ին"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Հավելումներ"
@@ -1475,6 +1498,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1887,6 +1916,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4205,6 +4239,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4237,6 +4276,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4797,6 +4855,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4805,6 +4870,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5011,6 +5083,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5660,6 +5738,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6328,9 +6412,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7423,6 +7520,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7507,6 +7611,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9099,6 +9208,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Սովորել %sԱվելին%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9618,6 +9732,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9824,6 +9944,11 @@ msgstr "Մենյու"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Մենյու"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10125,6 +10250,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Ավելին"
@@ -10284,6 +10414,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Մուգ կարմիր"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11163,6 +11298,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11769,6 +11925,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11777,6 +11938,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11821,6 +11987,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12835,6 +13013,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12984,6 +13167,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13191,6 +13379,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13224,6 +13417,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13772,6 +13975,11 @@ msgstr "Անանուն պահեք Ձեր կարգավորումներն ամպո
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14542,6 +14750,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14668,6 +14882,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14787,6 +15008,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15334,6 +15565,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16025,6 +16261,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16222,6 +16463,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16247,6 +16494,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "ՀՑ"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16699,6 +16951,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16767,6 +17033,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16850,6 +17121,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17364,6 +17645,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17456,6 +17742,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17655,6 +17946,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17663,6 +17959,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18040,6 +18341,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18067,6 +18373,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18833,6 +19144,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18867,6 +19185,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18891,6 +19216,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19135,6 +19467,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19597,6 +19934,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20000,6 +20344,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20167,6 +20517,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube ստանդարտ"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20184,6 +20549,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: id_ID\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% Divaksinasi Lengkap"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% Divaksinasi"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -299,7 +307,8 @@ msgstr "Peringkat %1$s belum tersedia"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s mencapai batas penggunaan 2-5x lebih cepat daripada model dasar. %2$s"
+msgstr ""
+"%1$s mencapai batas penggunaan 2-5x lebih cepat daripada model dasar. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -486,6 +495,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sPelajari cara kami merahasiakan lokasimu%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -512,7 +528,8 @@ msgstr "%1$sTekan lama%2$s ikon aplikasi DuckDuckGo di layar beranda"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
+msgstr ""
+"%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -776,6 +793,12 @@ msgid "2nd in Group %s"
 msgstr "Peringkat kedua di Grup %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -930,14 +953,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr ""
+"Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr ""
+"Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1459,6 +1484,12 @@ msgid "Add to Home Screen"
 msgstr "Tambahkan ke Layar Beranda"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Pengaya"
@@ -1782,7 +1813,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
+msgstr ""
+"Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1817,6 +1849,13 @@ msgstr "Semua ukuran"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Semua jenis"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2187,13 +2226,15 @@ msgstr "Apa kamu masih di sana?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
+msgstr ""
+"Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
+msgstr ""
+"Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2338,6 +2379,12 @@ msgstr "Ajukan pertanyaan tentang halaman ini"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask anything privately"
 msgstr "Tanyakan apa pun secara pribadi"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2511,18 +2558,21 @@ msgstr "Suara"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr ""
+"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr ""
+"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
+msgstr ""
+"Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3727,7 +3777,8 @@ msgstr "Mengubah warna latar belakang hasil hover, modul, dan menu dropdown"
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
+msgstr ""
+"Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3854,8 +3905,8 @@ msgstr ""
 "anonim dengan model chat AI pihak ketiga, yang mendukung model dari OpenAI, "
 "Anthropic, dan lainnya. Menonaktifkan pengaturan ini akan menyembunyikan "
 "tombol dan tautan Chat di DuckDuckGo Search. Namun, Anda masih dapat "
-"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi "
-"%1$shttps://duck.ai%2$s langsung."
+"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi %1$shttps://"
+"duck.ai%2$s langsung."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4103,7 +4154,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
+msgstr ""
+"Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4495,7 +4547,8 @@ msgstr "Klik %1$sDi sini%2$s untuk mengunduh ekstensi DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
+msgstr ""
+"Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4540,7 +4593,8 @@ msgstr "Klik %1$sYa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
+msgstr ""
+"Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -5274,6 +5328,12 @@ msgid "Copy"
 msgstr "Salin"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5313,6 +5373,28 @@ msgstr "Salin atau simpan kode ini"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Salin kode pemulihan"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5996,6 +6078,14 @@ msgid "Delete recent chats?"
 msgstr "Hapus obrolan terbaru?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6006,6 +6096,14 @@ msgstr "Hapus obrolan ini?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Obrolan yang dihapus"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6263,6 +6361,13 @@ msgid "Dismiss"
 msgstr "Tutup"
 
 # smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
 msgctxt "duckassist"
 msgid "Dismiss"
@@ -6313,7 +6418,8 @@ msgstr "Bahasa Tampilan"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr "Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
+msgstr ""
+"Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6593,8 +6699,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"Buatlah beberapa opsi untuk postingan media sosial yang mengundang "
-"orang-orang ke pesta saya yang akan datang."
+"Buatlah beberapa opsi untuk postingan media sosial yang mengundang orang-"
+"orang ke pesta saya yang akan datang."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6766,7 +6872,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
+msgstr ""
+"Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6856,7 +6963,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
+msgstr ""
+"Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6905,7 +7013,8 @@ msgstr "Duck.ai ditingkatkan!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
+msgstr ""
+"Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7091,7 +7200,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
+msgstr ""
+"DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7118,6 +7228,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Browser DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7396,9 +7513,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi "
-"kata-kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 "
-"kata acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
+"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi kata-"
+"kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 kata "
+"acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
 "sepanjang 18—20 karakter."
 
 # smartling.placeholder_format=C
@@ -7621,7 +7738,8 @@ msgstr "Aktifkan Dikte dalam Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
+msgstr ""
+"Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7947,10 +8065,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "Produk yang dibuat secara ahli untuk orang yang peduli dengan privasi."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Kadaluarsa"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7975,7 +8108,8 @@ msgstr "Jelaskan jawaban yang diterima dengan bahasa yang sederhana."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
+msgstr ""
+"Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8409,7 +8543,8 @@ msgstr "Temukan hasil yang lebih dekat dari lokasimu."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
+msgstr ""
+"Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8480,7 +8615,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
+msgstr ""
+"Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8705,8 +8841,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dari bilah menu aplikasi di Mac, pilih <strong>DuckDuckGo</strong> &gt; "
-"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal "
-"Pembaruan</strong>."
+"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal Pembaruan</"
+"strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9145,7 +9281,8 @@ msgstr "Dapatkan bantuan komputer"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr "Dapatkan batas penggunaan yang lebih tinggi dengan langganan DuckDuckGo."
+msgstr ""
+"Dapatkan batas penggunaan yang lebih tinggi dengan langganan DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9224,7 +9361,8 @@ msgstr "Dapatkan aplikasinya"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "Dapatkan Browser DuckDuckGo gratis %1$suntuk memblokir iklan di YouTube.%2$s"
+msgstr ""
+"Dapatkan Browser DuckDuckGo gratis %1$suntuk memblokir iklan di YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9320,6 +9458,14 @@ msgstr ""
 "Buka %1$sPengaturan Duck.ai%2$s di browser lain, atau aplikasi DuckDuckGo "
 "dan buka %3$sObrolan › Sync & Backup › Sinkronkan dengan Perangkat Lain%4$s. "
 "Atau pindai QR pada PDF Pemulihan."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9430,6 +9576,12 @@ msgstr "Paham"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Paham"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10358,7 +10510,8 @@ msgstr "Saya tidak paham informasi ini"
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "I don’t want to see any information from DuckDuckGo on this page"
-msgstr "Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
+msgstr ""
+"Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -10397,7 +10550,8 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
+msgstr ""
+"Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10685,7 +10839,8 @@ msgstr "Di menu atas, pilih %1$sAlat%2$s > %3$sPengaturan%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
+msgstr ""
+"Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11177,7 +11332,8 @@ msgstr ""
 #. An instruction to state that a list of companies/trackers will be updated with continued use
 msgctxt "tracker_stats"
 msgid "Keep browsing to see how many we block"
-msgstr "Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
+msgstr ""
+"Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
 
 # smartling.placeholder_format=C
 #. Header above social media links.
@@ -11405,6 +11561,12 @@ msgid "Learn %sMore%s"
 msgstr "Pelajari %1$sSelengkapnya%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11578,8 +11740,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Memungkinkan beralih antara mengirimkan kueri pencarian dan perintah ke "
-"Duck.ai"
+"Memungkinkan beralih antara mengirimkan kueri pencarian dan perintah ke Duck."
+"ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12038,6 +12200,13 @@ msgid "Manage"
 msgstr "Mengelola"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12287,6 +12456,12 @@ msgstr "Menu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12657,6 +12832,12 @@ msgid "More about Duck.ai"
 msgstr "Selengkapnya tentang Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Selengkapnya di"
@@ -12849,6 +13030,12 @@ msgstr "Redup"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Merah redup"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13409,7 +13596,8 @@ msgstr "Hasil tidak ditemukan."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
+msgstr ""
+"Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13918,6 +14106,30 @@ msgid ""
 msgstr ""
 "Di Mac, %1$sKlik Maxthon > Preferensi%2$s, Di Windows, %3$sKlik ikon %4$s > "
 "Pengaturan%5$s"
+
+# smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14670,6 +14882,12 @@ msgid "Past year"
 msgstr "Setahun terakhir"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14680,6 +14898,12 @@ msgstr "Tempel"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Tempelkan kode Sinkron"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14733,6 +14957,20 @@ msgstr "Ditutup secara permanen"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persia"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15005,13 +15243,15 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
+msgstr ""
+"Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
+msgstr ""
+"Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15269,7 +15509,8 @@ msgstr "Pemformatan yang buruk"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr "Model AI populer tersedia. Tidak perlu akun. Obrolan dianonimkan oleh kami."
+msgstr ""
+"Model AI populer tersedia. Tidak perlu akun. Obrolan dianonimkan oleh kami."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15495,7 +15736,8 @@ msgstr "Harga"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr "Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
+msgstr ""
+"Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -15996,6 +16238,12 @@ msgid "Reading website…"
 msgstr "Sedang membaca situs web..."
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16045,7 +16293,8 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Penalaran lebih menyeluruh, tetapi menggunakan batas 2-5x lebih cepat. %1$s"
+msgstr ""
+"Penalaran lebih menyeluruh, tetapi menggunakan batas 2-5x lebih cepat. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16188,6 +16437,12 @@ msgstr "Pemulihan"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Kode Pemulihan"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16441,6 +16696,12 @@ msgid "Remove %s"
 msgstr "Hapus %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16481,6 +16742,18 @@ msgstr "Hapus pemilihan teks"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Hapus tanda baca yang tidak perlu"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16774,7 +17047,8 @@ msgstr "Hasil mengecualikan informasi dari situs yang diblokir."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
+msgstr ""
+"Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17108,7 +17382,8 @@ msgstr "Simpan dan Keluar"
 #. Description explaining that sync allows saving more chats than local browser storage.
 msgctxt "Sync feature benefit description"
 msgid "Save more chats than you can in your web browser."
-msgstr "Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
+msgstr ""
+"Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
 
 # smartling.placeholder_format=C
 #. List item explaining that users can save more chats when Sync & Backup is enabled.
@@ -17170,6 +17445,12 @@ msgstr "Simpan pengaturanmu secara anonim ke cloud"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Sambutlah Duck.ai!"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17324,7 +17605,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
+msgstr ""
+"Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17547,8 +17829,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "Cari secara pribadi dengan aplikasi atau ekstensi kami, tambahkan pencarian "
-"web pribadi ke browser favoritmu, atau cari langsung di "
-"%1$sduckduckgo.com%2$s."
+"web pribadi ke browser favoritmu, atau cari langsung di %1$sduckduckgo."
+"com%2$s."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17713,7 +17995,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
+msgstr ""
+"Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17903,7 +18186,8 @@ msgstr "Pilih %1$sDuckDuckGo%2$s di menu dropdown Mesin Pencari Default"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
+msgstr ""
+"Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18022,7 +18306,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
+msgstr ""
+"Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18162,6 +18447,13 @@ msgstr "Serbia (Sirilik)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Serbia (Latin)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18316,6 +18608,14 @@ msgid "Share"
 msgstr "Bagikan"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18465,6 +18765,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Bagikan pemikiranmu tentang kotak pencarian."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18779,7 +19091,8 @@ msgstr "Tampilkan bilah samping"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Tunjukkan tips langkah demi langkah untuk memaksimalkan penggunaan Duck.ai."
+msgstr ""
+"Tunjukkan tips langkah demi langkah untuk memaksimalkan penggunaan Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18856,7 +19169,8 @@ msgstr "Menampilkan garis horizontal di pemisah halaman hasil"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
+msgstr ""
+"Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18872,18 +19186,21 @@ msgstr "Menampilkan tautan yang paling banyak dikunjungi di halaman tab baru"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
+msgstr ""
+"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
+msgstr ""
+"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr "Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
+msgstr ""
+"Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18921,7 +19238,8 @@ msgstr "Menampilkan pesan selamat datang di atas halaman hasil pencarian"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
+msgstr ""
+"Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19144,10 +19462,17 @@ msgid "Something went wrong"
 msgstr "Terjadi sesuatu yang salah"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
+msgstr ""
+"Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19750,7 +20075,8 @@ msgstr "Sarankan judul untuk postingan blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
+msgstr ""
+"Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19992,6 +20318,12 @@ msgid "Switch model"
 msgstr "Model sakelar"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20047,7 +20379,8 @@ msgstr "Beralih ke model yang lebih efisien"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr "Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
+msgstr ""
+"Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
 
 # smartling.placeholder_format=C
 #. Re-activates a stacked second opinion, making it the current answer again.
@@ -20068,7 +20401,8 @@ msgstr "Beralih ke %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
+msgstr ""
+"Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20122,7 +20456,8 @@ msgstr "Sync & Backup Diaktifkan!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
+msgstr ""
+"Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20247,6 +20582,13 @@ msgid "Synced Devices"
 msgstr "Perangkat Tersinkron"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Syria"
 
@@ -20277,6 +20619,12 @@ msgstr "TBD"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20524,7 +20872,8 @@ msgstr "Thailand (en)"
 #. Message displayed after the user has submitted feedback. It invites the user to share more feedback.
 msgctxt "Feedback toast"
 msgid "Thank you for your feedback. Have more to share?"
-msgstr "Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
+msgstr ""
+"Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
 
 # smartling.placeholder_format=C
 msgid "Thank you!"
@@ -20551,7 +20900,8 @@ msgstr "Terima kasih atas masukanmu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
+msgstr ""
+"Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
@@ -20653,7 +21003,8 @@ msgstr "Permintaan tersebut mengalami batas waktu. Silakan coba lagi."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr "Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
+msgstr ""
+"Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -20863,6 +21214,22 @@ msgstr ""
 "menyinggung (lihat %4$s untuk info selengkapnya)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20931,19 +21298,27 @@ msgstr "Gambar ini tidak dapat dibuat."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
+msgstr ""
+"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
+msgstr ""
+"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Informasi ini tidak berguna"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21060,6 +21435,18 @@ msgstr ""
 "menampilkan jawaban yang dibantu AI di %1$s."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21086,7 +21473,8 @@ msgstr "Video ini belum bisa ditonton di sini. Kamu bisa menontonnya di %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
+msgstr ""
+"Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21241,7 +21629,8 @@ msgstr "Untuk melanjutkan, kamu harus menyetujui %1$s dan %2$sDuck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
+msgstr ""
+"Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21273,8 +21662,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser "
-"DuckDuckGo-mu ke versi terbaru dan coba lagi."
+"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser DuckDuckGo-"
+"mu ke versi terbaru dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21306,8 +21695,8 @@ msgstr "Hari Ini"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Beralih untuk mencoba obrolan AI pribadi atau %1$snonaktifkan di menu "
-"%2$s.%3$s"
+"Beralih untuk mencoba obrolan AI pribadi atau %1$snonaktifkan di menu %2$s."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21703,6 +22092,12 @@ msgid "Try Free"
 msgstr "Coba Gratis"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21818,6 +22213,12 @@ msgstr "Coba Gratis"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Coba Gratis"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22066,6 +22467,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22076,6 +22483,12 @@ msgstr "Nonaktifkan Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Nonaktifkan Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22370,7 +22783,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
+msgstr ""
+"Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22558,6 +22972,12 @@ msgid "Unmute"
 msgstr "Membunyikan"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22591,6 +23011,12 @@ msgstr "Perbarui"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Perbarui Browser"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22762,7 +23188,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
+msgstr ""
+"Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23570,6 +23997,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Kami mengakhiri obrolan karena tidak aktif. Ingin mencoba lagi?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23616,6 +24051,14 @@ msgstr ""
 "baik dan lebih dekat. Kamu sewaktu-waktu bisa mengubahnya nanti."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23654,6 +24097,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Kami akan memblokir pelacak yang mencoba mengumpulkan data saat kamu "
 "menjelajah."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23924,8 +24375,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat "
-"Duck.ai. Coba muat ulang halaman."
+"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat Duck."
+"ai. Coba muat ulang halaman."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23947,7 +24398,8 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
+msgstr ""
+"Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -23972,6 +24424,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Apa saja pro dan kontra dari anuitas?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24541,6 +24999,14 @@ msgid "Without zero provider visibility"
 msgstr "Tanpa visibilitas penyedia"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -24912,7 +25378,8 @@ msgstr "Kamu bisa menemukan file <b>%1$s</b> di folder unduhanmu."
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
 msgid "You can hide this reminder in %sSearch Settings%s"
-msgstr "Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
+msgstr ""
+"Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -25040,6 +25507,13 @@ msgstr "Kamu punya %1$s upaya tersisa."
 msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Kamu punya 1 upaya tersisa."
+
+# smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25267,6 +25741,23 @@ msgid "YouTube Standard"
 msgstr "Standar YouTube"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Riwayat pencarian DuckDuckGo-mu bersifat pribadi"
@@ -25288,6 +25779,14 @@ msgstr "Lokasimu yang sebenarnya tetaplah terlindungi"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Lokasi aktual kamu tetap pribadi."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25617,9 +26116,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami "
-"alih-alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah "
-"terinstal dan dapat:"
+"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami alih-"
+"alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah terinstal dan "
+"dapat:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: id_ID\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Perangkat ini)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -307,8 +307,7 @@ msgstr "Peringkat %1$s belum tersedia"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s mencapai batas penggunaan 2-5x lebih cepat daripada model dasar. %2$s"
+msgstr "%1$s mencapai batas penggunaan 2-5x lebih cepat daripada model dasar. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -499,7 +498,7 @@ msgstr "%1$sPelajari cara kami merahasiakan lokasimu%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sPelajari lebih lanjut%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -528,8 +527,7 @@ msgstr "%1$sTekan lama%2$s ikon aplikasi DuckDuckGo di layar beranda"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
+msgstr "%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -796,7 +794,7 @@ msgstr "Peringkat kedua di Grup %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "Pendapat kedua"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -953,16 +951,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr "Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr "Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1487,7 +1483,7 @@ msgstr "Tambahkan ke Layar Beranda"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Tambahkan ke Obrolan Saya"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1813,8 +1809,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
+msgstr "Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1855,7 +1850,7 @@ msgstr "Semua jenis"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Semua perangkatmu terputus dari Sync."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2226,15 +2221,13 @@ msgstr "Apa kamu masih di sana?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
+msgstr "Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
+msgstr "Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2384,7 +2377,7 @@ msgstr "Tanyakan apa pun secara pribadi"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Tanyakan apa pun secara pribadi"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2558,21 +2551,18 @@ msgstr "Suara"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
+msgstr "Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3777,8 +3767,7 @@ msgstr "Mengubah warna latar belakang hasil hover, modul, dan menu dropdown"
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
+msgstr "Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3905,8 +3894,8 @@ msgstr ""
 "anonim dengan model chat AI pihak ketiga, yang mendukung model dari OpenAI, "
 "Anthropic, dan lainnya. Menonaktifkan pengaturan ini akan menyembunyikan "
 "tombol dan tautan Chat di DuckDuckGo Search. Namun, Anda masih dapat "
-"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi %1$shttps://"
-"duck.ai%2$s langsung."
+"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi "
+"%1$shttps://duck.ai%2$s langsung."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4154,8 +4143,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
+msgstr "Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4547,8 +4535,7 @@ msgstr "Klik %1$sDi sini%2$s untuk mengunduh ekstensi DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
+msgstr "Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4593,8 +4580,7 @@ msgstr "Klik %1$sYa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
+msgstr "Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -5331,7 +5317,7 @@ msgstr "Salin"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Salin"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5380,13 +5366,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Salin tautan yang dibagikan"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Salin kode dari perangkat lain"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5395,6 +5381,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Salin kode dari perangkat lain. Buka %1$sPengaturan Duck.ai › Obrolan › Sync "
+"& Backup › Sinkronkan dengan Perangkat Lain%2$s dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6083,7 +6071,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Hapus Tautan yang Dibagikan"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6104,6 +6092,9 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Menghapus tautan akan membuatnya berhenti berfungsi. Orang yang telah "
+"membukanya dan menambahkan percakapan ke obrolan mereka akan tetap menyimpan "
+"salinannya sendiri."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6365,7 +6356,7 @@ msgstr "Tutup"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Tutup"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6418,8 +6409,7 @@ msgstr "Bahasa Tampilan"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
+msgstr "Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6699,8 +6689,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"Buatlah beberapa opsi untuk postingan media sosial yang mengundang orang-"
-"orang ke pesta saya yang akan datang."
+"Buatlah beberapa opsi untuk postingan media sosial yang mengundang "
+"orang-orang ke pesta saya yang akan datang."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6872,8 +6862,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
+msgstr "Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6963,8 +6952,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
+msgstr "Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7013,8 +7001,7 @@ msgstr "Duck.ai ditingkatkan!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
+msgstr "Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7200,8 +7187,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
+msgstr "DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7234,7 +7220,7 @@ msgstr "Browser DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Halaman Bantuan DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7513,9 +7499,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi kata-"
-"kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 kata "
-"acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
+"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi "
+"kata-kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 "
+"kata acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
 "sepanjang 18—20 karakter."
 
 # smartling.placeholder_format=C
@@ -7738,8 +7724,7 @@ msgstr "Aktifkan Dikte dalam Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
+msgstr "Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8069,7 +8054,7 @@ msgstr "Produk yang dibuat secara ahli untuk orang yang peduli dengan privasi."
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Kedaluwarsa"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8083,7 +8068,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Berakhir %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8108,8 +8093,7 @@ msgstr "Jelaskan jawaban yang diterima dengan bahasa yang sederhana."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
+msgstr "Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8543,8 +8527,7 @@ msgstr "Temukan hasil yang lebih dekat dari lokasimu."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
+msgstr "Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8615,8 +8598,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
+msgstr "Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8841,8 +8823,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dari bilah menu aplikasi di Mac, pilih <strong>DuckDuckGo</strong> &gt; "
-"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal Pembaruan</"
-"strong>."
+"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal "
+"Pembaruan</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9281,8 +9263,7 @@ msgstr "Dapatkan bantuan komputer"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
-"Dapatkan batas penggunaan yang lebih tinggi dengan langganan DuckDuckGo."
+msgstr "Dapatkan batas penggunaan yang lebih tinggi dengan langganan DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9361,8 +9342,7 @@ msgstr "Dapatkan aplikasinya"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"Dapatkan Browser DuckDuckGo gratis %1$suntuk memblokir iklan di YouTube.%2$s"
+msgstr "Dapatkan Browser DuckDuckGo gratis %1$suntuk memblokir iklan di YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9466,6 +9446,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Buka %1$sPengaturan Duck.ai%2$s › %3$sObrolan › Sync & Backup › Sinkronkan "
+"dengan Perangkat Lain%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9581,7 +9563,7 @@ msgstr "Paham"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Oke"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10510,8 +10492,7 @@ msgstr "Saya tidak paham informasi ini"
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "I don’t want to see any information from DuckDuckGo on this page"
-msgstr ""
-"Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
+msgstr "Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -10550,8 +10531,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
+msgstr "Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10839,8 +10819,7 @@ msgstr "Di menu atas, pilih %1$sAlat%2$s > %3$sPengaturan%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
+msgstr "Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11332,8 +11311,7 @@ msgstr ""
 #. An instruction to state that a list of companies/trackers will be updated with continued use
 msgctxt "tracker_stats"
 msgid "Keep browsing to see how many we block"
-msgstr ""
-"Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
+msgstr "Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
 
 # smartling.placeholder_format=C
 #. Header above social media links.
@@ -11564,7 +11542,7 @@ msgstr "Pelajari %1$sSelengkapnya%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Pelajari Lebih Lanjut"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11740,8 +11718,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Memungkinkan beralih antara mengirimkan kueri pencarian dan perintah ke Duck."
-"ai"
+"Memungkinkan beralih antara mengirimkan kueri pencarian dan perintah ke "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12204,7 +12182,7 @@ msgstr "Mengelola"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Mengelola"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12461,7 +12439,7 @@ msgstr "Menu"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Pesan setelah titik ini hanya terlihat olehmu."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12835,7 +12813,7 @@ msgstr "Selengkapnya tentang Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Aksi lainnya"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13035,7 +13013,7 @@ msgstr "Merah redup"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Perangkat Saya"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13596,8 +13574,7 @@ msgstr "Hasil tidak ditemukan."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
+msgstr "Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14114,6 +14091,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Di perangkat lain, buka %1$sPengaturan Duck.ai%2$s › %3$sObrolan › Sync & "
+"Backup › Sinkronkan dengan Perangkat Lain%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14122,6 +14101,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Di perangkat lain, buka %1$sPengaturan Duck.ai%2$s › %3$sObrolan › Sync & "
+"Backup › Sinkronkan dengan Perangkat Lain%4$s dan pindai kode ini:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14130,6 +14111,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Di perangkat lain, buka %1$sPengaturan Duck.ai%2$s › %3$sObrolan › Sync & "
+"Backup › Sinkronkan dengan Perangkat Lain%4$s. Atau pindai QR pada PDF "
+"Pemulihan kamu."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14885,7 +14869,7 @@ msgstr "Setahun terakhir"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Tempel"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14903,7 +14887,7 @@ msgstr "Tempelkan kode Sinkron"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Tempelkan di bawah ini"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14962,7 +14946,7 @@ msgstr "Persia"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14971,6 +14955,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal menemukan info kamu di situs broker data yang "
+"menjualnya. Lalu kami berupaya menghapuskannya untuk kamu."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15243,15 +15229,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
+msgstr "Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
+msgstr "Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15509,8 +15493,7 @@ msgstr "Pemformatan yang buruk"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
-"Model AI populer tersedia. Tidak perlu akun. Obrolan dianonimkan oleh kami."
+msgstr "Model AI populer tersedia. Tidak perlu akun. Obrolan dianonimkan oleh kami."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15736,8 +15719,7 @@ msgstr "Harga"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr ""
-"Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
+msgstr "Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -16241,7 +16223,7 @@ msgstr "Sedang membaca situs web..."
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Siap untuk gerhana matahari?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16293,8 +16275,7 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Penalaran lebih menyeluruh, tetapi menggunakan batas 2-5x lebih cepat. %1$s"
+msgstr "Penalaran lebih menyeluruh, tetapi menggunakan batas 2-5x lebih cepat. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16442,7 +16423,7 @@ msgstr "Kode Pemulihan"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Kode Pemulihan"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16699,7 +16680,7 @@ msgstr "Hapus %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Hapus perangkat"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16747,13 +16728,13 @@ msgstr "Hapus tanda baca yang tidak perlu"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Hapus informasi kamu dari Internet"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Hapus infomu secara online"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17047,8 +17028,7 @@ msgstr "Hasil mengecualikan informasi dari situs yang diblokir."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
+msgstr "Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17382,8 +17362,7 @@ msgstr "Simpan dan Keluar"
 #. Description explaining that sync allows saving more chats than local browser storage.
 msgctxt "Sync feature benefit description"
 msgid "Save more chats than you can in your web browser."
-msgstr ""
-"Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
+msgstr "Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
 
 # smartling.placeholder_format=C
 #. List item explaining that users can save more chats when Sync & Backup is enabled.
@@ -17450,7 +17429,7 @@ msgstr "Sambutlah Duck.ai!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Sapa Duck.ai – obrolan AI gratis dan pribadi oleh DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17605,8 +17584,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
+msgstr "Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17829,8 +17807,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "Cari secara pribadi dengan aplikasi atau ekstensi kami, tambahkan pencarian "
-"web pribadi ke browser favoritmu, atau cari langsung di %1$sduckduckgo."
-"com%2$s."
+"web pribadi ke browser favoritmu, atau cari langsung di "
+"%1$sduckduckgo.com%2$s."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17995,8 +17973,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
+msgstr "Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18186,8 +18163,7 @@ msgstr "Pilih %1$sDuckDuckGo%2$s di menu dropdown Mesin Pencari Default"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
+msgstr "Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18306,8 +18282,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
+msgstr "Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18453,7 +18428,7 @@ msgstr "Serbia (Latin)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Data server telah dihapus"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18613,7 +18588,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Bagikan"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18770,13 +18745,13 @@ msgstr "Bagikan pemikiranmu tentang kotak pencarian."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Tautan Obrolan yang Dibagikan"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Tautan obrolan yang dibagikan"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19091,8 +19066,7 @@ msgstr "Tampilkan bilah samping"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Tunjukkan tips langkah demi langkah untuk memaksimalkan penggunaan Duck.ai."
+msgstr "Tunjukkan tips langkah demi langkah untuk memaksimalkan penggunaan Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19169,8 +19143,7 @@ msgstr "Menampilkan garis horizontal di pemisah halaman hasil"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
+msgstr "Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19186,21 +19159,18 @@ msgstr "Menampilkan tautan yang paling banyak dikunjungi di halaman tab baru"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
+msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
+msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
+msgstr "Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19238,8 +19208,7 @@ msgstr "Menampilkan pesan selamat datang di atas halaman hasil pencarian"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
+msgstr "Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19465,14 +19434,13 @@ msgstr "Terjadi sesuatu yang salah"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Terjadi kesalahan saat memuat obrolan yang dibagikan ini."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
+msgstr "Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -20075,8 +20043,7 @@ msgstr "Sarankan judul untuk postingan blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
+msgstr "Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20321,7 +20288,7 @@ msgstr "Model sakelar"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Model sakelar"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20379,8 +20346,7 @@ msgstr "Beralih ke model yang lebih efisien"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr ""
-"Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
+msgstr "Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
 
 # smartling.placeholder_format=C
 #. Re-activates a stacked second opinion, making it the current answer again.
@@ -20401,8 +20367,7 @@ msgstr "Beralih ke %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
+msgstr "Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20456,8 +20421,7 @@ msgstr "Sync & Backup Diaktifkan!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
+msgstr "Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20586,7 +20550,7 @@ msgstr "Perangkat Tersinkron"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Disinkronkan pada %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20624,7 +20588,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabel"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20872,8 +20836,7 @@ msgstr "Thailand (en)"
 #. Message displayed after the user has submitted feedback. It invites the user to share more feedback.
 msgctxt "Feedback toast"
 msgid "Thank you for your feedback. Have more to share?"
-msgstr ""
-"Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
+msgstr "Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
 
 # smartling.placeholder_format=C
 msgid "Thank you!"
@@ -20900,8 +20863,7 @@ msgstr "Terima kasih atas masukanmu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
+msgstr "Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
@@ -21003,8 +20965,7 @@ msgstr "Permintaan tersebut mengalami batas waktu. Silakan coba lagi."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
+msgstr "Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -21217,7 +21178,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Perangkat ini"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21228,6 +21189,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Perangkat ini tidak akan lagi dapat mengakses data yang disinkronkan di "
+"perangkat lain. %1$s obrolan terakhir akan tetap tersedia di penyimpanan "
+"lokal."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21298,16 +21262,14 @@ msgstr "Gambar ini tidak dapat dibuat."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
+msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
+msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21318,7 +21280,7 @@ msgstr "Informasi ini tidak berguna"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Ini adalah salinan obrolan yang dibagikan."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21438,13 +21400,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Obrolan yang dibagikan ini tidak dapat dibuka. Tautan mungkin tidak lengkap."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Tautan obrolan yang dibagikan ini sudah tidak tersedia lagi."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21473,8 +21435,7 @@ msgstr "Video ini belum bisa ditonton di sini. Kamu bisa menontonnya di %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
+msgstr "Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21629,8 +21590,7 @@ msgstr "Untuk melanjutkan, kamu harus menyetujui %1$s dan %2$sDuck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
+msgstr "Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21662,8 +21622,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser DuckDuckGo-"
-"mu ke versi terbaru dan coba lagi."
+"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser "
+"DuckDuckGo-mu ke versi terbaru dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21695,8 +21655,8 @@ msgstr "Hari Ini"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Beralih untuk mencoba obrolan AI pribadi atau %1$snonaktifkan di menu %2$s."
-"%3$s"
+"Beralih untuk mencoba obrolan AI pribadi atau %1$snonaktifkan di menu "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22095,7 +22055,7 @@ msgstr "Coba Gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Coba Gratis!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22218,7 +22178,7 @@ msgstr "Coba Gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Coba gratis!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22470,7 +22430,7 @@ msgstr "Turkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Matikan"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22488,7 +22448,7 @@ msgstr "Nonaktifkan Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Nonaktifkan Sync & Backup dan Hapus Data Server?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22783,8 +22743,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
+msgstr "Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22975,7 +22934,7 @@ msgstr "Membunyikan"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Obrolan tanpa judul"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23016,7 +22975,7 @@ msgstr "Perbarui Browser"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Perbarui Duck.ai untuk melihat obrolan yang dibagikan ini."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23188,8 +23147,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
+msgstr "Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -24003,6 +23961,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Kami menemukan dan menghapus info pribadi kamu dari situs broker data. Plus "
+"dapatkan VPN dan lainnya."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24057,6 +24017,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Kami secara rutin memindai situs broker data untuk mencari info pribadimu, "
+"dan kami membagikan kemajuan kami kepadamu di dasbor yang mudah digunakan."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24105,6 +24067,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Kami akan memindai situs broker data untuk mencari email, nama, alamat kamu, "
+"dan lainnya, serta berupaya menghapus apa pun yang kami temukan tentang kamu."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24375,8 +24339,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat Duck."
-"ai. Coba muat ulang halaman."
+"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat "
+"Duck.ai. Coba muat ulang halaman."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24398,8 +24362,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
+msgstr "Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -24429,7 +24392,7 @@ msgstr "Apa saja pro dan kontra dari anuitas?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Apa manfaat Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -25005,6 +24968,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Bekerja langsung dari perangkat kamu untuk menghapus email, nama, alamat "
+"kamu, dan lainnya dari situs pialang data."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25378,8 +25343,7 @@ msgstr "Kamu bisa menemukan file <b>%1$s</b> di folder unduhanmu."
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
 msgid "You can hide this reminder in %sSearch Settings%s"
-msgstr ""
-"Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
+msgstr "Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -25513,7 +25477,7 @@ msgstr "Kamu punya 1 upaya tersisa."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Kamu tidak memiliki tautan obrolan yang dibagikan."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25749,13 +25713,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"%1$s obrolan terbaru kamu akan tersedia di penyimpanan lokal pada browser "
+"ini:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Obrolan Duck.ai kamu sedang disinkronkan dengan enkripsi ujung ke ujung."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25787,6 +25753,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Cadangan kamu akan dihapus dari server DuckDuckGo. Hubungan semua perangkat "
+"akan terputus dari sinkronisasi."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26116,9 +26084,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami alih-"
-"alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah terinstal dan "
-"dapat:"
+"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami "
+"alih-alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah "
+"terinstal dan dapat:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.

--- a/locales/io_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/io_XX/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Augmentez ad %s"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Augmenti"
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4195,6 +4229,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4227,6 +4266,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4787,6 +4845,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4795,6 +4860,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5001,6 +5073,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5648,6 +5726,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6310,9 +6394,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7405,6 +7502,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7489,6 +7593,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9075,6 +9184,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9592,6 +9706,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9797,6 +9917,11 @@ msgstr "Menuo"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10099,6 +10224,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Plu multa ye"
@@ -10255,6 +10385,11 @@ msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
+msgstr ""
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
 msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -11133,6 +11268,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11737,6 +11893,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11745,6 +11906,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11789,6 +11955,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12803,6 +12981,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12952,6 +13135,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13159,6 +13347,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13192,6 +13385,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13740,6 +13943,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14504,6 +14712,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14628,6 +14842,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14747,6 +14968,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15294,6 +15525,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15983,6 +16219,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16180,6 +16421,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16205,6 +16452,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Televiziono"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16657,6 +16909,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16725,6 +16991,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16808,6 +17079,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17322,6 +17603,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17414,6 +17700,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17613,6 +17904,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17621,6 +17917,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -17998,6 +18299,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18025,6 +18331,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18791,6 +19102,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18825,6 +19143,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18849,6 +19174,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19093,6 +19425,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19555,6 +19892,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19957,6 +20301,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20123,6 +20473,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20140,6 +20505,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/is_IS/LC_MESSAGES/duckduckgo.po
+++ b/locales/is_IS/LC_MESSAGES/duckduckgo.po
@@ -43,6 +43,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -393,6 +400,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -627,6 +640,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1180,6 +1198,11 @@ msgstr "Bæta við %s"
 msgid "Add to Home Screen"
 msgstr "Bæta við upphafssíðu"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Viðbætur"
@@ -1470,6 +1493,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1882,6 +1911,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4198,6 +4232,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4230,6 +4269,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4790,6 +4848,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4798,6 +4863,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5004,6 +5076,12 @@ msgstr "Hunsa"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5651,6 +5729,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6314,9 +6398,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7407,6 +7504,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7491,6 +7595,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9077,6 +9186,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Fræðast %smeira%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9594,6 +9708,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9800,6 +9920,11 @@ msgstr "Valmynd"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Matseðill"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10101,6 +10226,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Meira á"
@@ -10258,6 +10388,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Dökkrautt"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11135,6 +11270,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11743,6 +11899,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11751,6 +11912,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11795,6 +11961,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12809,6 +12987,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12958,6 +13141,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13165,6 +13353,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13198,6 +13391,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13746,6 +13949,11 @@ msgstr "Vista stillingar þínar nafnlaust í skýið"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14510,6 +14718,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14634,6 +14848,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14754,6 +14975,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15301,6 +15532,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15993,6 +16229,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16190,6 +16431,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16215,6 +16462,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Þættir"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16671,6 +16923,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16739,6 +17005,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16822,6 +17093,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17338,6 +17619,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17430,6 +17716,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17629,6 +17920,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17637,6 +17933,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18014,6 +18315,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18041,6 +18347,11 @@ msgstr "Uppfæra"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18810,6 +19121,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18844,6 +19162,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18868,6 +19193,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19112,6 +19444,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19574,6 +19911,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19974,6 +20318,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20140,6 +20490,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20157,6 +20522,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Questo dispositivo)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -503,7 +503,7 @@ msgstr "%1$sScopri come manteniamo privata la tua posizione%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sUlteriori informazioni%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -526,8 +526,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
+msgstr "%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -802,7 +801,7 @@ msgstr "2° nel gruppo %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2° opinione"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -886,8 +885,7 @@ msgstr "Limite di utilizzo di 6 ore raggiunto."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr "Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1016,8 +1014,8 @@ msgstr ""
 "AI Chat consente di conversare in modo anonimo con modelli di chat di terze "
 "parti dotati di intelligenza artificiale. Disattivando questa funzione, AI "
 "Chat verrà nascosta su DuckDuckGo Search. È comunque possibile accedervi "
-"anche quando questa impostazione è disattivata visitando %1$sduckduckgo.com/"
-"aichat%2$s."
+"anche quando questa impostazione è disattivata visitando "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1088,8 +1086,7 @@ msgstr ""
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
 msgctxt "duckassist"
 msgid "AI-assisted answers have been turned off!"
-msgstr ""
-"Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
+msgstr "Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
 
 # smartling.placeholder_format=C
 #. Negative feedback suggestion for when user dislikes AI-generated content
@@ -1437,8 +1434,7 @@ msgstr "Aggiungi una casella di ricerca di %1$s al tuo sito!"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr ""
-"Aggiungi un punto di partenza e una destinazione per trovare un percorso."
+msgstr "Aggiungi un punto di partenza e una destinazione per trovare un percorso."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1500,7 +1496,7 @@ msgstr "Aggiungi alla Schermata Home"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Aggiungi alle mie chat"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1872,7 +1868,7 @@ msgstr "Tutti i tipi"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Tutti i dispositivi sono disconnessi da Sync."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1909,8 +1905,7 @@ msgstr "Vuoi consentire la revisione anonima dei file per questa chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
+msgstr "Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2404,7 +2399,7 @@ msgstr "Chiedi qualsiasi cosa in privato"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Chiedi qualsiasi cosa in privato"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2580,15 +2575,13 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2893,8 +2886,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Prima di archiviare questo rapporto, DuckDuckGo renderà anonima la tua "
-"conversazione eliminando le informazioni personali, come nomi, indirizzi e-"
-"mail e metadati identificativi."
+"conversazione eliminando le informazioni personali, come nomi, indirizzi "
+"e-mail e metadati identificativi."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3030,14 +3023,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
+msgstr "L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block most trackers as you browse."
-msgstr ""
-"Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
+msgstr "Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
 
 # smartling.placeholder_format=C
 #. Menu option to block a site from the displayed results
@@ -4682,8 +4673,7 @@ msgstr "Clicca sulla %1$slente di ingrandimento%2$s nella barra di ricerca"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr ""
-"Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
+msgstr "Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4736,21 +4726,18 @@ msgstr "Clicca sui %1$spuntini di sospensione%2$s nella barra degli strumenti."
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr ""
-"Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
+msgstr "Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %spermissions icon%s in the address bar"
-msgstr ""
-"Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
+msgstr "Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
+msgstr "Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5371,7 +5358,7 @@ msgstr "Copia"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Copia"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5382,8 +5369,7 @@ msgstr "Copia"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
+msgstr "Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5421,13 +5407,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Copia link condiviso"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Copia il codice da un altro dispositivo"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5436,6 +5422,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Copia il codice da un altro dispositivo. Vai su %1$sImpostazioni di Duck.ai "
+"› Chat › Sync & Backup › Sincronizza con un altro dispositivo%2$s e riprova."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5487,8 +5475,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
+msgstr "Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6125,7 +6112,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Elimina link condiviso"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6146,6 +6133,9 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"L'eliminazione di un link ne impedisce il funzionamento. Le persone che lo "
+"hanno aperto e hanno aggiunto la conversazione alle proprie chat manterranno "
+"la propria copia."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6407,7 +6397,7 @@ msgstr "Chiudi"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Chiudi"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6956,8 +6946,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai non è al momento disponibile. Se il problema persiste, invia un'e-"
-"mail con il codice anonimo %1$s a %2$s"
+"Duck.ai non è al momento disponibile. Se il problema persiste, invia "
+"un'e-mail con il codice anonimo %1$s a %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7050,8 +7040,7 @@ msgstr "Duck.ai è stato aggiornato!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
+msgstr "Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7273,7 +7262,7 @@ msgstr "Browser DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Pagine della guida DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7900,8 +7889,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
+msgstr "Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7953,15 +7941,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
+msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
+msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8126,7 +8112,7 @@ msgstr ""
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Scaduto"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8140,7 +8126,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Scade il %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8245,8 +8231,7 @@ msgstr "Esplora Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
+msgstr "Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8816,8 +8801,7 @@ msgstr "Condivisione e uso commerciale gratuiti"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
+msgstr "Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9254,8 +9238,7 @@ msgstr "Iniziamo"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
+msgstr "Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9524,6 +9507,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Vai su %1$sImpostazioni Duck.ai%2$s › %3$sChat › Sync & Backup › Sincronizza "
+"con un altro dispositivo%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9640,7 +9625,7 @@ msgstr "Fatto"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Fatto"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9806,8 +9791,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
+msgstr "Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10202,8 +10186,7 @@ msgstr "Nascondi il tuo indirizzo e-mail"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
+msgstr "Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10447,8 +10430,7 @@ msgstr "Come funziona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
+msgstr "Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10698,8 +10680,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
+msgstr "Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10902,8 +10883,7 @@ msgstr "Nel menu in alto seleziona %1$sStrumenti%2$s > %3$sImpostazioni%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
+msgstr "Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11626,7 +11606,7 @@ msgstr "Maggiori %1$sInformazioni%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Ulteriori informazioni"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11895,8 +11875,7 @@ msgstr "Link:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
+msgstr "Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12007,8 +11986,7 @@ msgstr "Carica altre immagini durante lo scorrimento"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
+msgstr "Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12268,7 +12246,7 @@ msgstr "Gestisci"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Gestisci"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12525,7 +12503,7 @@ msgstr "Menu"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "I messaggi da questo punto in poi sono visibili solo a te."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12790,8 +12768,7 @@ msgstr "Limite mensile raggiunto"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr "Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12902,7 +12879,7 @@ msgstr "Maggiori informazioni su Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Altre azioni"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13102,7 +13079,7 @@ msgstr "Rosso tenue"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "I miei dispositivi"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13688,15 +13665,13 @@ msgstr "Nessun sistema di tracciamento bloccato nell'ultima ora"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr ""
-"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
+msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
+msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -14183,6 +14158,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Su un altro dispositivo, vai su %1$sImpostazioni Duck.ai%2$s › %3$sChat › "
+"Sync & Backup › Sincronizza con un altro dispositivo%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14191,6 +14168,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Su un altro dispositivo, vai su %1$sImpostazioni Duck.ai%2$s › %3$sChat › "
+"Sync & Backup › Sincronizza con un altro dispositivo%4$s e scansiona questo "
+"codice:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14199,6 +14179,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Su un altro dispositivo, vai su %1$sImpostazioni Duck.ai%2$s › %3$sChat › "
+"Sync & Backup › Sincronizza con un altro dispositivo%4$s. Oppure scansiona "
+"il codice QR presente sul tuo PDF di recupero."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14958,7 +14941,7 @@ msgstr "Ultimo anno"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Incolla"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14976,7 +14959,7 @@ msgstr "Incolla codice di sincronizzazione"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Incollalo qui sotto"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -15035,7 +15018,7 @@ msgstr "Persiano"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -15044,6 +15027,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal trova le tue informazioni sui siti di data "
+"broker che le vendono. Poi lavoriamo per farle rimuovere per te."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15317,15 +15302,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
+msgstr "Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
+msgstr "Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -16114,8 +16097,7 @@ msgstr "Proteggi i tuoi dati durante le ricerche e la navigazione."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
+msgstr "Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16316,7 +16298,7 @@ msgstr "Lettura del sito web…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Pronti per l'eclissi solare?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16403,8 +16385,7 @@ msgstr "Schede recenti"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr ""
-"Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
+msgstr "Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
 
 # smartling.placeholder_format=C
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
@@ -16517,7 +16498,7 @@ msgstr "Codice di recupero"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Codice di recupero"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16727,8 +16708,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante &quot;"
-"Aggiorna&quot; o &quot;Ricarica&quot; del browser."
+"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante "
+"&quot;Aggiorna&quot; o &quot;Ricarica&quot; del browser."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16745,8 +16726,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr ""
-"Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
+msgstr "Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -16777,7 +16757,7 @@ msgstr "Rimuovi %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Rimuovi dispositivo"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16825,13 +16805,13 @@ msgstr "Rimuovi la punteggiatura superflua"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Rimuovi le tue informazioni da Internet"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Rimuovi le tue info online"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17494,8 +17474,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia end-to-"
-"end."
+"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17531,7 +17511,7 @@ msgstr "Saluta Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Ecco Duck.ai – la chat AI gratuita e privata di DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -18031,8 +18011,7 @@ msgstr "Seconda opinione"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
+msgstr "Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18082,8 +18061,8 @@ msgstr ""
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
-"end."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18092,8 +18071,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
-"end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
+"end-to-end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18248,27 +18227,24 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Scegli %1$sPersonalizzata%2$s e digita nel campo %3$shttps://duckduckgo."
-"com%4$s"
+"Scegli %1$sPersonalizzata%2$s e digita nel campo "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18383,8 +18359,7 @@ msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sImpostazioni avanzate%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
+msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18480,8 +18455,7 @@ msgstr "Testo selezionato da %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
+msgstr "Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18554,7 +18528,7 @@ msgstr "Serbo (Alfabeto latino)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Dati del server eliminati"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18716,7 +18690,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Condividi"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18873,13 +18847,13 @@ msgstr "Comunica la tua opinione sulla barra di ricerca."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Link delle chat condivise"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Link di chat condivisi"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19267,14 +19241,12 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows horizontal lines at result page breaks"
-msgstr ""
-"Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
+msgstr "Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
+msgstr "Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19295,8 +19267,7 @@ msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo al tuo browser"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
+msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19425,8 +19396,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
+msgstr "I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19573,7 +19543,7 @@ msgstr "Si è verificato un errore"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Si è verificato un errore durante il caricamento di questa chat condivisa."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19585,8 +19555,7 @@ msgstr "Qualcosa è andato storto durante il salvataggio nel server, riprova."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
+msgstr "Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19616,8 +19585,7 @@ msgstr "A volte"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
+msgstr "Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19693,8 +19661,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
+msgstr "Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20007,8 +19974,7 @@ msgstr "Interrompi la generazione"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
+msgstr "Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20433,7 +20399,7 @@ msgstr "Cambia modello"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Cambia modello"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20491,8 +20457,7 @@ msgstr "Passa a un modello più efficiente"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr ""
-"Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
+msgstr "Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
 
 # smartling.placeholder_format=C
 #. Re-activates a stacked second opinion, making it the current answer again.
@@ -20513,8 +20478,7 @@ msgstr "Passato a %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
+msgstr "Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20630,8 +20594,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Come funziona il codice?\n"
-"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di Duck."
-"ai.\n"
+"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di "
+"Duck.ai.\n"
 "2. Seleziona \"Attiva Sync & Backup\", poi \"Recupera dati sincronizzati\"\n"
 "3. Copia il codice di recupero sopra e incollalo nello spazio \"Incolla qui "
 "il tuo codice\"\n"
@@ -20699,7 +20663,7 @@ msgstr "Dispositivi sincronizzati"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Sincronizzato il %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20737,7 +20701,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabella"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -21335,7 +21299,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Questo dispositivo"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21346,6 +21310,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Questo dispositivo non potrà più accedere ai tuoi dati sincronizzati su "
+"altri dispositivi. Le ultime %1$s chat rimarranno ancora disponibili in "
+"archiviazione locale."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21416,8 +21383,7 @@ msgstr "Questa immagine non può essere creata."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
+msgstr "Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21437,7 +21403,7 @@ msgstr "Questa informazione non è utile"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Questa è una copia di una chat condivisa."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21507,8 +21473,7 @@ msgstr "Questa pagina richiede Javascript per funzionare."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
+msgstr "Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21560,13 +21525,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Impossibile aprire questa chat condivisa. Il link potrebbe essere incompleto."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Questo link di chat condivisa non è più disponibile."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21819,8 +21784,8 @@ msgstr "Oggi"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Attiva per provare la chat AI privata oppure %1$sdisabilitala nel menu %2$s."
-"%3$s"
+"Attiva per provare la chat AI privata oppure %1$sdisabilitala nel menu "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21985,8 +21950,7 @@ msgstr "Sistemi di tracciamento bloccati nell'ultima ora"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
+msgstr "I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22002,8 +21966,7 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr ""
-"I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
+msgstr "I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -22221,7 +22184,7 @@ msgstr "Prova gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Prova gratis!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22318,8 +22281,7 @@ msgstr "Prova ad abilitare la posizione anonima per risultati più accurati."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
+msgstr "Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22343,7 +22305,7 @@ msgstr "Provala gratuitamente"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Prova gratuitamente!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22596,7 +22558,7 @@ msgstr "Turkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Disattiva"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22614,7 +22576,7 @@ msgstr "Disattiva Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Disattivare Sync & Backup ed eliminare i dati del server?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22896,8 +22858,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: https://"
-"duckduckgo.com"
+"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22926,8 +22888,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di ricerca..."
-"%4$s"
+"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di "
+"ricerca...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22941,8 +22903,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
+msgstr "In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23103,7 +23064,7 @@ msgstr "Riattiva audio"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Chat senza titolo"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23144,7 +23105,7 @@ msgstr "Aggiorna browser"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Aggiorna Duck.ai per visualizzare questa chat condivisa."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23623,8 +23584,7 @@ msgstr "Visualizza i prezzi per il tuo soggiorno"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
+msgstr "La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -24028,8 +23988,7 @@ msgstr "Non memorizziamo nomi utente né informazioni personali."
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
+msgstr "Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24134,6 +24093,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Troviamo e rimuoviamo le tue informazioni personali dai siti di data broker. "
+"In più, ottieni una VPN e altro."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24188,13 +24149,15 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Scansioniamo regolarmente i siti di data broker alla ricerca delle tue "
+"informazioni personali e condividiamo con te i nostri progressi in una "
+"dashboard facile da usare."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
+msgstr "Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24233,6 +24196,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Scansioneremo i siti di data broker alla ricerca della tua e-mail, del tuo "
+"nome, del tuo indirizzo e altro ancora, e lavoreremo per far rimuovere tutto "
+"ciò che troviamo su di te."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24435,8 +24401,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
+msgstr "Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24559,7 +24524,7 @@ msgstr "Quali sono i pro e i contro delle rendite?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Quali sono i vantaggi di Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24662,8 +24627,7 @@ msgstr "Quali sono i piatti da provare in questo caso?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
+msgstr "Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24890,8 +24854,7 @@ msgstr "Su cosa vuoi dare un'opinione?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
+msgstr "Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25139,6 +25102,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Opera direttamente dal tuo dispositivo per rimuovere la tua e-mail, il tuo "
+"nome, il tuo indirizzo e altre informazioni dai siti dei broker di dati."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25479,8 +25444,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
+msgstr "Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25645,7 +25609,7 @@ msgstr "Hai ancora 1 tentativo."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Non hai link di chat condivisi."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25707,8 +25671,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Non vedrai più questo messaggio a meno che non elimini i dati del browser."
+msgstr "Non vedrai più questo messaggio a meno che non elimini i dati del browser."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25805,8 +25768,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Hai raggiunto la durata massima della chat vocale per una singola sessione."
+msgstr "Hai raggiunto la durata massima della chat vocale per una singola sessione."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -25818,8 +25780,7 @@ msgstr "Hai raggiunto il limite di chat vocale per oggi. Riprova domani."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
+msgstr "Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25880,6 +25841,8 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Le tue %1$s chat più recenti saranno disponibili in archiviazione locale su "
+"questi browser:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -25887,6 +25850,8 @@ msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
 msgstr ""
+"Le tue chat di Duck.ai sono in fase di sincronizzazione con crittografia "
+"end-to-end."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25918,6 +25883,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Il tuo backup sarà eliminato dal server di DuckDuckGo. Tutti i dispositivi "
+"saranno disconnessi dalla sincronizzazione."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26256,8 +26223,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
+msgstr "Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26291,8 +26257,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
+msgstr "Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26381,8 +26346,7 @@ msgstr "di %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
+msgstr "di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% completamente vaccinati"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% vaccinati"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -491,6 +499,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sScopri come manteniamo privata la tua posizione%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -511,7 +526,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
+msgstr ""
+"%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -783,6 +799,12 @@ msgid "2nd in Group %s"
 msgstr "2° nel gruppo %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -864,7 +886,8 @@ msgstr "Limite di utilizzo di 6 ore raggiunto."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr ""
+"Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -993,8 +1016,8 @@ msgstr ""
 "AI Chat consente di conversare in modo anonimo con modelli di chat di terze "
 "parti dotati di intelligenza artificiale. Disattivando questa funzione, AI "
 "Chat verrà nascosta su DuckDuckGo Search. È comunque possibile accedervi "
-"anche quando questa impostazione è disattivata visitando "
-"%1$sduckduckgo.com/aichat%2$s."
+"anche quando questa impostazione è disattivata visitando %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1065,7 +1088,8 @@ msgstr ""
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
 msgctxt "duckassist"
 msgid "AI-assisted answers have been turned off!"
-msgstr "Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
+msgstr ""
+"Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
 
 # smartling.placeholder_format=C
 #. Negative feedback suggestion for when user dislikes AI-generated content
@@ -1413,7 +1437,8 @@ msgstr "Aggiungi una casella di ricerca di %1$s al tuo sito!"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr "Aggiungi un punto di partenza e una destinazione per trovare un percorso."
+msgstr ""
+"Aggiungi un punto di partenza e una destinazione per trovare un percorso."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1470,6 +1495,12 @@ msgstr "Aggiungi a %1$s"
 #. Button that creates a shortcut to the current page on the home screen of the user's phone.
 msgid "Add to Home Screen"
 msgstr "Aggiungi alla Schermata Home"
+
+# smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1837,6 +1868,13 @@ msgid "All types"
 msgstr "Tutti i tipi"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1871,7 +1909,8 @@ msgstr "Vuoi consentire la revisione anonima dei file per questa chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
+msgstr ""
+"Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2362,6 +2401,12 @@ msgid "Ask anything privately"
 msgstr "Chiedi qualsiasi cosa in privato"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2535,13 +2580,15 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr ""
+"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr ""
+"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2846,8 +2893,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Prima di archiviare questo rapporto, DuckDuckGo renderà anonima la tua "
-"conversazione eliminando le informazioni personali, come nomi, indirizzi "
-"e-mail e metadati identificativi."
+"conversazione eliminando le informazioni personali, come nomi, indirizzi e-"
+"mail e metadati identificativi."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2983,12 +3030,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
+msgstr ""
+"L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block most trackers as you browse."
-msgstr "Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
+msgstr ""
+"Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
 
 # smartling.placeholder_format=C
 #. Menu option to block a site from the displayed results
@@ -4633,7 +4682,8 @@ msgstr "Clicca sulla %1$slente di ingrandimento%2$s nella barra di ricerca"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr "Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
+msgstr ""
+"Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4686,18 +4736,21 @@ msgstr "Clicca sui %1$spuntini di sospensione%2$s nella barra degli strumenti."
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr "Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
+msgstr ""
+"Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %spermissions icon%s in the address bar"
-msgstr "Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
+msgstr ""
+"Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
+msgstr ""
+"Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5315,6 +5368,12 @@ msgid "Copy"
 msgstr "Copia"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5323,7 +5382,8 @@ msgstr "Copia"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
+msgstr ""
+"Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5354,6 +5414,28 @@ msgstr "Copia o salva questo codice"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Copia il codice di recupero"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5405,7 +5487,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
+msgstr ""
+"Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6037,6 +6120,14 @@ msgid "Delete recent chats?"
 msgstr "Eliminare le chat recenti?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6047,6 +6138,14 @@ msgstr "Eliminare questa chat?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Chat eliminate"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6302,6 +6401,13 @@ msgstr "Chiudi"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Chiudi"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6850,8 +6956,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai non è al momento disponibile. Se il problema persiste, invia "
-"un'e-mail con il codice anonimo %1$s a %2$s"
+"Duck.ai non è al momento disponibile. Se il problema persiste, invia un'e-"
+"mail con il codice anonimo %1$s a %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6944,7 +7050,8 @@ msgstr "Duck.ai è stato aggiornato!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
+msgstr ""
+"Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7160,6 +7267,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Browser DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7786,7 +7900,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
+msgstr ""
+"Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7838,13 +7953,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
+msgstr ""
+"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
+msgstr ""
+"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8005,10 +8122,25 @@ msgstr ""
 "privacy."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Scaduto"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8113,7 +8245,8 @@ msgstr "Esplora Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
+msgstr ""
+"Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8683,7 +8816,8 @@ msgstr "Condivisione e uso commerciale gratuiti"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
+msgstr ""
+"Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9120,7 +9254,8 @@ msgstr "Iniziamo"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
+msgstr ""
+"Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9383,6 +9518,14 @@ msgstr ""
 "recupero."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -9492,6 +9635,12 @@ msgstr "Fatto"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Fatto"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9657,7 +9806,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
+msgstr ""
+"Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10052,7 +10202,8 @@ msgstr "Nascondi il tuo indirizzo e-mail"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
+msgstr ""
+"Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10296,7 +10447,8 @@ msgstr "Come funziona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
+msgstr ""
+"Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10546,7 +10698,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
+msgstr ""
+"Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10749,7 +10902,8 @@ msgstr "Nel menu in alto seleziona %1$sStrumenti%2$s > %3$sImpostazioni%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
+msgstr ""
+"Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11469,6 +11623,12 @@ msgid "Learn %sMore%s"
 msgstr "Maggiori %1$sInformazioni%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11735,7 +11895,8 @@ msgstr "Link:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
+msgstr ""
+"Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11846,7 +12007,8 @@ msgstr "Carica altre immagini durante lo scorrimento"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
+msgstr ""
+"Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12102,6 +12264,13 @@ msgid "Manage"
 msgstr "Gestisci"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12351,6 +12520,12 @@ msgstr "Menu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12615,7 +12790,8 @@ msgstr "Limite mensile raggiunto"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr ""
+"Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12721,6 +12897,12 @@ msgstr "Altre informazioni sui !bang"
 msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr "Maggiori informazioni su Duck.ai"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12915,6 +13097,12 @@ msgstr "Disattivato"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rosso tenue"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13500,13 +13688,15 @@ msgstr "Nessun sistema di tracciamento bloccato nell'ultima ora"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
+msgstr ""
+"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
+msgstr ""
+"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -13985,6 +14175,30 @@ msgid ""
 msgstr ""
 "Su Mac, %1$sClicca su Maxthon > Preferenze%2$s, su Windows %3$sClicca "
 "sull'icona%4$s > Impostazioni%5$s"
+
+# smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14741,6 +14955,12 @@ msgid "Past year"
 msgstr "Ultimo anno"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14751,6 +14971,12 @@ msgstr "Incolla"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Incolla codice di sincronizzazione"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14804,6 +15030,20 @@ msgstr "Chiuso definitivamente"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persiano"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15077,13 +15317,15 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
+msgstr ""
+"Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
+msgstr ""
+"Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15872,7 +16114,8 @@ msgstr "Proteggi i tuoi dati durante le ricerche e la navigazione."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
+msgstr ""
+"Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16070,6 +16313,12 @@ msgid "Reading website…"
 msgstr "Lettura del sito web…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16154,7 +16403,8 @@ msgstr "Schede recenti"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr "Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
+msgstr ""
+"Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
 
 # smartling.placeholder_format=C
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
@@ -16262,6 +16512,12 @@ msgstr "Recupero"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Codice di recupero"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16471,8 +16727,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante "
-"&quot;Aggiorna&quot; o &quot;Ricarica&quot; del browser."
+"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante &quot;"
+"Aggiorna&quot; o &quot;Ricarica&quot; del browser."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16489,7 +16745,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr "Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
+msgstr ""
+"Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -16515,6 +16772,12 @@ msgstr "Rimuovi %1$s"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "Rimuovi %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16557,6 +16820,18 @@ msgstr "Rimuovi selezione del testo"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Rimuovi la punteggiatura superflua"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17219,8 +17494,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia "
-"end-to-end."
+"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia end-to-"
+"end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17251,6 +17526,12 @@ msgstr "Salva anonimamente le tue impostazioni nel cloud"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Saluta Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17750,7 +18031,8 @@ msgstr "Seconda opinione"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
+msgstr ""
+"Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17800,8 +18082,8 @@ msgstr ""
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
-"end-to-end."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
+"end."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17810,8 +18092,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
-"end-to-end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
+"end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -17966,24 +18248,27 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Scegli %1$sPersonalizzata%2$s e digita nel campo "
-"%3$shttps://duckduckgo.com%4$s"
+"Scegli %1$sPersonalizzata%2$s e digita nel campo %3$shttps://duckduckgo."
+"com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
+msgstr ""
+"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
+msgstr ""
+"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
+msgstr ""
+"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18098,7 +18383,8 @@ msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sImpostazioni avanzate%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
+msgstr ""
+"Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18194,7 +18480,8 @@ msgstr "Testo selezionato da %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
+msgstr ""
+"Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18261,6 +18548,13 @@ msgstr "Serbo (Cirillico)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Serbo (Alfabeto latino)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18417,6 +18711,14 @@ msgid "Share"
 msgstr "Condividi"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18566,6 +18868,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Comunica la tua opinione sulla barra di ricerca."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18953,12 +19267,14 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows horizontal lines at result page breaks"
-msgstr "Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
+msgstr ""
+"Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
+msgstr ""
+"Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18979,7 +19295,8 @@ msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo al tuo browser"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
+msgstr ""
+"Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19108,7 +19425,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
+msgstr ""
+"I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19252,6 +19570,12 @@ msgid "Something went wrong"
 msgstr "Si è verificato un errore"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19261,7 +19585,8 @@ msgstr "Qualcosa è andato storto durante il salvataggio nel server, riprova."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
+msgstr ""
+"Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19291,7 +19616,8 @@ msgstr "A volte"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
+msgstr ""
+"Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19367,7 +19693,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
+msgstr ""
+"Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19680,7 +20007,8 @@ msgstr "Interrompi la generazione"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
+msgstr ""
+"Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20102,6 +20430,12 @@ msgid "Switch model"
 msgstr "Cambia modello"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20157,7 +20491,8 @@ msgstr "Passa a un modello più efficiente"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr "Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
+msgstr ""
+"Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
 
 # smartling.placeholder_format=C
 #. Re-activates a stacked second opinion, making it the current answer again.
@@ -20178,7 +20513,8 @@ msgstr "Passato a %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
+msgstr ""
+"Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20294,8 +20630,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Come funziona il codice?\n"
-"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di "
-"Duck.ai.\n"
+"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di Duck."
+"ai.\n"
 "2. Seleziona \"Attiva Sync & Backup\", poi \"Recupera dati sincronizzati\"\n"
 "3. Copia il codice di recupero sopra e incollalo nello spazio \"Incolla qui "
 "il tuo codice\"\n"
@@ -20359,6 +20695,13 @@ msgid "Synced Devices"
 msgstr "Dispositivi sincronizzati"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Siria"
 
@@ -20389,6 +20732,12 @@ msgstr "Da stabilire"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20983,6 +21332,22 @@ msgstr ""
 "o offensive (per maggiori informazioni vedi %4$s)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -21051,7 +21416,8 @@ msgstr "Questa immagine non può essere creata."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
+msgstr ""
+"Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21066,6 +21432,12 @@ msgstr ""
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Questa informazione non è utile"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21135,7 +21507,8 @@ msgstr "Questa pagina richiede Javascript per funzionare."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
+msgstr ""
+"Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21182,6 +21555,18 @@ msgstr ""
 "cancelli i dati del browser di duckduckgo.com, potresti vedere di nuovo le "
 "risposte assistite dall'IA. Tuttavia, abbiamo anche una pagina iniziale che "
 "non mostra mai risposte assistite dall'IA all'indirizzo %1$s."
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21434,8 +21819,8 @@ msgstr "Oggi"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Attiva per provare la chat AI privata oppure %1$sdisabilitala nel menu "
-"%2$s.%3$s"
+"Attiva per provare la chat AI privata oppure %1$sdisabilitala nel menu %2$s."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21600,7 +21985,8 @@ msgstr "Sistemi di tracciamento bloccati nell'ultima ora"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr "I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
+msgstr ""
+"I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21616,7 +22002,8 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr "I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
+msgstr ""
+"I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -21831,6 +22218,12 @@ msgid "Try Free"
 msgstr "Prova gratis"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21925,7 +22318,8 @@ msgstr "Prova ad abilitare la posizione anonima per risultati più accurati."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
+msgstr ""
+"Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21944,6 +22338,12 @@ msgstr "Provala gratuitamente"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Provala gratuitamente"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22193,6 +22593,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22203,6 +22609,12 @@ msgstr "Disattiva Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Disattiva Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22484,8 +22896,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: "
-"https://duckduckgo.com"
+"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22514,8 +22926,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di "
-"ricerca...%4$s"
+"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di ricerca..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22529,7 +22941,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
+msgstr ""
+"In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22687,6 +23100,12 @@ msgid "Unmute"
 msgstr "Riattiva audio"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22720,6 +23139,12 @@ msgstr "Aggiorna"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Aggiorna browser"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23198,7 +23623,8 @@ msgstr "Visualizza i prezzi per il tuo soggiorno"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
+msgstr ""
+"La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23602,7 +24028,8 @@ msgstr "Non memorizziamo nomi utente né informazioni personali."
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
+msgstr ""
+"Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23701,6 +24128,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Abbiamo interrotto la chat per inattività. Riprovare?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23747,10 +24182,19 @@ msgstr ""
 "vicini a te. Puoi sempre cambiare idea in seguito."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
+msgstr ""
+"Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23781,6 +24225,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Bloccheremo i sistemi di tracciamento che cercano di acquisire i tuoi dati "
 "durante la navigazione."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23983,7 +24435,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
+msgstr ""
+"Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24103,6 +24556,12 @@ msgid "What are some pros and cons of annuities?"
 msgstr "Quali sono i pro e i contro delle rendite?"
 
 # smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
 msgctxt "User prompt seeded by Learn More CTA"
 msgid ""
@@ -24203,7 +24662,8 @@ msgstr "Quali sono i piatti da provare in questo caso?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
+msgstr ""
+"Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24430,7 +24890,8 @@ msgstr "Su cosa vuoi dare un'opinione?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
+msgstr ""
+"Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24670,6 +25131,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Senza visibilità zero lato provider"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25010,7 +25479,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
+msgstr ""
+"Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25171,6 +25641,13 @@ msgid "You have 1 attempt left."
 msgstr "Hai ancora 1 tentativo."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25230,7 +25707,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Non vedrai più questo messaggio a meno che non elimini i dati del browser."
+msgstr ""
+"Non vedrai più questo messaggio a meno che non elimini i dati del browser."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25327,7 +25805,8 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Hai raggiunto la durata massima della chat vocale per una singola sessione."
+msgstr ""
+"Hai raggiunto la durata massima della chat vocale per una singola sessione."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -25339,7 +25818,8 @@ msgstr "Hai raggiunto il limite di chat vocale per oggi. Riprova domani."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
+msgstr ""
+"Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25392,6 +25872,23 @@ msgid "YouTube Standard"
 msgstr "Standard YouTube"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "La cronologia delle tue ricerche su DuckDuckGo è privata"
@@ -25413,6 +25910,14 @@ msgstr "La tua attuale posizione rimane privata"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "La tua posizione attuale rimane privata."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25751,7 +26256,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
+msgstr ""
+"Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25785,7 +26291,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
+msgstr ""
+"Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25874,7 +26381,8 @@ msgstr "di %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
+msgstr ""
+"di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ja_JP\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s（このデバイス）"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -189,10 +189,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
-"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
-"てください。"
+msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -201,10 +198,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
-"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
-"てください。"
+msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -219,10 +213,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるに"
-"は、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替え"
-"てください。"
+msgstr "%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるには、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -230,9 +221,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直し"
-"てください。"
+msgstr "%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -329,9 +318,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$sはTrusted Execution Environmentで動作します。つまり、モデルプロバイダーで"
-"さえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサー"
-"バーに保存することもできません。"
+"%1$sはTrusted Execution "
+"Environmentで動作します。つまり、モデルプロバイダーでさえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサーバーに保存することもできません。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -416,9 +404,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替え"
-"てこのチャットを続けることができます。"
+msgstr "%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -428,9 +414,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えて"
-"このチャットを続けることができます。"
+msgstr "%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -442,9 +426,7 @@ msgstr "%1$s単語"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$s"
-"をクリックしてください"
+msgstr "%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$sをクリックしてください"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -452,8 +434,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$s"
-"ボックスをオンにしてから %8$sOK%9$sをクリックしてください"
+"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$sボックスをオンにしてから "
+"%8$sOK%9$sをクリックしてください"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -463,8 +445,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sインストールを続行%3$sをクリックして %4$s追加ボタン%5$sを押し、%6$s許"
-"可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
+"%1$s%2$sインストールを続行%3$sをクリックして "
+"%4$s追加ボタン%5$sを押し、%6$s許可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -472,9 +454,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう"
-"一度試します。"
+msgstr "この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう一度試します。"
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -492,24 +472,21 @@ msgstr "%1$sさらに詳しく%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
+msgstr "%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$s詳細情報%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこち"
-"ら%2$sをご覧ください。"
+msgstr "DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこちら%2$sをご覧ください。"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -527,8 +504,7 @@ msgstr "ホーム画面でDuckDuckGoのアプリアイコンを%1$s長押し%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
+msgstr "%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -795,7 +771,7 @@ msgstr "グループ%1$sの2位"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "他のAIモデルに質問"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -886,8 +862,7 @@ msgstr "6時間の使用制限に達しました。このチャットは%1$s以�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
+msgstr "6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -940,27 +915,21 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"ネットワークの問題により、Search Assistは回答を生成できません。接続を確認し"
-"て、もう一度試してください。"
+msgstr "ネットワークの問題により、Search Assistは回答を生成できません。接続を確認して、もう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
-"い。"
+msgstr "AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
-"い。"
+msgstr "Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてください。"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1004,9 +973,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフ"
-"にすると、DuckDuckGo SearchのAI Chat機能は非表示になりますが、%1$sduckduckgo."
-"com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
+"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフにすると、DuckDuckGo SearchのAI "
+"Chat機能は非表示になりますが、%1$sduckduckgo.com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1066,11 +1034,7 @@ msgid ""
 "However, we also offer and often link to %sDuck.ai%s for follow-up "
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
-msgstr ""
-"AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただ"
-"し、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供して"
-"います。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活"
-"用したプライベートチャットサービスです。"
+msgstr "AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただし、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供しています。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活用したプライベートチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1254,9 +1218,7 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr ""
-"チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切"
-"り替えてください。"
+msgstr "チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1291,18 +1253,14 @@ msgstr "広告"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファ"
-"イリングには使用されません。"
+msgstr "広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr ""
-"広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロ"
-"ファイリングには使用されません。"
+msgstr "広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1352,9 +1310,7 @@ msgstr "DuckDuckGo拡張機能を追加"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加でき"
-"ます："
+msgstr "DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加できます："
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1484,7 +1440,7 @@ msgstr "ホーム画面に追加"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "マイチャットに追加"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1587,9 +1543,7 @@ msgctxt ""
 "model picker dropdown"
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
-msgstr ""
-"高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性がありま"
-"す。%1$s"
+msgstr "高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性があります。%1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1597,9 +1551,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性がありま"
-"す。%1$s"
+msgstr "高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性があります。%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1635,16 +1587,13 @@ msgstr "アフリカーンス語"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
+msgstr "ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールして"
-"ください"
+msgstr "ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールしてください"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1779,9 +1728,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
-"すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供"
-"元が学習内容をチャットモデルの学習に利用することはありません"
+msgstr "すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供元が学習内容をチャットモデルの学習に利用することはありません"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1813,9 +1760,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されてい"
-"ます。"
+msgstr "すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されています。"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1829,9 +1774,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスな"
-"ど）が削除されます。"
+msgstr "AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスなど）が削除されます。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1856,7 +1799,7 @@ msgstr "すべての種類"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "すべてのデバイスの同期が解除されました。"
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1869,9 +1812,7 @@ msgstr "許可"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可"
-"してください。"
+msgstr "ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可してください。"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1902,19 +1843,14 @@ msgid ""
 "Allows %s to search the web to improve responses to relevant prompts. Only "
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
-msgstr ""
-"%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。"
-"AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$s"
-"のプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
+msgstr "%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$sのプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr ""
-"デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する"
-"場合に必須)"
+msgstr "デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する場合に必須)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2051,9 +1987,7 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
-"セスできます。"
+msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2061,9 +1995,7 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
-"セスできます。"
+msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2076,9 +2008,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選"
-"択するか、完全に無効にすることができます。"
+msgstr "ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選択するか、完全に無効にすることができます。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2124,9 +2054,7 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr ""
-"Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教"
-"えてください"
+msgstr "Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教えてください"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2245,9 +2173,7 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr ""
-"履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むす"
-"べてのチャットが削除されます。"
+msgstr "履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むすべてのチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2255,9 +2181,7 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr ""
-"最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている"
-"最近のチャットも削除されます。"
+msgstr "最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている最近のチャットも削除されます。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2294,9 +2218,7 @@ msgstr "最終更新："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"私達はプライバシーポリシーに従って、個人情報を収集または共有することはありま"
-"せん。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
+msgstr "私達はプライバシーポリシーに従って、個人情報を収集または共有することはありません。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2380,7 +2302,7 @@ msgstr "非公開でなんでも聞いてください"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "非公開でなんでも聞いてください"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2438,12 +2360,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿"
-"名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist UIを完全に"
-"削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回"
-"答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻"
-"繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できま"
-"す。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
+""
+"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist "
+"UIを完全に削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できます。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2454,12 +2373,7 @@ msgid ""
 "generate a brief answer based on relevant information found. It’s important "
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
-msgstr ""
-"Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプ"
-"ション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活"
-"用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答"
-"は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されるこ"
-"とを覚えておくことが重要です。"
+msgstr "Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2484,9 +2398,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr ""
-"DuckDuckGo VPNは、カフェ、空港、ホテルでのWi-Fi接続を暗号化し、IPアドレスを非"
-"表示にして保護します。"
+msgstr "DuckDuckGo VPNは、カフェ、空港、ホテルでのWi-Fi接続を暗号化し、IPアドレスを非表示にして保護します。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2560,8 +2472,7 @@ msgstr "チャット終了後、音声は当社または OpenAI によって保�
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
+msgstr "チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2602,24 +2513,18 @@ msgstr "自動応答"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があ"
-"ります。"
+msgstr "リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる"
-"場合があります。"
+msgstr "リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"ソースに基づき自動生成されています。内容に不正確な部分を含む可能性がありま"
-"す。"
+msgstr "ソースに基づき自動生成されています。内容に不正確な部分を含む可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2638,10 +2543,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して"
-"情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能で"
-"す。"
+msgstr "関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2650,16 +2552,14 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"関連する検索に DuckAssist を自動表示します。このツールを使用すると、一部の検"
-"索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ"
-"利用可能です。"
+"関連する検索に DuckAssist "
+"を自動表示します。このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
+msgstr "動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2858,9 +2758,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
-"このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータ"
-"などのPIIを削除することで、会話を匿名化します。"
+msgstr "このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータなどのPIIを削除することで、会話を匿名化します。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2989,15 +2887,12 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr ""
-"DuckDuckGoのサブスクリプションなら、有害サイトのブロックやIPアドレスの非表示"
-"などのプレミアム保護を利用できます。"
+msgstr "DuckDuckGoのサブスクリプションなら、有害サイトのブロックやIPアドレスの非表示などのプレミアム保護を利用できます。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
+msgstr "ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3251,28 +3146,20 @@ msgstr "ファイルを参照"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索"
-"エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$s"
-"にまとめました。"
+msgstr "DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、"
-"高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
+msgstr "いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロッ"
-"ク、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウン"
-"ロードしましょう。"
+msgstr "いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロック、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウンロードしましょう。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3358,8 +3245,7 @@ msgstr "「%1$s」をクリックすると、当社の%2$sに同意したこと�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
+msgstr "「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3380,19 +3266,16 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に"
-"保存されます。匿名の Cloud Save 機能を利用すると、設定情報を (クラウド上のリ"
-"モートサーバーに) より長期的に保存できます。個人を特定できる情報がクラウドに"
-"保存されたり、パスフレーズがブラウザ上に残ることもありません。"
+"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に保存されます。匿名の Cloud Save "
+"機能を利用すると、設定情報を (クラウド上のリモートサーバーに) "
+"より長期的に保存できます。個人を特定できる情報がクラウドに保存されたり、パスフレーズがブラウザ上に残ることもありません。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信される"
-"ことに同意したことになります。開始する間に当社の%1$sを確認してください。"
+msgstr "音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3401,9 +3284,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI に送信"
-"されることに同意したことになります。開始する間に当社の%1$sを確認してくださ"
-"い。"
+"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI "
+"に送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3758,8 +3640,7 @@ msgstr "サイト全体の背景色を変更する"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
+msgstr "マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3888,11 +3769,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"チャット（Duck.ai サービス経由）を通じて、OpenAI、Anthropicなどのサードパー"
-"ティのAIチャットモデルと匿名で会話することができます。この設定をオフにする"
-"と、DuckDuckGo Searchのチャットボタンとリンクが非表示になります。ただし、この"
-"設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用"
-"できます。"
+"チャット（Duck.ai "
+""
+"サービス経由）を通じて、OpenAI、AnthropicなどのサードパーティのAIチャットモデルと匿名で会話することができます。この設定をオフにすると、DuckDuckGo "
+"Searchのチャットボタンとリンクが非表示になります。ただし、この設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3947,18 +3827,14 @@ msgstr "プライベートチャット"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートに"
-"チャットできます。"
+msgstr "無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプラ"
-"イベートにチャットできます。"
+msgstr "無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプライベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4026,10 +3902,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスに"
-"ローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが"
-"削除されます。"
+msgstr "チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスにローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4040,12 +3913,7 @@ msgid ""
 "help recover a chat if you lose your internet connection. Disabling chat "
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
-msgstr ""
-"チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗"
-"号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インター"
-"ネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にする"
-"と、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効"
-"になります。"
+msgstr "チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4067,19 +3935,14 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr ""
-"%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップ"
-"ロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロ"
-"バイダーによって匿名でレビューされます。"
+msgstr "%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロバイダーによって匿名でレビューされます。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr ""
-"添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはスト"
-"レージを解放してください。"
+msgstr "添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはストレージを解放してください。"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4138,8 +4001,7 @@ msgstr "この障害に関する最新情報は、DuckDuckGoのサブレディ�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"この停止に関する最新情報については、ステータスページを確認してください。"
+msgstr "この停止に関する最新情報については、ステータスページを確認してください。"
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4204,8 +4066,7 @@ msgstr "%1$sや%2$sを含むAIモデルの選択"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
+msgstr "%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4236,9 +4097,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
-msgstr ""
-"VPNサーバーは世界中に40以上あり、都合の良い場所を選択して、有害サイトや詐欺サ"
-"イトをブロックできます。"
+msgstr "VPNサーバーは世界中に40以上あり、都合の良い場所を選択して、有害サイトや詐欺サイトをブロックできます。"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4436,9 +4295,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最"
-"近のチャットが無期限に保存される場合、またはAI Chatの未使用期間が7日を超える"
-"と自動的に削除される場合があります。"
+"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最近のチャットが無期限に保存される場合、またはAI "
+"Chatの未使用期間が7日を超えると自動的に削除される場合があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4447,10 +4305,7 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr ""
-"ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは"
-"無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあ"
-"ります。ブラウザによって異なります。"
+msgstr "ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあります。ブラウザによって異なります。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4458,9 +4313,7 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr ""
-"ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリ"
-"ストを当社の無料ブラウザに"
+msgstr "ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリストを当社の無料ブラウザに"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4468,11 +4321,7 @@ msgid ""
 "Click \"More\" to go deeper on a topic, and ask follow-up questions via "
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
-msgstr ""
-"「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。ま"
-"た、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなど"
-"のチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用で"
-"きます。"
+msgstr "「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。また、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなどのチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用できます。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4513,9 +4362,7 @@ msgstr "一覧から%1$s検索設定の変更%2$sをクリックしてくださ�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてく"
-"ださい"
+msgstr "%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてください"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4526,15 +4373,12 @@ msgstr "%1$sここ%2$sをクリックして検索エンジンとして追加し�
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo browser extension to Safari.
 msgid "Click %sHere%s to download the DuckDuckGo extension"
-msgstr ""
-"%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
+msgstr "%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
 
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてくださ"
-"い"
+msgstr "%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてください"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4548,9 +4392,7 @@ msgstr "左側のサイドバーにある%1$sプライバシーとサービス%2
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、"
-"右上の%3$s歯車アイコン%4$sをクリックしてください)"
+msgstr "%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、右上の%3$s歯車アイコン%4$sをクリックしてください)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4579,8 +4421,7 @@ msgstr "%1$sはい%2$sをクリックしてください"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
+msgstr "Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4616,8 +4457,7 @@ msgstr "下のほうの %1$sデフォルトに設定%2$s をクリックしま�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
+msgstr "アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4642,10 +4482,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作"
-"によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がク"
-"リックまたはタップされるまでブラウザに残ります。"
+msgstr "「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がクリックまたはタップされるまでブラウザに残ります。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4655,10 +4492,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはク"
-"ラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップし"
-"ない限り、お使いのブラウザに保存されたままとなります。"
+msgstr "%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはクラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップしない限り、お使いのブラウザに保存されたままとなります。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4726,18 +4560,14 @@ msgstr "検索ボックスの選択項目をクリック"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューを"
-"クリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
+msgstr "%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューをクリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr ""
-"広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機"
-"能のアイコンはブラウザの右上隅に表示されています。"
+msgstr "広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機能のアイコンはブラウザの右上隅に表示されています。"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4937,9 +4767,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能"
-"を使うかどうかはあなた次第。強制ではありません。"
+msgstr "パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能を使うかどうかはあなた次第。強制ではありません。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5210,9 +5038,7 @@ msgstr "広告ブロックを継続"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"最近のチャットはここから再開できます。または、Fire Buttonで削除することもでき"
-"ます。"
+msgstr "最近のチャットはここから再開できます。または、Fire Buttonで削除することもできます。"
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5319,7 +5145,7 @@ msgstr "コピー"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "コピー"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5330,8 +5156,7 @@ msgstr "コピー"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
+msgstr "「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5369,13 +5194,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "共有リンクをコピー"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "別のデバイスからコードをコピーしてください"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5384,6 +5209,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"別のデバイスからコードをコピーしてください。%1$sDuck.ai設定 › チャット › Sync & Backup › "
+"別のデバイスと同期%2$sに移動して、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5435,9 +5262,7 @@ msgstr "コスタリカ"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しくださ"
-"い。"
+msgstr "リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5537,9 +5362,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr ""
-"リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲覧"
-"できるようになります。"
+msgstr "リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲覧できるようになります。"
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5778,8 +5601,7 @@ msgstr "1日の使用制限に達しました。このチャットは%1$s以降�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
+msgstr "1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6055,8 +5877,7 @@ msgstr "ストレージを解放するために最も古いチャットを削除
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
+msgstr "保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6070,7 +5891,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "共有リンクを削除"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6090,7 +5911,7 @@ msgctxt "Description at the top of the Duck.ai shared links modal"
 msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
-msgstr ""
+msgstr "リンクを削除すると、そのリンクは機能しなくなります。 リンクを開いて会話を自分のチャットに追加したユーザーは、各自のコピーをそのまま保持します。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6186,9 +6007,7 @@ msgstr "Duck.aiの音声入力"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されま"
-"せん。"
+msgstr "音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6205,9 +6024,7 @@ msgstr "音声入力は一時的に利用できません"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck."
-"aiチャットができます。"
+msgstr "音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck.aiチャットができます。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6352,7 +6169,7 @@ msgstr "無視する"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "無視する"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6488,15 +6305,13 @@ msgstr "DuckDuckGoがリストにありませんか？"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
+msgstr "表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr ""
-"チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
+msgstr "チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6527,9 +6342,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
-"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供さ"
-"れず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供されず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6537,9 +6350,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr ""
-"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能"
-"は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6654,9 +6465,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr ""
-"シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成しま"
-"す。内容は、簡潔かつ詳細に入力してください。"
+msgstr "シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成します。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6664,9 +6473,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr ""
-"家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容"
-"は、簡潔かつ詳細に入力してください。"
+msgstr "家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6686,9 +6493,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか"
-"作成してください。"
+msgstr "今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6696,9 +6501,7 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr ""
-"チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をい"
-"くつか作成してください。"
+msgstr "チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をいくつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6832,8 +6635,7 @@ msgid ""
 msgstr ""
 "Duck.aiは、現在表示しているページに関する質問に回答できるようになりました。\n"
 "\n"
-"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したと"
-"きにのみ含まれます。"
+"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したときにのみ含まれます。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6842,10 +6644,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。"
-"ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しくださ"
-"い。"
+msgstr "Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6853,16 +6652,13 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr ""
-"Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してくだ"
-"さい。"
+msgstr "Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
+msgstr "Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6871,9 +6667,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻"
-"したいユーザーのためにオンライン保護に取り組む独立系企業です。"
+msgstr "Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻したいユーザーのためにオンライン保護に取り組む独立系企業です。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6887,9 +6681,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが"
-"「https://duck.ai」と覚えやすくなります"
+msgstr "Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが「https://duck.ai」と覚えやすくなります"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6903,18 +6695,14 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」"
-"を%2$s宛てにメールで送信してください"
+msgstr "Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してくださ"
-"い。"
+msgstr "Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6927,10 +6715,7 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr ""
-"Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiの"
-"ボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスで"
-"きます。"
+msgstr "Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiのボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスできます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6941,10 +6726,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデル"
-"と匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタ"
-"ンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://"
-"duck.ai%2$s に直接アクセスすることでDuck.aiを利用できます。"
+""
+"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデルと匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://duck.ai%2$s "
+"に直接アクセスすることでDuck.aiを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6958,9 +6742,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr ""
-"Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用"
-"できます。"
+msgstr "Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用できます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6973,8 +6755,7 @@ msgstr "Duck.aiでPDFを読み、解析できるようになりました。ぜ�
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr ""
-"Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
+msgstr "Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -6998,8 +6779,7 @@ msgstr "Duck.aiがアップグレードしました！"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
+msgstr "Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7009,9 +6789,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、プライベートAIチャットボット、無料AIチャット、匿名AI"
-"チャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オー"
-"プンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
+"Duck.ai、DuckDuckGo "
+"AI、プライベートAIチャットボット、無料AIチャット、匿名AIチャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オープンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7039,11 +6818,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。"
-"DuckAssistの表示頻度は、なし（検索結果からDuckAssist UIを完全に削除）、オンデ"
-"マンド（[アシスト] ボタンをクリックした場合にのみ表示）、時々（関連性の高い場"
-"合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点で"
-"は、米国（英語）地域でのみ利用可能です。"
+"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。DuckAssistの表示頻度は、なし（検索結果からDuckAssist "
+"UIを完全に削除）、オンデマンド（[アシスト] "
+"ボタンをクリックした場合にのみ表示）、時々（関連性の高い場合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点では、米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7052,9 +6829,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他か"
-"らチャットモデルをサポートするプライベートAI搭載チャットサービ"
-"ス、%1$sDuckDuckGo AI Chat%2$sもご利用いただけます。"
+""
+"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他からチャットモデルをサポートするプライベートAI搭載チャットサービス、%1$sDuckDuckGo "
+"AI Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7063,8 +6840,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャット"
-"モデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
+""
+"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャットモデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
 "Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
@@ -7077,11 +6854,9 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 こ"
-"れを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、"
-"AIを活用した自然言語技術を使用して情報の要約を生成します。 現時点での回答は"
-"Wikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご"
-"注意ください。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 "
+"これを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、AIを活用した自然言語技術を使用して情報の要約を生成します。 "
+"現時点での回答はWikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご注意ください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7095,22 +6870,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション"
-"機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI を活用した"
-"自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssist"
-"の回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのた"
-"め、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成さ"
-"れ、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重"
-"要です。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI "
+"を活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssistの回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのため、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr ""
-"DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認さ"
-"れません。"
+msgstr "DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認されません。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7118,9 +6886,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続"
-"行してください。"
+msgstr "DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7129,8 +6895,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
-"いるプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI "
+"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7139,8 +6905,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
-"いるプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI "
+"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7148,9 +6914,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr ""
-"DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される"
-"可能性があります。"
+msgstr "DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される可能性があります。"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7158,9 +6922,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード"
-"「%1$s」を%2$s宛てにメールで送信してください"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7168,17 +6930,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直"
-"してください。"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しくださ"
-"い。"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7211,7 +6969,7 @@ msgstr "DuckDuckGoブラウザ%1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo ヘルプページ"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7327,18 +7085,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的"
-"に削除することで、これらのレポートを匿名化します。"
+msgstr "DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的に削除することで、これらのレポートを匿名化します。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに"
-"同意したことになります。"
+msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7346,9 +7100,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同"
-"意したことになります。"
+msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7356,9 +7108,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による"
-"追跡行為を阻止することができます。"
+msgstr "DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による追跡行為を阻止することができます。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7370,12 +7120,8 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する"
-"場合、ローカルデバイスだけに保存されます。DuckDuckGo は検索時にユーザーのデバ"
-"イスから送信される位置情報を検索結果を向上するために使用します。位置情報は使"
-"用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様の"
-"プライバシーを保護するため、当社がどのようにこの技術を設計したかについては、"
-"こちらをご覧ください%2$s。"
+"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する場合、ローカルデバイスだけに保存されます。DuckDuckGo "
+"は検索時にユーザーのデバイスから送信される位置情報を検索結果を向上するために使用します。位置情報は使用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様のプライバシーを保護するため、当社がどのようにこの技術を設計したかについては、こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7394,9 +7140,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を"
-"表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
+msgstr "DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7487,10 +7231,7 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr ""
-"パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載"
-"されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～"
-"20字のパスフレーズ候補として4、5個の単語が選ばれます。"
+msgstr "パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～20字のパスフレーズ候補として4、5個の単語が選ばれます。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7560,8 +7301,7 @@ msgstr "画像を編集中..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
+msgstr "メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7698,9 +7438,7 @@ msgstr "ウェブ検索を有効にする"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後"
-"でいつでも変更できます。"
+msgstr "検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7742,9 +7480,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索"
-"データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
+msgstr "「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7862,8 +7598,7 @@ msgstr "位置情報へのアクセスは必ず %1$s許可%2$s にします。"
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
+msgstr "ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7906,9 +7641,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてくだ"
-"さい。データが新しいパスフレーズで保存されます。"
+msgstr "新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてください。データが新しいパスフレーズで保存されます。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7933,9 +7666,7 @@ msgstr "テキストを入力"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイ"
-"リアス%6$s: d%7$s"
+msgstr "以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイリアス%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8042,7 +7773,7 @@ msgstr "プライバシーを優先するユーザーのために趣向を凝ら
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "期限切れ"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8056,7 +7787,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "%1$sに期限切れになります"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8318,9 +8049,7 @@ msgstr "フィードバックが送信されました"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきま"
-"す。"
+msgstr "お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきます。"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8328,19 +8057,14 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用さ"
-"せていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組ん"
-"で参ります。"
+msgstr "お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用させていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組んで参ります。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆"
-"ペーストしてください。"
+msgstr "以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆ペーストしてください。"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8458,8 +8182,7 @@ msgstr "金融アドバイザー"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
+msgstr "%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8471,9 +8194,7 @@ msgstr "ダウンロードフォルダで<b>%1$s</b>を表示"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックしま"
-"す"
+msgstr "表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックします"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8510,9 +8231,7 @@ msgstr "あなたにとって最も的確な結果を見つけます。"
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されま"
-"す。"
+msgstr "お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されます。"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8575,9 +8294,7 @@ msgstr "霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオ"
-"プションを選択したり、ボタンをクリックする必要がある場合があります。"
+msgstr "DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオプションを選択したり、ボタンをクリックする必要がある場合があります。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8724,9 +8441,7 @@ msgstr "営利目的で共有、使用が可能"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されませ"
-"ん。"
+msgstr "チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8807,9 +8522,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; <strong>[アッ"
-"プデートを確認...]</strong>、次に<strong>[アップデートをインストール]</"
-"strong> を選択します。"
+"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; "
+"<strong>[アップデートを確認...]</strong>、次に<strong>[アップデートをインストール]</strong> を選択します。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9095,16 +8809,14 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN、高度なDuck.ai、Personal Information Removal（個人情報の削"
-"除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+"DuckDuckGo VPN、高度なDuck.ai、Personal Information Removal（個人情報の削除）、Identity "
+"Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"DuckDuckGo VPN、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機"
-"能を利用できます。"
+msgstr "DuckDuckGo VPN、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9163,9 +8875,7 @@ msgstr "開始"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがです"
-"か。"
+msgstr "VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがですか。"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9186,9 +8896,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ノーログ型高速VPNに加え、高度なAIチャット（オプション）、Personal "
-"Information Removal（個人情報の削除）、Identity Theft Restoration（ID盗難後の"
-"復旧）機能を利用できます。"
+"ノーログ型高速VPNに加え、高度なAIチャット（オプション）、Personal Information "
+"Removal（個人情報の削除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9196,9 +8905,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr ""
-"ノーログ型高速VPNに加え、高度なAIチャット（オプション）Identity Theft "
-"Restoration（ID盗難後の復旧）機能を利用できます。"
+msgstr "ノーログ型高速VPNに加え、高度なAIチャット（オプション）Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9206,9 +8913,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これに"
-"は、VPNやその他のプレミアムなプライバシー保護も含まれています。"
+msgstr "DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これには、VPNやその他のプレミアムなプライバシー保護も含まれています。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9218,9 +8923,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。"
-"VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
+msgstr "DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9263,9 +8966,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr ""
-"ノーログ型高速VPNに加え、高度なAIモデルへのアクセス（コール上限数拡大付きオプ"
-"ション）、その他のプレミアム保護機能を利用できます。"
+msgstr "ノーログ型高速VPNに加え、高度なAIモデルへのアクセス（コール上限数拡大付きオプション）、その他のプレミアム保護機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9274,25 +8975,20 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ノーログ型の安全なVPNに加え、高度なDuck.ai、Personal Information Removal（個"
-"人情報の削除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できま"
-"す。"
+"ノーログ型の安全なVPNに加え、高度なDuck.ai、Personal Information Removal（個人情報の削除）、Identity "
+"Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"ノーログ型安全なVPNに加え、高度なDuck.ai、Identity Theft Restoration（ID盗難"
-"後の復旧）機能を利用できます。"
+msgstr "ノーログ型安全なVPNに加え、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロー"
-"ド："
+msgstr "ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロード："
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9328,9 +9024,7 @@ msgstr "アプリをダウンロード"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"DuckDuckGoブラウザを無料で入手して、%1$sYouTubeの広告をブロックしましょ"
-"う。%2$s"
+msgstr "DuckDuckGoブラウザを無料で入手して、%1$sYouTubeの広告をブロックしましょう。%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9389,9 +9083,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」 › 「テキストコードをコ"
-"ピー」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」 › 「テキストコードをコピー」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9400,8 +9093,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9411,9 +9104,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックして、次の"
-"コードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」%4$sの順にクリックして、次のコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9423,9 +9115,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします。ま"
-"たは、リカバリーPDFのQRコードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」%4$sの順にクリックします。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9433,14 +9124,13 @@ msgctxt "Detail under the first numbered step on the Enter Code tab"
 msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
-msgstr ""
+msgstr "%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイスと同期%4$sに移動します。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
+msgstr "%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9449,8 +9139,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動"
-"し、[位置情報サービス] がオンになっていることを確認します。"
+"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動し、[位置情報サービス] "
+"がオンになっていることを確認します。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9459,8 +9149,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、"
-"[DuckDuckGo] まで下にスクロールします。%3$s%4$s"
+"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、[DuckDuckGo] "
+"まで下にスクロールします。%3$s%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9550,7 +9240,7 @@ msgstr "了解"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "了解"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10148,8 +9838,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
+msgstr "Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10176,8 +9865,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"キーボードの %1$s戻る%2$s キーを押して、%3$sDuckDuckGoをリストに保存しま"
-"す。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
+"キーボードの %1$s戻る%2$s "
+"キーを押して、%3$sDuckDuckGoをリストに保存します。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10190,9 +9879,7 @@ msgstr "ミャオ語"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバ"
-"シーが保護されなくなります。"
+msgstr "ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバシーが保護されなくなります。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10241,9 +9928,7 @@ msgstr "猛暑"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr ""
-"ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様の"
-"プロファイリングには使用されません。"
+msgstr "ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10505,9 +10190,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズは"
-"どんなものですか、またその理由は何ですか？"
+msgstr "私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズはどんなものですか、またその理由は何ですか？"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10542,8 +10225,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセッ"
-"ト] > [位置情報とプライバシー設定をリセット]%2$s の順に移動します。"
+"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセット] > [位置情報とプライバシー設定をリセット]%2$s "
+"の順に移動します。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10553,9 +10236,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク "
-"> [メニュー] > [設定] > [サイト設定] > [位置情報]%2$s の順に移動し、"
-"DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
+"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク > [メニュー] > [設定] > [サイト設定] > "
+"[位置情報]%2$s の順に移動し、DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10569,9 +10251,7 @@ msgstr "このエラーが続く場合は、%1$sに連絡してください。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追"
-"加する必要があります"
+msgstr "%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追加する必要があります"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10580,8 +10260,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"チャット プロバイダーまたは特定のチャット応答についてご不明な点がある場合"
-"は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
+"チャット "
+"プロバイダーまたは特定のチャット応答についてご不明な点がある場合は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10589,18 +10269,13 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこの"
-"コードが必要になります。このコードはテキストファイルとしてデバイスに保存でき"
-"ます。"
+msgstr "デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこのコードが必要になります。このコードはテキストファイルとしてデバイスに保存できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力くだ"
-"さい%2$s"
+msgstr "もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力ください%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10609,18 +10284,14 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンを"
-"ご利用ください。"
+msgstr "Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンをご利用ください。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択して"
-"ください。"
+msgstr "ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択してください。"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10760,9 +10431,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレ"
-"クトする必要があります。%1$sさらに詳しく%2$s。"
+msgstr "古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレクトする必要があります。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10772,9 +10441,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同"
-"期」を選択します。"
+msgstr "DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同期」を選択します。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10788,9 +10455,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に"
-"保存されている情報を正確に知ることができます。"
+msgstr "情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に保存されている情報を正確に知ることができます。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10800,8 +10465,7 @@ msgstr "上部のメニューから%1$sツール%2$s > %3$s設定%4$sを選択"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
+msgstr "ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11127,8 +10791,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
+msgstr "この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11196,11 +10859,7 @@ msgid ""
 "Items are ranked based on relevance to your search terms and are delivered "
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
-msgstr ""
-"アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告"
-"ネットワークを通じて配信されます。クリック後はマーチャントのランディングペー"
-"ジに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け"
-"取ることはありません。"
+msgstr "アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告ネットワークを通じて配信されます。クリック後はマーチャントのランディングページに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け取ることはありません。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11208,9 +10867,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっ"
-"と安全です。"
+msgstr "ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっと安全です。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11282,9 +10939,7 @@ msgstr "両方のデバイスでSync & Backupを開いたままにします。"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr ""
-"一度に最大5台のデバイスで、すべてのアプリとオンラインの活動のプライバシーを確"
-"保できます。"
+msgstr "一度に最大5台のデバイスで、すべてのアプリとオンラインの活動のプライバシーを確保できます。"
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11521,7 +11176,7 @@ msgstr "詳しくは%1$sこちら%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "詳細情報"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11696,8 +11351,7 @@ msgstr "DuckDuckGo を使って匿名で検索しましょう"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"検索クエリの送信とDuck.aiへのプロンプトの送信を切り替えることができます。"
+msgstr "検索クエリの送信とDuck.aiへのプロンプトの送信を切り替えることができます。"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12158,7 +11812,7 @@ msgstr "管理"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "管理"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12415,7 +12069,7 @@ msgstr "メニュー"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "これ以降のメッセージは、自分にのみ表示されます。"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12445,9 +12099,7 @@ msgstr "ミクロネシア"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試し"
-"ください。"
+msgstr "マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12789,7 +12441,7 @@ msgstr "Duck.aiの詳細"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "その他のアクション"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12989,7 +12641,7 @@ msgstr "海老茶"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "マイデバイス"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13230,11 +12882,7 @@ msgid ""
 "DuckDuckGo server after being sent, to help recover a chat if you lose your "
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
-msgstr ""
-"新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的"
-"に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立"
-"ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロ"
-"ンプトと応答の一時的な保存が無効になります。"
+msgstr "新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13549,8 +13197,7 @@ msgstr "結果が見つかりません。"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
+msgstr "音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14056,9 +13703,7 @@ msgstr "オンデマンド"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順"
-"に%5$sクリックしてください"
+msgstr "Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順に%5$sクリックしてください"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14066,7 +13711,7 @@ msgctxt "Instruction under the Scan QR tab sub-heading"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
-msgstr ""
+msgstr "別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイスと同期%4$sに移動します"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14075,6 +13720,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › "
+"別のデバイスと同期%4$sに移動して、このコードをスキャンします："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14083,6 +13730,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › "
+"別のデバイスと同期%4$sに移動します。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14109,9 +13758,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルを"
-"アップロードしてください。"
+msgstr "添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルをアップロードしてください。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14137,8 +13784,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
+msgstr "変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14152,9 +13798,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおい"
-"てからもう一度試してください。"
+msgstr "おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおいてからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14476,9 +14120,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡していま"
-"す。私たちは追跡しません。"
+msgstr "他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡しています。私たちは追跡しません。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14491,27 +14133,21 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr ""
-"ノーログ型の高速VPNに加え、上級AIチャット（利用上限数拡大）、その他のプレミア"
-"ム保護機能を利用できます。全機能を1つにまとめたサブスクリプションです。"
+msgstr "ノーログ型の高速VPNに加え、上級AIチャット（利用上限数拡大）、その他のプレミアム保護機能を利用できます。全機能を1つにまとめたサブスクリプションです。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr ""
-"私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しま"
-"せん。"
+msgstr "私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しません。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、"
-"強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
+msgstr "当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14763,9 +14399,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情"
-"報をファイルに関連付けないため、パスフレーズを復元できません。"
+msgstr "当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情報をファイルに関連付けないため、パスフレーズを復元できません。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14835,7 +14469,7 @@ msgstr "過去1年間"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "貼り付け"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14853,7 +14487,7 @@ msgstr "同期コードを貼り付け"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "下に貼り付けてください"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14912,7 +14546,7 @@ msgstr "ペルシャ語"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14921,6 +14555,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information "
+"Removalは、お客様の個人情報を売買しているデータブローカーサイトから、その情報を見つけ出します。そして、お客様に代わって削除に向けて対応します。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14990,10 +14626,7 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr ""
-"検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能"
-"性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検"
-"索設定%2$sにアクセスしてください。"
+msgstr "検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検索設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15002,9 +14635,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精"
-"度が高くなります。 この機能の動作を調整したり、オフにするには、%1$sDuckAssist"
-"設定%2$sにアクセスしてください。"
+"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精度が高くなります。 "
+"この機能の動作を調整したり、オフにするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15013,10 +14645,7 @@ msgid ""
 "DuckAssist more likely to appear automatically and often yields better "
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
-msgstr ""
-"検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精"
-"度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設"
-"定%2$sにアクセスしてください。"
+msgstr "検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15048,8 +14677,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15057,8 +14685,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15066,9 +14693,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGo"
-"の保護が付属しません。"
+msgstr "目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGoの保護が付属しません。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15168,9 +14793,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"このプロンプトがボットにより行われていないことを確認するため、次のチャレンジ"
-"を完了してください。"
+msgstr "このプロンプトがボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15178,9 +14801,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"この検索がボットにより行われていないことを確認するため、次のチャレンジを完了"
-"してください。"
+msgstr "この検索がボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15212,9 +14833,7 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
-msgstr ""
-"注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除され"
-"ます。"
+msgstr "注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除されます。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15222,9 +14841,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害また"
-"は違法である理由を説明してください。"
+msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害または違法である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15232,9 +14849,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法また"
-"は有害である理由を説明してください。"
+msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法または有害である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15448,9 +15063,7 @@ msgstr "フォーマットが不十分"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
-"人気のAIモデルが利用可能です。アカウントは必要ありません。当社によりチャット"
-"は匿名化されます。"
+msgstr "人気のAIモデルが利用可能です。アカウントは必要ありません。当社によりチャットは匿名化されます。"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15959,9 +15572,7 @@ msgstr "確認する"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示し"
-"ます。"
+msgstr "ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示します。"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16003,9 +15614,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独"
-"自のテキストを挿入します。]"
+msgstr "次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独自のテキストを挿入します。]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16180,7 +15789,7 @@ msgstr "ウェブサイトを読み込み中…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "日食の準備はできていますか？"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16277,9 +15886,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
-"バイスにローカルで保存されます。"
+msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16287,9 +15894,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
-"バイスにローカルで保存されます。"
+msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16298,10 +15903,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポン"
-"スは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、イ"
-"ンターネット接続が途切れた場合のチャット復旧に役立ちます。"
+msgstr "最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16375,7 +15977,7 @@ msgstr "リカバリーコード"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "リカバリーコード"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16442,9 +16044,7 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr ""
-"結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズ"
-"を縮小します"
+msgstr "結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズを縮小します"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16585,8 +16185,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッ"
-"シュ）]、または [Reload（再読み込み）] ボタンをクリックします。"
+"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッシュ）]、または [Reload（再読み込み）] "
+"ボタンをクリックします。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16632,7 +16232,7 @@ msgstr "%1$sを削除"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "デバイスを削除"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16680,31 +16280,27 @@ msgstr "不要な句読点を削除してください"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "インターネット上から個人情報を削除"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "オンライン上の個人情報を削除"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
-"します。キャッシュされた回答は常に自動的に表示されます。"
+msgstr "「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
-"します。キャッシュされた回答は常に自動的に表示されます。"
+msgstr "「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16761,18 +16357,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の"
-"匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
+msgstr "レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個"
-"人を特定できる情報を含めないようお願いいたします。"
+msgstr "DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16780,10 +16372,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべ"
-"てのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を"
-"特定できる情報を含めないようお願いいたします。"
+msgstr "DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべてのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16874,10 +16463,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
-"イスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象"
-"です。"
+msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象です。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16885,10 +16471,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
-"イスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象"
-"になります。"
+msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象になります。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16898,10 +16481,9 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なア"
-"ドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて"
-"生成されているため、不正確な情報が含まれている可能性があります。Search Assist"
-"には、当社の%1$s利用規約%2$sが適用されます。"
+""
+"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なアドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて生成されているため、不正確な情報が含まれている可能性があります。Search "
+"Assistには、当社の%1$s利用規約%2$sが適用されます。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17325,9 +16907,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージ"
-"を使用すれば、さらに多くのチャットを保存できます。"
+msgstr "最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージを使用すれば、さらに多くのチャットを保存できます。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17340,9 +16920,7 @@ msgstr "最新のチャットを最大30件デバイスにローカルで保存�
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょ"
-"う。"
+msgstr "エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょう。"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17378,7 +16956,7 @@ msgstr "Duck.aiへようこそ"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Duck.aiへようこそ — DuckDuckGoによる無料のプライベートAIチャットです。"
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17495,9 +17073,7 @@ msgstr "下方向にスクロールし、%1$s詳細設定を表示%2$s をクリ
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変"
-"更%4$s (または %5$s新たに追加%6$s) をクリックします"
+msgstr "%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) をクリックします"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17506,8 +17082,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変"
-"更%4$s (または %5$s新たに追加%6$s) をクリックします。"
+"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) "
+"をクリックします。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17531,9 +17107,7 @@ msgstr "%1$sDuckDuckGo%2$sまで下にスクロールし、位置情報の使用
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s "
-"をクリックします。"
+msgstr "%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s をクリックします。"
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17587,20 +17161,17 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コン"
-"テンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻"
-"度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々"
-"（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。"
-"Search Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
+"Search "
+""
+"Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コンテンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。Search "
+"Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr ""
-"Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけること"
-"ができませんでした。別の検索をお試しください。"
+msgstr "Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけることができませんでした。別の検索をお試しください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17609,9 +17180,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。こ"
-"れを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情"
-"報に基づいてAIを使って簡潔な回答を生成します。"
+"Search "
+"Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。これを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情報に基づいてAIを使って簡潔な回答を生成します。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17731,9 +17301,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、"
-"Wikipediaで「ducks」を直接検索します。"
+msgstr "%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、Wikipediaで「ducks」を直接検索します。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17751,10 +17319,7 @@ msgstr "プライベートに検索し、トラッカーをブロック"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りの"
-"ブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索"
-"できます。"
+msgstr "検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りのブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17773,10 +17338,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されます"
-"が、設定をクラウド上のリモートサーバーに匿名で保存できるCloud Saveもご利用い"
-"ただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズが"
-"ブラウザの外に送信されることもありません。"
+"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されますが、設定をクラウド上のリモートサーバーに匿名で保存できるCloud "
+"Saveもご利用いただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズがブラウザの外に送信されることもありません。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17878,9 +17441,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべてのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17888,9 +17449,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべてのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17898,9 +17457,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべての同期済みのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべての同期済みのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17908,9 +17465,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべ"
-"てのデバイスからアクセスできます。"
+msgstr "チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべてのデバイスからアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17924,9 +17479,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。"
-"DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
+msgstr "データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18076,41 +17629,35 @@ msgstr "Safariメニューの%1$s「このウェブサイトの設定...」%2$s 
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
+msgstr "%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
+msgstr "%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
+msgstr "リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18122,9 +17669,7 @@ msgstr "検索エンジンから%1$sDuckDuckGo%2$sを選択してください"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択"
-"してください"
+msgstr "%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択してください"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18135,8 +17680,7 @@ msgstr "選ぶなら%1$sDuckDuckGo%2$s！"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
+msgstr "ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18149,9 +17693,7 @@ msgstr "ドロップダウンメニューの%1$sアドオン管理%2$sを選択�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$s"
-"メニュー > 設定%4$sの順に選択してください"
+msgstr "Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$sメニュー > 設定%4$sの順に選択してください"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18159,8 +17701,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合"
-"は、%3$sOpera > オプション%4$sの順に選択してください"
+"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合は、%3$sOpera > "
+"オプション%4$sの順に選択してください"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18179,8 +17721,7 @@ msgstr "%1$s検索エンジン%2$s を選択"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
+msgstr "%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18225,17 +17766,13 @@ msgstr "%1$s設定%2$sを選択し、%3$s検索エンジン%4$sを選択して�
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオ"
-"プションをどれか一つどうぞ)"
+msgstr "%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオプションをどれか一つどうぞ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$s"
-"します"
+msgstr "リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18307,9 +17844,7 @@ msgstr "選択テキストの参照元：%1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しくだ"
-"さい。"
+msgstr "選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18352,9 +17887,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これら"
-"の指示は、今後のすべての会話に適用されます。"
+msgstr "AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これらの指示は、今後のすべての会話に適用されます。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18381,7 +17914,7 @@ msgstr "セルビア語(ラテン文字)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "サーバーデータが削除されました"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18476,9 +18009,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるように"
-"Sync & Backupを設定します。"
+msgstr "チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるようにSync & Backupを設定します。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18541,7 +18072,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "共有"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18584,9 +18115,7 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お"
-"客様の正確な位置情報を当社や AI モデルに決して公開しません。"
+msgstr "都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お客様の正確な位置情報を当社や AI モデルに決して公開しません。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18681,9 +18210,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事"
-"象の報告には必須）"
+msgstr "プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事象の報告には必須）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18695,13 +18222,13 @@ msgstr "検索ボックスについてご意見をお寄せください。"
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "共有チャットリンク"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "共有チャットリンク"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18709,9 +18236,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr ""
-"ノーログ型の高速VPNを使って、オンライン活動を保護できます。セットアップは簡単"
-"で、オン/オフの切り替えがいつでも可能です。"
+msgstr "ノーログ型の高速VPNを使って、オンライン活動を保護できます。セットアップは簡単で、オン/オフの切り替えがいつでも可能です。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18831,9 +18356,7 @@ msgstr "DuckAssist<sup>ベータ版</sup>を表示"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできま"
-"す。）"
+msgstr "DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできます。）"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19016,8 +18539,7 @@ msgstr "サイドバーを表示する"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Duck.aiを最大限に活用するためのステップバイステップのヒントを表示します。"
+msgstr "Duck.aiを最大限に活用するためのステップバイステップのヒントを表示します。"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19071,18 +18593,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオ"
-"フにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
+msgstr "DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオフにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これを"
-"オフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
+msgstr "DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これをオフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19119,8 +18637,7 @@ msgstr "DuckDuckGoを端末に追加するリマインダーを随時表示"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
+msgstr "DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19141,9 +18658,7 @@ msgstr "入力に応じて検索ボックスの下に検索候補を表示"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表"
-"示"
+msgstr "ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19382,7 +18897,7 @@ msgstr "問題が発生しました"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "この共有チャットの読み込み中に問題が発生しました。"
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19394,8 +18909,7 @@ msgstr "サーバーへの保存が失敗しました。再度お試しくださ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
+msgstr "Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19425,8 +18939,7 @@ msgstr "時々表示する"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
+msgstr "申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19464,9 +18977,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像また"
-"は形式を試してください。"
+msgstr "申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像または形式を試してください。"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19474,17 +18985,13 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされ"
-"たことを確認してください。"
+msgstr "申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされたことを確認してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
-msgstr ""
-"申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai "
-"に聞いてみてください。"
+msgstr "申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai に聞いてみてください。"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19492,17 +18999,13 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行す"
-"るには、%1$sこちらをクリック%2$sしてください。"
+msgstr "申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行するには、%1$sこちらをクリック%2$sしてください。"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてか"
-"らもう一度試してください。"
+msgstr "申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19556,9 +19059,7 @@ msgstr "ソーステキストが消去されました"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度"
-"お試しください。"
+msgstr "ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19763,8 +19264,7 @@ msgstr "DuckDuckGoを使用し続ける"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
+msgstr "プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19908,9 +19408,7 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr ""
-"Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像"
-"を作成してください。"
+msgstr "Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像を作成してください。"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19978,8 +19476,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
+msgstr "手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20236,7 +19733,7 @@ msgstr "モデルを切り替える"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "モデルを切り替える"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20315,8 +19812,7 @@ msgstr "%1$sに切り替えました"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
+msgstr "切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20419,25 +19915,21 @@ msgid ""
 msgstr ""
 "同期リカバリーコード\n"
 "\n"
-"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複"
-"数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同"
-"期済みのデータを回復できます。\n"
+""
+""
+"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同期済みのデータを回復できます。\n"
 "\n"
 "この情報は安全に保管してください。\n"
-"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできま"
-"す。\n"
+"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできます。\n"
 "\n"
 "%1$s\n"
 "\n"
 "このコードの仕組みは？\n"
 "1. ブラウザでDuck.aiにアクセスし、Duck.aiの設定を開きます。\n"
-"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択しま"
-"す\n"
-"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付"
-"けます\n"
+"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択します\n"
+"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付けます\n"
 "\n"
-"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除さ"
-"れ、復元できなくなります。"
+"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除され、復元できなくなります。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20498,7 +19990,7 @@ msgstr "同期されたデバイス"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "%1$sに同期済み"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20536,7 +20028,7 @@ msgstr "テレビ"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "表"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20569,9 +20061,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
-"Duck.aiをどこへでも連れて行きましょう。どこにいても素早くアクセスできるよう、"
-"無料アプリに組み込めます。"
+msgstr "Duck.aiをどこへでも連れて行きましょう。どこにいても素早くアクセスできるよう、無料アプリに組み込めます。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20579,9 +20069,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
-"Duck.aiをどこへでも連れて行きましょう。無料ブラウザに組み込むことで、どこから"
-"でも素早くアクセスできます。"
+msgstr "Duck.aiをどこへでも連れて行きましょう。無料ブラウザに組み込むことで、どこからでも素早くアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20604,8 +20092,7 @@ msgstr "個人データを自己管理しましょう！"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
+msgstr "この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20825,10 +20312,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情"
-"報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワード"
-"や支払い情報がこうした情報に含まれる場合もあります。"
+msgstr "つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワードや支払い情報がこうした情報に含まれる場合もあります。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20836,9 +20320,7 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr ""
-"Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動"
-"保存できます。"
+msgstr "Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動保存できます。"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20867,18 +20349,14 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr ""
-"暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本"
-"人だけです。"
+msgstr "暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本人だけです。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除しま"
-"す。"
+msgstr "モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除します。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20892,8 +20370,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
+msgstr "モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20951,9 +20428,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確"
-"認し、ローカルデータの保存が有効になっていることをご確認ください。"
+msgstr "このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確認し、ローカルデータの保存が有効になっていることをご確認ください。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20967,9 +20442,7 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr ""
-"検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してくださ"
-"い。"
+msgstr "検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してください。"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20987,10 +20460,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加す"
-"るために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoを"
-"デフォルトの検索エンジンにするために使用されます。"
+msgstr "これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加するために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoをデフォルトの検索エンジンにするために使用されます。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21027,9 +20497,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみ"
-"てください。"
+msgstr "このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21037,9 +20505,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャッ"
-"トを開始してください。"
+msgstr "このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャットを開始してください。"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21077,10 +20543,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AI"
-"チャットでは不正確な情報や不快な情報が表示される場合があります（詳細について"
-"は%4$sを参照してください）。"
+msgstr "この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21089,10 +20552,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AI"
-"チャットでは不正確な情報や不快な内容が表示される場合があります（詳細について"
-"は%2$sを参照してください）。"
+msgstr "この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な内容が表示される場合があります（詳細については%2$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21100,9 +20560,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な"
-"情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
+msgstr "この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21112,15 +20570,14 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI Chat（%1$s）で生成されま"
-"した。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細"
-"については%4$sを参照してください）。"
+"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI "
+"Chat（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "このデバイス"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21130,7 +20587,7 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr ""
+msgstr "このデバイスは、他のデバイスの同期データにアクセスできなくなります。直近%1$s件のチャットはローカルストレージで引き続き利用可能です。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21162,8 +20619,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21171,8 +20627,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21203,18 +20658,14 @@ msgstr "この画像は作成できませんでした。"
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
-"さい。"
+msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
-"さい。"
+msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21225,7 +20676,7 @@ msgstr "この情報は役に立たない"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "これは共有されたチャットのコピーです。"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21233,9 +20684,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
-"これはサンプルチャットです。メニュー（3つの点）を開き、「ピン留め」を選択する"
-"と、チャットの先頭に固定できます！"
+msgstr "これはサンプルチャットです。メニュー（3つの点）を開き、「ピン留め」を選択すると、チャットの先頭に固定できます！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21243,9 +20692,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
-"これはサンプルチャットです。サイドメニューのFire Buttonを使って削除してくださ"
-"い！"
+msgstr "これはサンプルチャットです。サイドメニューのFire Buttonを使って削除してください！"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21265,9 +20712,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除しま"
-"す。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
+msgstr "このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除します。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21275,9 +20720,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"このモデルプロバイダーはこのチャットに関連するデータを保存していません。他の"
-"モデルプロバイダーは限定的なデータ保持モデルを採用しています。"
+msgstr "このモデルプロバイダーはこのチャットに関連するデータを保存していません。他のモデルプロバイダーは限定的なデータ保持モデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21313,9 +20756,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後"
-"でどのブラウザからでもアクセスできます。"
+msgstr "チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後でどのブラウザからでもアクセスできます。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21323,9 +20764,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
-"すると、AI支援の回答が再表示されることがあります。"
+msgstr "この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21335,21 +20774,21 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
-"すると、AI支援の回答が再表示されることがあります。ただし、%1$s にはAI支援の回"
-"答が一切表示されないスタートページもご用意しています。"
+""
+"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。ただし、%1$s "
+"にはAI支援の回答が一切表示されないスタートページもご用意しています。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "この共有チャットを開くことができませんでした。リンクが不完全な可能性があります。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "この共有チャットリンクは利用できなくなりました。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21372,16 +20811,13 @@ msgstr "この翻訳は正しくありません"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能で"
-"す。"
+msgstr "この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能です。"
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
+msgstr "このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21391,9 +20827,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除さ"
-"れ、Sync & Backupとの接続は解除されます。Sync & Backupに接続している他のブラ"
-"ウザでは、引き続きチャットにアクセスできます。"
+"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除され、Sync & Backupとの接続は解除されます。Sync & "
+"Backupに接続している他のブラウザでは、引き続きチャットにアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21401,9 +20836,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。こ"
-"の操作は取り消せません。"
+msgstr "これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。この操作は取り消せません。"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21540,9 +20973,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印"
-"刷アイコンをクリックします。%4$s"
+msgstr "ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印刷アイコンをクリックします。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21551,10 +20982,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"同期したデータを復元するには、同期を初めて設定したときに保存したリカバリー"
-"コードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保"
-"存されている可能性があります。"
+msgstr "同期したデータを復元するには、同期を初めて設定したときに保存したリカバリーコードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保存されている可能性があります。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21562,18 +20990,14 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアッ"
-"プデートし、再度お試しください。"
+msgstr "チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアップデートし、再度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr ""
-"音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるよ"
-"うに設定してください。"
+msgstr "音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるように設定してください。"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21595,9 +21019,7 @@ msgstr "今日"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"トグルを切り替えてプライベートAIチャットを試すか、%1$s%2$sメニューで無効にで"
-"きます。%3$s"
+msgstr "トグルを切り替えてプライベートAIチャットを試すか、%1$s%2$sメニューで無効にできます。%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21770,9 +21192,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、"
-"ブロック件数が表示されるようになります。"
+msgstr "DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、ブロック件数が表示されるようになります。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21819,9 +21239,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって"
-"行けばいいですか？」"
+msgstr "この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21829,9 +21247,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行け"
-"ばいいですか？」"
+msgstr "この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21939,8 +21355,7 @@ msgstr "%1$sを試す"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr ""
-"このようなメッセージが表示されないようにするには、%1$sをお試しください。"
+msgstr "このようなメッセージが表示されないようにするには、%1$sをお試しください。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -21950,9 +21365,7 @@ msgstr "プロバイダーの可視性がゼロの最初のモデル%1$sをお�
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試し"
-"を！"
+msgstr "%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試しを！"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -21999,7 +21412,7 @@ msgstr "無料で試す"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "無料で試す"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22081,16 +21494,13 @@ msgstr "別のキーワードを試してみてください。"
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しく"
-"ださい。"
+msgstr "より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しください。"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
+msgstr "検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22121,7 +21531,7 @@ msgstr "無料で試す"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "無料で試す"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22223,8 +21633,7 @@ msgstr "位置情報を手動で設定してみてください。"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
+msgstr "%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22282,8 +21691,7 @@ msgstr "最近追加されたオープンソースのLlama 3.1とMixtralをお�
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
+msgstr "まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22370,7 +21778,7 @@ msgstr "トルクメニスタン"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "オフにする"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22388,7 +21796,7 @@ msgstr "Sync & Backupをオフにする"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Sync & Backupをオフにしてサーバーデータを削除しますか？"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22477,8 +21885,7 @@ msgstr "より正確な結果を得るには、「正確な位置情報」をオ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
+msgstr "より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22522,17 +21929,14 @@ msgstr "「%1$sDuckDuckGo%2$s」と %3$s フォームの最初のフィールド
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Type %sduckduckgo.com%s in the %ssecond form field"
-msgstr ""
-"「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
+msgstr "「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索して"
-"から回答が表示されるまでに、多少タイムラグが生じる場合があります。"
+msgstr "DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索してから回答が表示されるまでに、多少タイムラグが生じる場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22661,18 +22065,14 @@ msgstr "長所と短所を明らかにする"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$s"
-"ページがセレクト%6$s クリックします。"
+msgstr "%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$sページがセレクト%6$s クリックします。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと"
-"入力してください"
+msgstr "%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと入力してください"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22682,8 +22082,7 @@ msgstr "%1$s開く%2$s の中から %3$s特定のページを開く%4$s を選�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
+msgstr "%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22693,17 +22092,13 @@ msgstr "%1$s検索設定%2$sで、%3$sDuckDuckGo%4$sを選択します"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$s"
-"を選択します"
+msgstr "%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$sを選択します"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックし"
-"ます"
+msgstr "%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックします"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22792,9 +22187,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上"
-"限がPlusプランの2倍になります。"
+msgstr "Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上限がPlusプランの2倍になります。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22854,9 +22247,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょ"
-"う。%1$s"
+msgstr "DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょう。%1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -22874,7 +22265,7 @@ msgstr "ミュート解除"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "無題のチャット"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22915,7 +22306,7 @@ msgstr "ブラウザを更新"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "この共有チャットを表示するには、Duck.aiをアップデートしてください。"
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22953,9 +22344,7 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr ""
-"DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度な"
-"モデルにアクセスしよう"
+msgstr "DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度なモデルにアクセスしよう"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23079,9 +22468,7 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr ""
-"ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像"
-"を作成してください。"
+msgstr "ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像を作成してください。"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -23182,10 +22569,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、"
-"詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必"
-"要ありません。"
+msgstr "ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必要ありません。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23197,8 +22581,7 @@ msgstr "DuckDuckGo Private Searchを使う"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
+msgstr "あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23240,18 +22623,14 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr ""
-"デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大"
-"切に保管してください。"
+msgstr "デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大切に保管してください。"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr ""
-"デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを"
-"復元してください。"
+msgstr "デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを復元してください。"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23400,9 +22779,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは "
-"Microsoft の広告ネットワークで管理されています"
+msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは Microsoft の広告ネットワークで管理されています"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23410,9 +22787,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは"
-"TripAdvisorの広告ネットワークで管理されています。"
+msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックはTripAdvisorの広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23423,9 +22798,7 @@ msgstr "ヴァージン諸島"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr ""
-"この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセ"
-"スしてください。"
+msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23433,9 +22806,7 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr ""
-"この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにア"
-"クセスしてください。"
+msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23443,9 +22814,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従って"
-"ください。"
+msgstr "タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従ってください。"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23460,9 +22829,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してくださ"
-"い。"
+"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s "
+"に進み、%7$s別のデバイスと同期%8$sを選択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23471,10 +22839,7 @@ msgid ""
 "Visit Duck.ai in your other browser and open Duck.ai Settings. Select “Turn "
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
-msgstr ""
-"別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆"
-"Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。ま"
-"たは、リカバリーPDFのQRコードをスキャンしてください。"
+msgstr "別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。または、リカバリーPDFのQRコードをスキャンしてください。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23484,9 +22849,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s "
-"> %3$sSync & Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選"
-"択してください。"
+"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23495,10 +22859,7 @@ msgid ""
 "Visit Duck.ai in your other browser or the DuckDuckGo app and open Duck.ai "
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
-msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開き"
-"ます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択しま"
-"す。または、リカバリーPDFのQRコードをスキャンします。"
+msgstr "他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開きます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択します。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23550,9 +22911,7 @@ msgstr "ボイスチャットは終了しました"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用"
-"されません。"
+msgstr "ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23696,8 +23055,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、"
-"YouTube のおすすめに影響されずに動画を視聴できます。"
+"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、YouTube "
+"のおすすめに影響されずに動画を視聴できます。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23716,11 +23075,7 @@ msgid ""
 "because we have to stream the content from there. DuckDuckGo is an "
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
-msgstr ""
-"このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテン"
-"ツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGo"
-"は独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ござ"
-"いません。"
+msgstr "このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテンツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGoは独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ございません。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23732,8 +23087,7 @@ msgstr "匿名化に対応"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
+msgstr "%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23744,10 +23098,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
-"当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報する"
-"には、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してし"
-"てください。"
+msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報するには、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してしてください。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23758,9 +23109,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する"
-"場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
+msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23773,9 +23122,7 @@ msgstr "匿名の%1$s位置情報%2$sを使用すると、おおよその結果�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることがで"
-"きません。"
+msgstr "添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることができません。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23802,9 +23149,7 @@ msgstr "私たちはあなたの個人情報を保存しません。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr ""
-"個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束"
-"します。"
+msgstr "個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束します。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23817,9 +23162,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った"
-"理由」を教えてください。"
+msgstr "私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23827,9 +23170,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと"
-"思った理由」を教えてください。"
+msgstr "私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23868,23 +23209,18 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr ""
-"私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であ"
-"なたを追跡して、それを広告主に販売することはありません。"
+msgstr "私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であなたを追跡して、それを広告主に販売することはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しま"
-"せん。"
+msgstr "私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しません。"
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
+msgstr "私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23898,7 +23234,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr ""
+msgstr "データブローカーサイトから個人情報を探して削除します。さらにVPNなどの機能もご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23906,8 +23242,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
+msgstr "チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23931,9 +23266,7 @@ msgstr "接続が失われました。メッセージの送信をもう一度お
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr ""
-"私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索"
-"広告%2$sから収益を得ています。"
+msgstr "私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索広告%2$sから収益を得ています。"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23941,9 +23274,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されま"
-"す。この設定は後でいつでも変更できます。"
+msgstr "匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されます。この設定は後でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -23951,15 +23282,13 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr ""
+msgstr "当社はデータブローカーサイトを定期的にスキャンしてお客様の個人情報を検索し、使いやすいダッシュボードで進捗状況を共有します。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名"
-"でのフィードバックを頼りにしています。"
+msgstr "DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名でのフィードバックを頼りにしています。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23979,9 +23308,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご"
-"提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
+msgstr "このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23994,7 +23321,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr ""
+msgstr "データブローカーサイトをスキャンして、お客様のメールアドレス、名前、住所などを探し、見つかった個人情報の削除に向けて対応します。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24002,9 +23329,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエ"
-"ラーが続く場合は、%1$sに連絡してください。"
+msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエラーが続く場合は、%1$sに連絡してください。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24012,9 +23337,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウ"
-"ザのキャッシュをクリアすると解決に役立つ場合があります。"
+msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウザのキャッシュをクリアすると解決に役立つ場合があります。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24028,9 +23351,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力していま"
-"す。"
+msgstr "ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力しています。"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24038,9 +23359,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr ""
-"Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要"
-"があります。"
+msgstr "Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要があります。"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24161,9 +23480,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのト"
-"レーニングには使用されません。"
+msgstr "Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24171,9 +23488,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、"
-"AIモデルのトレーニングには使用されません。"
+msgstr "DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24183,17 +23498,14 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chatへようこそ！このチャットセッションは%1$sの%2$sを使用してい"
-"ます。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルの"
-"トレーニングに使用されたりすることはありません。"
+"DuckDuckGo AI "
+"Chatへようこそ！このチャットセッションは%1$sの%2$sを使用しています。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルのトレーニングに使用されたりすることはありません。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになり"
-"ました。"
+msgstr "新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになりました。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24260,9 +23572,7 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr ""
-"申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込"
-"みしてみてください。"
+msgstr "申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込みしてみてください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24276,9 +23586,7 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr ""
-"プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありま"
-"すか？"
+msgstr "プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24298,9 +23606,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をど"
-"う言い換えられますか？"
+msgstr "「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をどう言い換えられますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24312,7 +23618,7 @@ msgstr "年金の長所と短所は何ですか？"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Duck.aiのメリットは何ですか？"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24324,12 +23630,7 @@ msgid ""
 "ai integrations, and privacy protections. Keep it quite short, simple, and "
 "easy to understand for people with or without much AI, or technical, "
 "experience."
-msgstr ""
-"Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメ"
-"リットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回"
-"答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に"
-"重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、"
-"誰でも簡単に理解できるように回答します。"
+msgstr "Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメリットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、誰でも簡単に理解できるように回答します。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24564,9 +23865,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットと"
-"の違いは？"
+msgstr "Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットとの違いは？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24666,9 +23965,7 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr ""
-"初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何です"
-"か？"
+msgstr "初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何ですか？"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24868,9 +24165,7 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr ""
-"Duck.aiでは、チャットは匿名化されており、AIのトレーニングに使用されることはあ"
-"りません。「%1$s」メニューでいつでもオン/オフを切り替えられます。"
+msgstr "Duck.aiでは、チャットは匿名化されており、AIのトレーニングに使用されることはありません。「%1$s」メニューでいつでもオン/オフを切り替えられます。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24884,7 +24179,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
-msgstr ""
+msgstr "お使いのデバイス上で直接動作し、データブローカーサイトからメールアドレス、名前、住所などの個人情報を削除します。"
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25151,9 +24446,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合"
-"があります。"
+msgstr "%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25161,9 +24454,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検"
-"索できます。"
+msgstr "%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検索できます。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25176,8 +24467,7 @@ msgstr "DuckDuckGo AI Chatには%1$sから直接アクセスできます。"
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
+msgstr "%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25185,22 +24475,17 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr ""
-"Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
+msgstr "Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできま"
-"す。"
+msgstr "%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr ""
-"%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりする"
-"こともできます。"
+msgstr "%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25213,9 +24498,7 @@ msgstr "添付するテキストは最大%1$sまで選択できます。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりで"
-"きます。"
+msgstr "Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25235,9 +24518,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任"
-"意で削除できます。"
+msgstr "設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任意で削除できます。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25266,8 +24547,7 @@ msgstr "月間制限時間を使ってチャットを続行できます。"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
+msgstr "このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25330,9 +24610,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトの"
-"ブロックを解除する必要があります。"
+msgstr "最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトのブロックを解除する必要があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25387,7 +24665,7 @@ msgstr "あと1回試行できます。"
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "共有チャットリンクはありません。"
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25395,8 +24673,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
+msgstr "これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25404,9 +24681,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスク"
-"リプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
+msgstr "高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスクリプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25427,10 +24702,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
-"チャットはローカルストレージで引き続き利用可能です。これにより、暗号化された"
-"サーバーからチャットデータが削除されることはありません。"
+msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。これにより、暗号化されたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25439,10 +24711,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
-"チャットはローカルストレージで引き続き利用可能です。この操作により、暗号化さ"
-"れたサーバーからチャットデータが削除されることはありません。"
+msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。この操作により、暗号化されたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25455,8 +24724,7 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr ""
-"最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
+msgstr "最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -25470,10 +24738,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを"
-"使ってもプライベートに閲覧できます。このアプリはすでにインストールされてお"
-"り、以下が可能になります。"
+msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを使ってもプライベートに閲覧できます。このアプリはすでにインストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25485,9 +24750,7 @@ msgstr "あなたは今、匿名で検索しています！"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡を"
-"もっと減らすヒントを学びましょう。"
+msgstr "今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡をもっと減らすヒントを学びましょう。"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25536,8 +24799,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
+msgstr "現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25550,14 +24812,12 @@ msgstr "1回のセッションの最大ボイスチャット時間に達しま�
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
+msgstr "本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
+msgstr "ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25566,9 +24826,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"添付ファイル付きのDuck.aiチャットのSync & Backup用ストレージ容量が不足してい"
-"ます。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされ"
-"たチャットは削除されません。"
+"添付ファイル付きのDuck.aiチャットのSync & "
+"Backup用ストレージ容量が不足しています。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25578,9 +24837,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.aiチャットのSync & Backup用ストレージ容量が不足しています。同期を再開す"
-"るには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留め"
-"されたチャットは削除されません。"
+"Duck.aiチャットのSync & "
+"Backup用ストレージ容量が不足しています。同期を再開するには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25593,9 +24851,7 @@ msgstr "ストレージの容量がいっぱいです"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録"
-"されています。"
+msgstr "YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録されています。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25616,14 +24872,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
+msgstr "最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Duck.aiのチャットは、エンドツーエンド暗号化で同期されています。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25654,7 +24910,7 @@ msgctxt "First body paragraph in the Delete Server Data confirmation modal"
 msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
-msgstr ""
+msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25663,10 +24919,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
-"同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージ"
-"に保存されます。"
+msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25675,10 +24928,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
-"同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルスト"
-"レージに保存されます。"
+msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25702,18 +24952,14 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr ""
-"お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGo"
-"がこのデータにアクセスすることはありません。"
+msgstr "お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGoがこのデータにアクセスすることはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、"
-"DuckDuckGoはこのデータにアクセスすることはできません。"
+msgstr "ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、DuckDuckGoはこのデータにアクセスすることはできません。"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25721,9 +24967,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示さ"
-"れる場合があります。"
+msgstr "%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25735,50 +24979,41 @@ msgstr "チャットが保存されるようになりました。"
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr ""
-"チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはあ"
-"りません。"
+msgstr "チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
+msgstr "チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
-"されません。"
+msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
-"されません。"
+msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25792,9 +25027,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されま"
-"せん。チャット履歴を保持するには、以下の手順に従ってください。"
+msgstr "チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されません。チャット履歴を保持するには、以下の手順に従ってください。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25802,8 +25035,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
+msgstr "チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25834,9 +25066,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検"
-"索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
+msgstr "あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25879,10 +25109,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) を使用した512ビットの"
-"キーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残りま"
-"す。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo がお客様の"
-"パスフレーズを知ることはありません。"
+"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) "
+""
+"を使用した512ビットのキーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残ります。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo "
+"がお客様のパスフレーズを知ることはありません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25896,10 +25126,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータ"
-"が取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはで"
-"きません。"
+msgstr "プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータが取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはできません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25912,9 +25139,7 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr ""
-"最近のチャットはここにあります！チャットはいつでも参照したり、消去したりでき"
-"ます。"
+msgstr "最近のチャットはここにあります！チャットはいつでも参照したり、消去したりできます。"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25946,8 +25171,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に"
-"保存するには、%1$sDuckDuckGo No AI%2$s拡張機能を有効にしてください。"
+"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に保存するには、%1$sDuckDuckGo No "
+"AI%2$s拡張機能を有効にしてください。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25956,9 +25181,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に"
-"保存するには、%1$sDuckDuckGo No AI%2$s拡張機能をインストールしてくださ"
-"い。%3$s詳細情報%4$s"
+"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に保存するには、%1$sDuckDuckGo No "
+"AI%2$s拡張機能をインストールしてください。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25977,10 +25201,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウ"
-"ザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにイン"
-"ストールされており、以下が可能になります。"
+msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにインストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25988,9 +25209,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直して"
-"ください。"
+msgstr "メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25998,9 +25217,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして"
-"続行します。"
+msgstr "この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして続行します。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26008,9 +25225,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始"
-"します。"
+msgstr "この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始します。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26024,15 +25239,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr "1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
+msgstr "ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26115,9 +25328,7 @@ msgstr "（%1$s）"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されて"
-"います。"
+msgstr "DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されています。"
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26330,9 +25541,7 @@ msgstr "公式ウェブサイト"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードし"
-"たものです)"
+msgstr "あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードしたものです)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ja_JP\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "ワクチン接種完了率 (%)"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "ワクチン接種率 (%)"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -181,7 +189,10 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
+msgstr ""
+"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
+"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -190,7 +201,10 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
+msgstr ""
+"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
+"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -205,7 +219,10 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr "%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるには、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替えてください。"
+msgstr ""
+"%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるに"
+"は、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替え"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -213,7 +230,9 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直してください。"
+msgstr ""
+"%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直し"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -310,8 +329,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$sはTrusted Execution "
-"Environmentで動作します。つまり、モデルプロバイダーでさえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサーバーに保存することもできません。"
+"%1$sはTrusted Execution Environmentで動作します。つまり、モデルプロバイダーで"
+"さえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサー"
+"バーに保存することもできません。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -396,7 +416,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr "%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
+msgstr ""
+"%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替え"
+"てこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -406,7 +428,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
+msgstr ""
+"%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えて"
+"このチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -418,7 +442,9 @@ msgstr "%1$s単語"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$sをクリックしてください"
+msgstr ""
+"%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$s"
+"をクリックしてください"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -426,8 +452,8 @@ msgstr "%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェ�
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$sボックスをオンにしてから "
-"%8$sOK%9$sをクリックしてください"
+"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$s"
+"ボックスをオンにしてから %8$sOK%9$sをクリックしてください"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -437,8 +463,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sインストールを続行%3$sをクリックして "
-"%4$s追加ボタン%5$sを押し、%6$s許可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
+"%1$s%2$sインストールを続行%3$sをクリックして %4$s追加ボタン%5$sを押し、%6$s許"
+"可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -446,7 +472,9 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr "この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう一度試します。"
+msgstr ""
+"この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう"
+"一度試します。"
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -464,14 +492,24 @@ msgstr "%1$sさらに詳しく%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
+msgstr ""
+"%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
+
+# smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこちら%2$sをご覧ください。"
+msgstr ""
+"DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこち"
+"ら%2$sをご覧ください。"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -489,7 +527,8 @@ msgstr "ホーム画面でDuckDuckGoのアプリアイコンを%1$s長押し%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
+msgstr ""
+"%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -753,6 +792,12 @@ msgid "2nd in Group %s"
 msgstr "グループ%1$sの2位"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -841,7 +886,8 @@ msgstr "6時間の使用制限に達しました。このチャットは%1$s以�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr "6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
+msgstr ""
+"6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -894,21 +940,27 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "ネットワークの問題により、Search Assistは回答を生成できません。接続を確認して、もう一度試してください。"
+msgstr ""
+"ネットワークの問題により、Search Assistは回答を生成できません。接続を確認し"
+"て、もう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてください。"
+msgstr ""
+"AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてください。"
+msgstr ""
+"Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -952,8 +1004,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフにすると、DuckDuckGo SearchのAI "
-"Chat機能は非表示になりますが、%1$sduckduckgo.com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
+"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフ"
+"にすると、DuckDuckGo SearchのAI Chat機能は非表示になりますが、%1$sduckduckgo."
+"com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1013,7 +1066,11 @@ msgid ""
 "However, we also offer and often link to %sDuck.ai%s for follow-up "
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
-msgstr "AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただし、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供しています。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活用したプライベートチャットサービスです。"
+msgstr ""
+"AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただ"
+"し、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供して"
+"います。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活"
+"用したプライベートチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1197,7 +1254,9 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr "チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切り替えてください。"
+msgstr ""
+"チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切"
+"り替えてください。"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1232,14 +1291,18 @@ msgstr "広告"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr "広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
+msgstr ""
+"広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファ"
+"イリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr "広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
+msgstr ""
+"広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロ"
+"ファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1289,7 +1352,9 @@ msgstr "DuckDuckGo拡張機能を追加"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加できます："
+msgstr ""
+"DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加でき"
+"ます："
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1416,6 +1481,12 @@ msgid "Add to Home Screen"
 msgstr "ホーム画面に追加"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "アドオン"
@@ -1516,7 +1587,9 @@ msgctxt ""
 "model picker dropdown"
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
-msgstr "高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性があります。%1$s"
+msgstr ""
+"高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性がありま"
+"す。%1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1524,7 +1597,9 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性があります。%1$s"
+msgstr ""
+"高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性がありま"
+"す。%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1560,13 +1635,16 @@ msgstr "アフリカーンス語"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
+msgstr ""
+"ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールしてください"
+msgstr ""
+"ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールして"
+"ください"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1701,7 +1779,9 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr "すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供元が学習内容をチャットモデルの学習に利用することはありません"
+msgstr ""
+"すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供"
+"元が学習内容をチャットモデルの学習に利用することはありません"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1733,7 +1813,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されています。"
+msgstr ""
+"すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されてい"
+"ます。"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1747,7 +1829,9 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr "AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスなど）が削除されます。"
+msgstr ""
+"AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスな"
+"ど）が削除されます。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1768,6 +1852,13 @@ msgid "All types"
 msgstr "すべての種類"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1778,7 +1869,9 @@ msgstr "許可"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr "ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可してください。"
+msgstr ""
+"ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可"
+"してください。"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1809,14 +1902,19 @@ msgid ""
 "Allows %s to search the web to improve responses to relevant prompts. Only "
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
-msgstr "%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$sのプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
+msgstr ""
+"%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。"
+"AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$s"
+"のプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr "デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する場合に必須)"
+msgstr ""
+"デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する"
+"場合に必須)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1953,7 +2051,9 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
+msgstr ""
+"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
+"セスできます。"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1961,7 +2061,9 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
+msgstr ""
+"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
+"セスできます。"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1974,7 +2076,9 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr "ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選択するか、完全に無効にすることができます。"
+msgstr ""
+"ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選"
+"択するか、完全に無効にすることができます。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2020,7 +2124,9 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr "Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教えてください"
+msgstr ""
+"Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教"
+"えてください"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2139,7 +2245,9 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr "履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むすべてのチャットが削除されます。"
+msgstr ""
+"履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むす"
+"べてのチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2147,7 +2255,9 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr "最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている最近のチャットも削除されます。"
+msgstr ""
+"最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている"
+"最近のチャットも削除されます。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2184,7 +2294,9 @@ msgstr "最終更新："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr "私達はプライバシーポリシーに従って、個人情報を収集または共有することはありません。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
+msgstr ""
+"私達はプライバシーポリシーに従って、個人情報を収集または共有することはありま"
+"せん。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2265,6 +2377,12 @@ msgid "Ask anything privately"
 msgstr "非公開でなんでも聞いてください"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2320,9 +2438,12 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-""
-"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist "
-"UIを完全に削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できます。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
+"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿"
+"名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist UIを完全に"
+"削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回"
+"答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻"
+"繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できま"
+"す。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2333,7 +2454,12 @@ msgid ""
 "generate a brief answer based on relevant information found. It’s important "
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
-msgstr "Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
+msgstr ""
+"Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプ"
+"ション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活"
+"用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答"
+"は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されるこ"
+"とを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2358,7 +2484,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr "DuckDuckGo VPNは、カフェ、空港、ホテルでのWi-Fi接続を暗号化し、IPアドレスを非表示にして保護します。"
+msgstr ""
+"DuckDuckGo VPNは、カフェ、空港、ホテルでのWi-Fi接続を暗号化し、IPアドレスを非"
+"表示にして保護します。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2432,7 +2560,8 @@ msgstr "チャット終了後、音声は当社または OpenAI によって保�
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
+msgstr ""
+"チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2473,18 +2602,24 @@ msgstr "自動応答"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があります。"
+msgstr ""
+"リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があ"
+"ります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる場合があります。"
+msgstr ""
+"リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる"
+"場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr "ソースに基づき自動生成されています。内容に不正確な部分を含む可能性があります。"
+msgstr ""
+"ソースに基づき自動生成されています。内容に不正確な部分を含む可能性がありま"
+"す。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2503,7 +2638,10 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr "関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能です。"
+msgstr ""
+"関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して"
+"情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能で"
+"す。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2512,14 +2650,16 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"関連する検索に DuckAssist "
-"を自動表示します。このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ利用可能です。"
+"関連する検索に DuckAssist を自動表示します。このツールを使用すると、一部の検"
+"索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ"
+"利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
+msgstr ""
+"動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2718,7 +2858,9 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr "このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータなどのPIIを削除することで、会話を匿名化します。"
+msgstr ""
+"このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータ"
+"などのPIIを削除することで、会話を匿名化します。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2847,12 +2989,15 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr "DuckDuckGoのサブスクリプションなら、有害サイトのブロックやIPアドレスの非表示などのプレミアム保護を利用できます。"
+msgstr ""
+"DuckDuckGoのサブスクリプションなら、有害サイトのブロックやIPアドレスの非表示"
+"などのプレミアム保護を利用できます。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
+msgstr ""
+"ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3106,20 +3251,28 @@ msgstr "ファイルを参照"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$sにまとめました。"
+msgstr ""
+"DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索"
+"エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$s"
+"にまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
+msgstr ""
+"いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、"
+"高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr "いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロック、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウンロードしましょう。"
+msgstr ""
+"いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロッ"
+"ク、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウン"
+"ロードしましょう。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3205,7 +3358,8 @@ msgstr "「%1$s」をクリックすると、当社の%2$sに同意したこと�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
+msgstr ""
+"「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3226,16 +3380,19 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に保存されます。匿名の Cloud Save "
-"機能を利用すると、設定情報を (クラウド上のリモートサーバーに) "
-"より長期的に保存できます。個人を特定できる情報がクラウドに保存されたり、パスフレーズがブラウザ上に残ることもありません。"
+"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に"
+"保存されます。匿名の Cloud Save 機能を利用すると、設定情報を (クラウド上のリ"
+"モートサーバーに) より長期的に保存できます。個人を特定できる情報がクラウドに"
+"保存されたり、パスフレーズがブラウザ上に残ることもありません。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
+msgstr ""
+"音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信される"
+"ことに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3244,8 +3401,9 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI "
-"に送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
+"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI に送信"
+"されることに同意したことになります。開始する間に当社の%1$sを確認してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3600,7 +3758,8 @@ msgstr "サイト全体の背景色を変更する"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
+msgstr ""
+"マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3729,10 +3888,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"チャット（Duck.ai "
-""
-"サービス経由）を通じて、OpenAI、AnthropicなどのサードパーティのAIチャットモデルと匿名で会話することができます。この設定をオフにすると、DuckDuckGo "
-"Searchのチャットボタンとリンクが非表示になります。ただし、この設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用できます。"
+"チャット（Duck.ai サービス経由）を通じて、OpenAI、Anthropicなどのサードパー"
+"ティのAIチャットモデルと匿名で会話することができます。この設定をオフにする"
+"と、DuckDuckGo Searchのチャットボタンとリンクが非表示になります。ただし、この"
+"設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用"
+"できます。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3787,14 +3947,18 @@ msgstr "プライベートチャット"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートにチャットできます。"
+msgstr ""
+"無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートに"
+"チャットできます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプライベートにチャットできます。"
+msgstr ""
+"無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプラ"
+"イベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3862,7 +4026,10 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスにローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが削除されます。"
+msgstr ""
+"チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスに"
+"ローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが"
+"削除されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3873,7 +4040,12 @@ msgid ""
 "help recover a chat if you lose your internet connection. Disabling chat "
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
-msgstr "チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
+msgstr ""
+"チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗"
+"号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インター"
+"ネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にする"
+"と、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効"
+"になります。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3895,14 +4067,19 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr "%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロバイダーによって匿名でレビューされます。"
+msgstr ""
+"%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップ"
+"ロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロ"
+"バイダーによって匿名でレビューされます。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr "添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはストレージを解放してください。"
+msgstr ""
+"添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはスト"
+"レージを解放してください。"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -3961,7 +4138,8 @@ msgstr "この障害に関する最新情報は、DuckDuckGoのサブレディ�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "この停止に関する最新情報については、ステータスページを確認してください。"
+msgstr ""
+"この停止に関する最新情報については、ステータスページを確認してください。"
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4026,7 +4204,8 @@ msgstr "%1$sや%2$sを含むAIモデルの選択"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
+msgstr ""
+"%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4057,7 +4236,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
-msgstr "VPNサーバーは世界中に40以上あり、都合の良い場所を選択して、有害サイトや詐欺サイトをブロックできます。"
+msgstr ""
+"VPNサーバーは世界中に40以上あり、都合の良い場所を選択して、有害サイトや詐欺サ"
+"イトをブロックできます。"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4255,8 +4436,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最近のチャットが無期限に保存される場合、またはAI "
-"Chatの未使用期間が7日を超えると自動的に削除される場合があります。"
+"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最"
+"近のチャットが無期限に保存される場合、またはAI Chatの未使用期間が7日を超える"
+"と自動的に削除される場合があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4265,7 +4447,10 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr "ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあります。ブラウザによって異なります。"
+msgstr ""
+"ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは"
+"無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあ"
+"ります。ブラウザによって異なります。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4273,7 +4458,9 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr "ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリストを当社の無料ブラウザに"
+msgstr ""
+"ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリ"
+"ストを当社の無料ブラウザに"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4281,7 +4468,11 @@ msgid ""
 "Click \"More\" to go deeper on a topic, and ask follow-up questions via "
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
-msgstr "「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。また、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなどのチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用できます。"
+msgstr ""
+"「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。ま"
+"た、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなど"
+"のチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用で"
+"きます。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4322,7 +4513,9 @@ msgstr "一覧から%1$s検索設定の変更%2$sをクリックしてくださ�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr "%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてください"
+msgstr ""
+"%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてく"
+"ださい"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4333,12 +4526,15 @@ msgstr "%1$sここ%2$sをクリックして検索エンジンとして追加し�
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo browser extension to Safari.
 msgid "Click %sHere%s to download the DuckDuckGo extension"
-msgstr "%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
+msgstr ""
+"%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
 
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてください"
+msgstr ""
+"%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてくださ"
+"い"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4352,7 +4548,9 @@ msgstr "左側のサイドバーにある%1$sプライバシーとサービス%2
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr "%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、右上の%3$s歯車アイコン%4$sをクリックしてください)"
+msgstr ""
+"%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、"
+"右上の%3$s歯車アイコン%4$sをクリックしてください)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4381,7 +4579,8 @@ msgstr "%1$sはい%2$sをクリックしてください"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
+msgstr ""
+"Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4417,7 +4616,8 @@ msgstr "下のほうの %1$sデフォルトに設定%2$s をクリックしま�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr "アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
+msgstr ""
+"アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4442,7 +4642,10 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr "「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がクリックまたはタップされるまでブラウザに残ります。"
+msgstr ""
+"「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作"
+"によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がク"
+"リックまたはタップされるまでブラウザに残ります。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4452,7 +4655,10 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr "%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはクラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップしない限り、お使いのブラウザに保存されたままとなります。"
+msgstr ""
+"%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはク"
+"ラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップし"
+"ない限り、お使いのブラウザに保存されたままとなります。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4520,14 +4726,18 @@ msgstr "検索ボックスの選択項目をクリック"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr "%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューをクリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
+msgstr ""
+"%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューを"
+"クリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr "広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機能のアイコンはブラウザの右上隅に表示されています。"
+msgstr ""
+"広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機"
+"能のアイコンはブラウザの右上隅に表示されています。"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4727,7 +4937,9 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr "パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能を使うかどうかはあなた次第。強制ではありません。"
+msgstr ""
+"パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能"
+"を使うかどうかはあなた次第。強制ではありません。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -4998,7 +5210,9 @@ msgstr "広告ブロックを継続"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "最近のチャットはここから再開できます。または、Fire Buttonで削除することもできます。"
+msgstr ""
+"最近のチャットはここから再開できます。または、Fire Buttonで削除することもでき"
+"ます。"
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5102,6 +5316,12 @@ msgid "Copy"
 msgstr "コピー"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5110,7 +5330,8 @@ msgstr "コピー"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
+msgstr ""
+"「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5141,6 +5362,28 @@ msgstr "このコードをコピーまたは保存"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "リカバリーコードをコピー"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5192,7 +5435,9 @@ msgstr "コスタリカ"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しください。"
+msgstr ""
+"リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5292,7 +5537,9 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr "リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲覧できるようになります。"
+msgstr ""
+"リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲覧"
+"できるようになります。"
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5531,7 +5778,8 @@ msgstr "1日の使用制限に達しました。このチャットは%1$s以降�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr "1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
+msgstr ""
+"1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5807,13 +6055,22 @@ msgstr "ストレージを解放するために最も古いチャットを削除
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
+msgstr ""
+"保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
 msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr "最近のチャットを削除しますか？"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -5826,6 +6083,14 @@ msgstr "このチャットを削除しますか？"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "チャットが削除された"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5921,7 +6186,9 @@ msgstr "Duck.aiの音声入力"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されま"
+"せん。"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5938,7 +6205,9 @@ msgstr "音声入力は一時的に利用できません"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck.aiチャットができます。"
+msgstr ""
+"音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck."
+"aiチャットができます。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6079,6 +6348,13 @@ msgid "Dismiss"
 msgstr "無視する"
 
 # smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
 msgctxt "duckassist"
 msgid "Dismiss"
@@ -6212,13 +6488,15 @@ msgstr "DuckDuckGoがリストにありませんか？"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
+msgstr ""
+"表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr "チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
+msgstr ""
+"チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6249,7 +6527,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供されず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr ""
+"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供さ"
+"れず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6257,7 +6537,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr ""
+"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能"
+"は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6372,7 +6654,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr "シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成します。内容は、簡潔かつ詳細に入力してください。"
+msgstr ""
+"シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成しま"
+"す。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6380,7 +6664,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr "家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容は、簡潔かつ詳細に入力してください。"
+msgstr ""
+"家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容"
+"は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6400,7 +6686,9 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr "今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか作成してください。"
+msgstr ""
+"今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか"
+"作成してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6408,7 +6696,9 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr "チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をいくつか作成してください。"
+msgstr ""
+"チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をい"
+"くつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6542,7 +6832,8 @@ msgid ""
 msgstr ""
 "Duck.aiは、現在表示しているページに関する質問に回答できるようになりました。\n"
 "\n"
-"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したときにのみ含まれます。"
+"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したと"
+"きにのみ含まれます。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6551,7 +6842,10 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr "Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しください。"
+msgstr ""
+"Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。"
+"ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6559,13 +6853,16 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr "Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr ""
+"Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
+msgstr ""
+"Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6574,7 +6871,9 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr "Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻したいユーザーのためにオンライン保護に取り組む独立系企業です。"
+msgstr ""
+"Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻"
+"したいユーザーのためにオンライン保護に取り組む独立系企業です。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6588,7 +6887,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが「https://duck.ai」と覚えやすくなります"
+msgstr ""
+"Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが"
+"「https://duck.ai」と覚えやすくなります"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6602,14 +6903,18 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
+msgstr ""
+"Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」"
+"を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してください。"
+msgstr ""
+"Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6622,7 +6927,10 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr "Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiのボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスできます。"
+msgstr ""
+"Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiの"
+"ボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスで"
+"きます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6633,9 +6941,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-""
-"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデルと匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://duck.ai%2$s "
-"に直接アクセスすることでDuck.aiを利用できます。"
+"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデル"
+"と匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタ"
+"ンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://"
+"duck.ai%2$s に直接アクセスすることでDuck.aiを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6649,7 +6958,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr "Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用できます。"
+msgstr ""
+"Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用"
+"できます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6662,7 +6973,8 @@ msgstr "Duck.aiでPDFを読み、解析できるようになりました。ぜ�
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr "Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
+msgstr ""
+"Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -6686,7 +6998,8 @@ msgstr "Duck.aiがアップグレードしました！"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
+msgstr ""
+"Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6696,8 +7009,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo "
-"AI、プライベートAIチャットボット、無料AIチャット、匿名AIチャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オープンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
+"Duck.ai、DuckDuckGo AI、プライベートAIチャットボット、無料AIチャット、匿名AI"
+"チャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オー"
+"プンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6725,9 +7039,11 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。DuckAssistの表示頻度は、なし（検索結果からDuckAssist "
-"UIを完全に削除）、オンデマンド（[アシスト] "
-"ボタンをクリックした場合にのみ表示）、時々（関連性の高い場合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点では、米国（英語）地域でのみ利用可能です。"
+"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。"
+"DuckAssistの表示頻度は、なし（検索結果からDuckAssist UIを完全に削除）、オンデ"
+"マンド（[アシスト] ボタンをクリックした場合にのみ表示）、時々（関連性の高い場"
+"合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点で"
+"は、米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6736,9 +7052,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他からチャットモデルをサポートするプライベートAI搭載チャットサービス、%1$sDuckDuckGo "
-"AI Chat%2$sもご利用いただけます。"
+"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他か"
+"らチャットモデルをサポートするプライベートAI搭載チャットサービ"
+"ス、%1$sDuckDuckGo AI Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6747,8 +7063,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャットモデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
+"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャット"
+"モデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
 "Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
@@ -6761,9 +7077,11 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 "
-"これを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、AIを活用した自然言語技術を使用して情報の要約を生成します。 "
-"現時点での回答はWikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご注意ください。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 こ"
+"れを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、"
+"AIを活用した自然言語技術を使用して情報の要約を生成します。 現時点での回答は"
+"Wikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご"
+"注意ください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6777,15 +7095,22 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI "
-"を活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssistの回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのため、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション"
+"機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI を活用した"
+"自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssist"
+"の回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのた"
+"め、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成さ"
+"れ、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重"
+"要です。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr "DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認されません。"
+msgstr ""
+"DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認さ"
+"れません。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6793,7 +7118,9 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr "DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr ""
+"DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続"
+"行してください。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6802,8 +7129,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI "
-"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
+"いるプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6812,8 +7139,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI "
-"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
+"いるプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6821,7 +7148,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr "DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される可能性があります。"
+msgstr ""
+"DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される"
+"可能性があります。"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6829,7 +7158,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
+msgstr ""
+"DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード"
+"「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6837,13 +7168,17 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直してください。"
+msgstr ""
+"DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直"
+"してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しください。"
+msgstr ""
+"DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6870,6 +7205,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGoブラウザ%1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6985,14 +7327,18 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr "DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的に削除することで、これらのレポートを匿名化します。"
+msgstr ""
+"DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的"
+"に削除することで、これらのレポートを匿名化します。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに同意したことになります。"
+msgstr ""
+"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに"
+"同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7000,7 +7346,9 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同意したことになります。"
+msgstr ""
+"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同"
+"意したことになります。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7008,7 +7356,9 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr "DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による追跡行為を阻止することができます。"
+msgstr ""
+"DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による"
+"追跡行為を阻止することができます。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7020,8 +7370,12 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する場合、ローカルデバイスだけに保存されます。DuckDuckGo "
-"は検索時にユーザーのデバイスから送信される位置情報を検索結果を向上するために使用します。位置情報は使用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様のプライバシーを保護するため、当社がどのようにこの技術を設計したかについては、こちらをご覧ください%2$s。"
+"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する"
+"場合、ローカルデバイスだけに保存されます。DuckDuckGo は検索時にユーザーのデバ"
+"イスから送信される位置情報を検索結果を向上するために使用します。位置情報は使"
+"用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様の"
+"プライバシーを保護するため、当社がどのようにこの技術を設計したかについては、"
+"こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7040,7 +7394,9 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr "DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
+msgstr ""
+"DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を"
+"表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7131,7 +7487,10 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr "パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～20字のパスフレーズ候補として4、5個の単語が選ばれます。"
+msgstr ""
+"パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載"
+"されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～"
+"20字のパスフレーズ候補として4、5個の単語が選ばれます。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7201,7 +7560,8 @@ msgstr "画像を編集中..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
+msgstr ""
+"メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7338,7 +7698,9 @@ msgstr "ウェブ検索を有効にする"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr "検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後でいつでも変更できます。"
+msgstr ""
+"検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後"
+"でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7380,7 +7742,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
+msgstr ""
+"「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索"
+"データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7498,7 +7862,8 @@ msgstr "位置情報へのアクセスは必ず %1$s許可%2$s にします。"
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
+msgstr ""
+"ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7541,7 +7906,9 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr "新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてください。データが新しいパスフレーズで保存されます。"
+msgstr ""
+"新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてくだ"
+"さい。データが新しいパスフレーズで保存されます。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7566,7 +7933,9 @@ msgstr "テキストを入力"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイリアス%6$s: d%7$s"
+msgstr ""
+"以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイ"
+"リアス%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7669,10 +8038,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "プライバシーを優先するユーザーのために趣向を凝らした商品です。"
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "期限切れ"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7934,7 +8318,9 @@ msgstr "フィードバックが送信されました"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきます。"
+msgstr ""
+"お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7942,14 +8328,19 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用させていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組んで参ります。"
+msgstr ""
+"お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用さ"
+"せていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組ん"
+"で参ります。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆ペーストしてください。"
+msgstr ""
+"以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆"
+"ペーストしてください。"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8067,7 +8458,8 @@ msgstr "金融アドバイザー"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
+msgstr ""
+"%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8079,7 +8471,9 @@ msgstr "ダウンロードフォルダで<b>%1$s</b>を表示"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックします"
+msgstr ""
+"表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックしま"
+"す"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8116,7 +8510,9 @@ msgstr "あなたにとって最も的確な結果を見つけます。"
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されます。"
+msgstr ""
+"お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8179,7 +8575,9 @@ msgstr "霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr "DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオプションを選択したり、ボタンをクリックする必要がある場合があります。"
+msgstr ""
+"DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオ"
+"プションを選択したり、ボタンをクリックする必要がある場合があります。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8326,7 +8724,9 @@ msgstr "営利目的で共有、使用が可能"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されません。"
+msgstr ""
+"チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されませ"
+"ん。"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8407,8 +8807,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; "
-"<strong>[アップデートを確認...]</strong>、次に<strong>[アップデートをインストール]</strong> を選択します。"
+"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; <strong>[アッ"
+"プデートを確認...]</strong>、次に<strong>[アップデートをインストール]</"
+"strong> を選択します。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8694,14 +9095,16 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN、高度なDuck.ai、Personal Information Removal（個人情報の削除）、Identity "
-"Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+"DuckDuckGo VPN、高度なDuck.ai、Personal Information Removal（個人情報の削"
+"除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "DuckDuckGo VPN、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+msgstr ""
+"DuckDuckGo VPN、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機"
+"能を利用できます。"
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8760,7 +9163,9 @@ msgstr "開始"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがですか。"
+msgstr ""
+"VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがです"
+"か。"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8781,8 +9186,9 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ノーログ型高速VPNに加え、高度なAIチャット（オプション）、Personal Information "
-"Removal（個人情報の削除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+"ノーログ型高速VPNに加え、高度なAIチャット（オプション）、Personal "
+"Information Removal（個人情報の削除）、Identity Theft Restoration（ID盗難後の"
+"復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -8790,7 +9196,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr "ノーログ型高速VPNに加え、高度なAIチャット（オプション）Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+msgstr ""
+"ノーログ型高速VPNに加え、高度なAIチャット（オプション）Identity Theft "
+"Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -8798,7 +9206,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これには、VPNやその他のプレミアムなプライバシー保護も含まれています。"
+msgstr ""
+"DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これに"
+"は、VPNやその他のプレミアムなプライバシー保護も含まれています。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8808,7 +9218,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
+msgstr ""
+"DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。"
+"VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8851,7 +9263,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr "ノーログ型高速VPNに加え、高度なAIモデルへのアクセス（コール上限数拡大付きオプション）、その他のプレミアム保護機能を利用できます。"
+msgstr ""
+"ノーログ型高速VPNに加え、高度なAIモデルへのアクセス（コール上限数拡大付きオプ"
+"ション）、その他のプレミアム保護機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -8860,20 +9274,25 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ノーログ型の安全なVPNに加え、高度なDuck.ai、Personal Information Removal（個人情報の削除）、Identity "
-"Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+"ノーログ型の安全なVPNに加え、高度なDuck.ai、Personal Information Removal（個"
+"人情報の削除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "ノーログ型安全なVPNに加え、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+msgstr ""
+"ノーログ型安全なVPNに加え、高度なDuck.ai、Identity Theft Restoration（ID盗難"
+"後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロード："
+msgstr ""
+"ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロー"
+"ド："
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8909,7 +9328,9 @@ msgstr "アプリをダウンロード"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "DuckDuckGoブラウザを無料で入手して、%1$sYouTubeの広告をブロックしましょう。%2$s"
+msgstr ""
+"DuckDuckGoブラウザを無料で入手して、%1$sYouTubeの広告をブロックしましょ"
+"う。%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -8968,8 +9389,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
-"「別のデバイスと同期」 › 「テキストコードをコピー」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
+"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」 › 「テキストコードをコ"
+"ピー」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8978,8 +9400,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
-"「別のデバイスと同期」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
+"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8989,8 +9411,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
-"「別のデバイスと同期」%4$sの順にクリックして、次のコードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
+"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックして、次の"
+"コードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9000,14 +9423,24 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
-"「別のデバイスと同期」%4$sの順にクリックします。または、リカバリーPDFのQRコードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
+"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします。ま"
+"たは、リカバリーPDFのQRコードをスキャンします。"
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
+msgstr ""
+"%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9016,8 +9449,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動し、[位置情報サービス] "
-"がオンになっていることを確認します。"
+"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動"
+"し、[位置情報サービス] がオンになっていることを確認します。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9026,8 +9459,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、[DuckDuckGo] "
-"まで下にスクロールします。%3$s%4$s"
+"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、"
+"[DuckDuckGo] まで下にスクロールします。%3$s%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9112,6 +9545,12 @@ msgstr "了解"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "了解"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9709,7 +10148,8 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr "Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
+msgstr ""
+"Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9736,8 +10176,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"キーボードの %1$s戻る%2$s "
-"キーを押して、%3$sDuckDuckGoをリストに保存します。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
+"キーボードの %1$s戻る%2$s キーを押して、%3$sDuckDuckGoをリストに保存しま"
+"す。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9750,7 +10190,9 @@ msgstr "ミャオ語"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr "ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバシーが保護されなくなります。"
+msgstr ""
+"ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバ"
+"シーが保護されなくなります。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9799,7 +10241,9 @@ msgstr "猛暑"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr "ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様のプロファイリングには使用されません。"
+msgstr ""
+"ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様の"
+"プロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10061,7 +10505,9 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr "私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズはどんなものですか、またその理由は何ですか？"
+msgstr ""
+"私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズは"
+"どんなものですか、またその理由は何ですか？"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10096,8 +10542,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセット] > [位置情報とプライバシー設定をリセット]%2$s "
-"の順に移動します。"
+"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセッ"
+"ト] > [位置情報とプライバシー設定をリセット]%2$s の順に移動します。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10107,8 +10553,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク > [メニュー] > [設定] > [サイト設定] > "
-"[位置情報]%2$s の順に移動し、DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
+"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク "
+"> [メニュー] > [設定] > [サイト設定] > [位置情報]%2$s の順に移動し、"
+"DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10122,7 +10569,9 @@ msgstr "このエラーが続く場合は、%1$sに連絡してください。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追加する必要があります"
+msgstr ""
+"%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追"
+"加する必要があります"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10131,8 +10580,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"チャット "
-"プロバイダーまたは特定のチャット応答についてご不明な点がある場合は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
+"チャット プロバイダーまたは特定のチャット応答についてご不明な点がある場合"
+"は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10140,13 +10589,18 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこのコードが必要になります。このコードはテキストファイルとしてデバイスに保存できます。"
+msgstr ""
+"デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこの"
+"コードが必要になります。このコードはテキストファイルとしてデバイスに保存でき"
+"ます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力ください%2$s"
+msgstr ""
+"もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力くだ"
+"さい%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10155,14 +10609,18 @@ msgstr "もし、私たちをもっとサポートして頂けるなら、%1$sDu
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンをご利用ください。"
+msgstr ""
+"Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンを"
+"ご利用ください。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択してください。"
+msgstr ""
+"ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択して"
+"ください。"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10302,7 +10760,9 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr "古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレクトする必要があります。%1$sさらに詳しく%2$s。"
+msgstr ""
+"古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレ"
+"クトする必要があります。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10312,7 +10772,9 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同期」を選択します。"
+msgstr ""
+"DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同"
+"期」を選択します。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10326,7 +10788,9 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr "情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に保存されている情報を正確に知ることができます。"
+msgstr ""
+"情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に"
+"保存されている情報を正確に知ることができます。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10336,7 +10800,8 @@ msgstr "上部のメニューから%1$sツール%2$s > %3$s設定%4$sを選択"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
+msgstr ""
+"ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10662,7 +11127,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
+msgstr ""
+"この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10730,7 +11196,11 @@ msgid ""
 "Items are ranked based on relevance to your search terms and are delivered "
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
-msgstr "アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告ネットワークを通じて配信されます。クリック後はマーチャントのランディングページに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け取ることはありません。"
+msgstr ""
+"アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告"
+"ネットワークを通じて配信されます。クリック後はマーチャントのランディングペー"
+"ジに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け"
+"取ることはありません。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10738,7 +11208,9 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr "ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっと安全です。"
+msgstr ""
+"ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっ"
+"と安全です。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10810,7 +11282,9 @@ msgstr "両方のデバイスでSync & Backupを開いたままにします。"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr "一度に最大5台のデバイスで、すべてのアプリとオンラインの活動のプライバシーを確保できます。"
+msgstr ""
+"一度に最大5台のデバイスで、すべてのアプリとオンラインの活動のプライバシーを確"
+"保できます。"
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11044,6 +11518,12 @@ msgid "Learn %sMore%s"
 msgstr "詳しくは%1$sこちら%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11216,7 +11696,8 @@ msgstr "DuckDuckGo を使って匿名で検索しましょう"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "検索クエリの送信とDuck.aiへのプロンプトの送信を切り替えることができます。"
+msgstr ""
+"検索クエリの送信とDuck.aiへのプロンプトの送信を切り替えることができます。"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11673,6 +12154,13 @@ msgid "Manage"
 msgstr "管理"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -11924,6 +12412,12 @@ msgid "Menu"
 msgstr "メニュー"
 
 # smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
 msgstr "メートル法 (キログラム・メートル・セ氏温度)"
@@ -11951,7 +12445,9 @@ msgstr "ミクロネシア"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試しください。"
+msgstr ""
+"マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試し"
+"ください。"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12290,6 +12786,12 @@ msgid "More about Duck.ai"
 msgstr "Duck.aiの詳細"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "詳しくは"
@@ -12482,6 +12984,12 @@ msgstr "ミュート"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "海老茶"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -12722,7 +13230,11 @@ msgid ""
 "DuckDuckGo server after being sent, to help recover a chat if you lose your "
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
-msgstr "新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
+msgstr ""
+"新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的"
+"に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立"
+"ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロ"
+"ンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13037,7 +13549,8 @@ msgstr "結果が見つかりません。"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
+msgstr ""
+"音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13543,7 +14056,33 @@ msgstr "オンデマンド"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順に%5$sクリックしてください"
+msgstr ""
+"Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順"
+"に%5$sクリックしてください"
+
+# smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13570,7 +14109,9 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr "添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルをアップロードしてください。"
+msgstr ""
+"添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルを"
+"アップロードしてください。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13596,7 +14137,8 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
+msgstr ""
+"変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13610,7 +14152,9 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおいてからもう一度試してください。"
+msgstr ""
+"おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおい"
+"てからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13932,7 +14476,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡しています。私たちは追跡しません。"
+msgstr ""
+"他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡していま"
+"す。私たちは追跡しません。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13945,21 +14491,27 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr "ノーログ型の高速VPNに加え、上級AIチャット（利用上限数拡大）、その他のプレミアム保護機能を利用できます。全機能を1つにまとめたサブスクリプションです。"
+msgstr ""
+"ノーログ型の高速VPNに加え、上級AIチャット（利用上限数拡大）、その他のプレミア"
+"ム保護機能を利用できます。全機能を1つにまとめたサブスクリプションです。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr "私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しません。"
+msgstr ""
+"私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しま"
+"せん。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr "当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
+msgstr ""
+"当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、"
+"強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14211,7 +14763,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情報をファイルに関連付けないため、パスフレーズを復元できません。"
+msgstr ""
+"当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情"
+"報をファイルに関連付けないため、パスフレーズを復元できません。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14278,6 +14832,12 @@ msgid "Past year"
 msgstr "過去1年間"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14288,6 +14848,12 @@ msgstr "貼り付ける"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "同期コードを貼り付け"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14341,6 +14907,20 @@ msgstr "完全に閉店"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "ペルシャ語"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14410,7 +14990,10 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr "検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検索設定%2$sにアクセスしてください。"
+msgstr ""
+"検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能"
+"性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検"
+"索設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14419,8 +15002,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精度が高くなります。 "
-"この機能の動作を調整したり、オフにするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
+"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精"
+"度が高くなります。 この機能の動作を調整したり、オフにするには、%1$sDuckAssist"
+"設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14429,7 +15013,10 @@ msgid ""
 "DuckAssist more likely to appear automatically and often yields better "
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
-msgstr "検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
+msgstr ""
+"検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精"
+"度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設"
+"定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14461,7 +15048,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr ""
+"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14469,7 +15057,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr ""
+"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14477,7 +15066,9 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGoの保護が付属しません。"
+msgstr ""
+"目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGo"
+"の保護が付属しません。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14577,7 +15168,9 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "このプロンプトがボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
+msgstr ""
+"このプロンプトがボットにより行われていないことを確認するため、次のチャレンジ"
+"を完了してください。"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14585,7 +15178,9 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "この検索がボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
+msgstr ""
+"この検索がボットにより行われていないことを確認するため、次のチャレンジを完了"
+"してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14617,7 +15212,9 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
-msgstr "注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除されます。"
+msgstr ""
+"注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除され"
+"ます。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14625,7 +15222,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害または違法である理由を説明してください。"
+msgstr ""
+"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害また"
+"は違法である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14633,7 +15232,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法または有害である理由を説明してください。"
+msgstr ""
+"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法また"
+"は有害である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14847,7 +15448,9 @@ msgstr "フォーマットが不十分"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr "人気のAIモデルが利用可能です。アカウントは必要ありません。当社によりチャットは匿名化されます。"
+msgstr ""
+"人気のAIモデルが利用可能です。アカウントは必要ありません。当社によりチャット"
+"は匿名化されます。"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15356,7 +15959,9 @@ msgstr "確認する"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示します。"
+msgstr ""
+"ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示し"
+"ます。"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15398,7 +16003,9 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独自のテキストを挿入します。]"
+msgstr ""
+"次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独"
+"自のテキストを挿入します。]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15570,6 +16177,12 @@ msgid "Reading website…"
 msgstr "ウェブサイトを読み込み中…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -15664,7 +16277,9 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
+msgstr ""
+"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
+"バイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15672,7 +16287,9 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
+msgstr ""
+"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
+"バイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15681,7 +16298,10 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr "最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。"
+msgstr ""
+"最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポン"
+"スは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、イ"
+"ンターネット接続が途切れた場合のチャット復旧に役立ちます。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15752,6 +16372,12 @@ msgid "Recovery Code"
 msgstr "リカバリーコード"
 
 # smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Red"
 msgstr "赤"
@@ -15816,7 +16442,9 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr "結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズを縮小します"
+msgstr ""
+"結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズ"
+"を縮小します"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -15957,8 +16585,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッシュ）]、または [Reload（再読み込み）] "
-"ボタンをクリックします。"
+"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッ"
+"シュ）]、または [Reload（再読み込み）] ボタンをクリックします。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15999,6 +16627,12 @@ msgstr "%1$sを削除"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "%1$sを削除"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16043,18 +16677,34 @@ msgid "Remove unnecessary punctuation"
 msgstr "不要な句読点を削除してください"
 
 # smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr "「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
+msgstr ""
+"「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
+"します。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr "「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
+msgstr ""
+"「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
+"します。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16111,14 +16761,18 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr "レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
+msgstr ""
+"レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の"
+"匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
+msgstr ""
+"DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個"
+"人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16126,7 +16780,10 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr "DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべてのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
+msgstr ""
+"DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべ"
+"てのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を"
+"特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16217,7 +16874,10 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象です。"
+msgstr ""
+"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
+"イスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象"
+"です。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16225,7 +16885,10 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象になります。"
+msgstr ""
+"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
+"イスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象"
+"になります。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16235,9 +16898,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-""
-"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なアドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて生成されているため、不正確な情報が含まれている可能性があります。Search "
-"Assistには、当社の%1$s利用規約%2$sが適用されます。"
+"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なア"
+"ドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて"
+"生成されているため、不正確な情報が含まれている可能性があります。Search Assist"
+"には、当社の%1$s利用規約%2$sが適用されます。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16661,7 +17325,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージを使用すれば、さらに多くのチャットを保存できます。"
+msgstr ""
+"最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージ"
+"を使用すれば、さらに多くのチャットを保存できます。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16674,7 +17340,9 @@ msgstr "最新のチャットを最大30件デバイスにローカルで保存�
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょう。"
+msgstr ""
+"エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょ"
+"う。"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16705,6 +17373,12 @@ msgstr "設定内容を匿名でクラウドに保存します"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Duck.aiへようこそ"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -16821,7 +17495,9 @@ msgstr "下方向にスクロールし、%1$s詳細設定を表示%2$s をクリ
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr "%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) をクリックします"
+msgstr ""
+"%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変"
+"更%4$s (または %5$s新たに追加%6$s) をクリックします"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16830,8 +17506,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) "
-"をクリックします。"
+"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変"
+"更%4$s (または %5$s新たに追加%6$s) をクリックします。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16855,7 +17531,9 @@ msgstr "%1$sDuckDuckGo%2$sまで下にスクロールし、位置情報の使用
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s をクリックします。"
+msgstr ""
+"%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s "
+"をクリックします。"
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16909,17 +17587,20 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search "
-""
-"Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コンテンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。Search "
-"Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
+"Search Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コン"
+"テンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻"
+"度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々"
+"（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。"
+"Search Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr "Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけることができませんでした。別の検索をお試しください。"
+msgstr ""
+"Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけること"
+"ができませんでした。別の検索をお試しください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16928,8 +17609,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search "
-"Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。これを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情報に基づいてAIを使って簡潔な回答を生成します。"
+"Search Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。こ"
+"れを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情"
+"報に基づいてAIを使って簡潔な回答を生成します。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17049,7 +17731,9 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr "%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、Wikipediaで「ducks」を直接検索します。"
+msgstr ""
+"%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、"
+"Wikipediaで「ducks」を直接検索します。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17067,7 +17751,10 @@ msgstr "プライベートに検索し、トラッカーをブロック"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr "検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りのブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索できます。"
+msgstr ""
+"検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りの"
+"ブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索"
+"できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17086,8 +17773,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されますが、設定をクラウド上のリモートサーバーに匿名で保存できるCloud "
-"Saveもご利用いただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズがブラウザの外に送信されることもありません。"
+"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されます"
+"が、設定をクラウド上のリモートサーバーに匿名で保存できるCloud Saveもご利用い"
+"ただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズが"
+"ブラウザの外に送信されることもありません。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17189,7 +17878,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
+msgstr ""
+"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
+"すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17197,7 +17888,9 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
+msgstr ""
+"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
+"すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17205,7 +17898,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべての同期済みのデバイスから簡単にアクセスできます。"
+msgstr ""
+"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
+"すべての同期済みのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17213,7 +17908,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべてのデバイスからアクセスできます。"
+msgstr ""
+"チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべ"
+"てのデバイスからアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17227,7 +17924,9 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
+msgstr ""
+"データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。"
+"DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -17377,35 +18076,41 @@ msgstr "Safariメニューの%1$s「このウェブサイトの設定...」%2$s 
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
+msgstr ""
+"%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
+msgstr ""
+"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
+msgstr ""
+"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
+msgstr ""
+"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
+msgstr ""
+"%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
+msgstr ""
+"リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17417,7 +18122,9 @@ msgstr "検索エンジンから%1$sDuckDuckGo%2$sを選択してください"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択してください"
+msgstr ""
+"%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択"
+"してください"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17428,7 +18135,8 @@ msgstr "選ぶなら%1$sDuckDuckGo%2$s！"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
+msgstr ""
+"ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17441,7 +18149,9 @@ msgstr "ドロップダウンメニューの%1$sアドオン管理%2$sを選択�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr "Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$sメニュー > 設定%4$sの順に選択してください"
+msgstr ""
+"Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$s"
+"メニュー > 設定%4$sの順に選択してください"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17449,8 +18159,8 @@ msgstr "Macの場合、%1$sOpera > 設定%2$sの順に選択してください�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合は、%3$sOpera > "
-"オプション%4$sの順に選択してください"
+"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合"
+"は、%3$sOpera > オプション%4$sの順に選択してください"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17469,7 +18179,8 @@ msgstr "%1$s検索エンジン%2$s を選択"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
+msgstr ""
+"%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -17514,13 +18225,17 @@ msgstr "%1$s設定%2$sを選択し、%3$s検索エンジン%4$sを選択して�
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr "%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオプションをどれか一つどうぞ)"
+msgstr ""
+"%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオ"
+"プションをどれか一つどうぞ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
+msgstr ""
+"リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$s"
+"します"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17592,7 +18307,9 @@ msgstr "選択テキストの参照元：%1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しください。"
+msgstr ""
+"選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17635,7 +18352,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これらの指示は、今後のすべての会話に適用されます。"
+msgstr ""
+"AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これら"
+"の指示は、今後のすべての会話に適用されます。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17656,6 +18375,13 @@ msgstr "セルビア語(キリル文字)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "セルビア語(ラテン文字)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -17750,7 +18476,9 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr "チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるようにSync & Backupを設定します。"
+msgstr ""
+"チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるように"
+"Sync & Backupを設定します。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17808,6 +18536,14 @@ msgid "Share"
 msgstr "共有"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -17848,7 +18584,9 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr "都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お客様の正確な位置情報を当社や AI モデルに決して公開しません。"
+msgstr ""
+"都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お"
+"客様の正確な位置情報を当社や AI モデルに決して公開しません。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -17943,7 +18681,9 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr "プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事象の報告には必須）"
+msgstr ""
+"プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事"
+"象の報告には必須）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17952,12 +18692,26 @@ msgid "Share your thoughts on the search box."
 msgstr "検索ボックスについてご意見をお寄せください。"
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr "ノーログ型の高速VPNを使って、オンライン活動を保護できます。セットアップは簡単で、オン/オフの切り替えがいつでも可能です。"
+msgstr ""
+"ノーログ型の高速VPNを使って、オンライン活動を保護できます。セットアップは簡単"
+"で、オン/オフの切り替えがいつでも可能です。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18077,7 +18831,9 @@ msgstr "DuckAssist<sup>ベータ版</sup>を表示"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできます。）"
+msgstr ""
+"DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできま"
+"す。）"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18260,7 +19016,8 @@ msgstr "サイドバーを表示する"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Duck.aiを最大限に活用するためのステップバイステップのヒントを表示します。"
+msgstr ""
+"Duck.aiを最大限に活用するためのステップバイステップのヒントを表示します。"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18314,14 +19071,18 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr "DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオフにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
+msgstr ""
+"DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオ"
+"フにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これをオフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
+msgstr ""
+"DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これを"
+"オフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18358,7 +19119,8 @@ msgstr "DuckDuckGoを端末に追加するリマインダーを随時表示"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr "DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
+msgstr ""
+"DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18379,7 +19141,9 @@ msgstr "入力に応じて検索ボックスの下に検索候補を表示"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表示"
+msgstr ""
+"ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表"
+"示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18615,6 +19379,12 @@ msgid "Something went wrong"
 msgstr "問題が発生しました"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -18624,7 +19394,8 @@ msgstr "サーバーへの保存が失敗しました。再度お試しくださ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
+msgstr ""
+"Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18654,7 +19425,8 @@ msgstr "時々表示する"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
+msgstr ""
+"申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18692,7 +19464,9 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像または形式を試してください。"
+msgstr ""
+"申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像また"
+"は形式を試してください。"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18700,13 +19474,17 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされたことを確認してください。"
+msgstr ""
+"申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされ"
+"たことを確認してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
-msgstr "申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai に聞いてみてください。"
+msgstr ""
+"申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai "
+"に聞いてみてください。"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18714,13 +19492,17 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行するには、%1$sこちらをクリック%2$sしてください。"
+msgstr ""
+"申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行す"
+"るには、%1$sこちらをクリック%2$sしてください。"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてからもう一度試してください。"
+msgstr ""
+"申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてか"
+"らもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18774,7 +19556,9 @@ msgstr "ソーステキストが消去されました"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度お試しください。"
+msgstr ""
+"ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度"
+"お試しください。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18979,7 +19763,8 @@ msgstr "DuckDuckGoを使用し続ける"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
+msgstr ""
+"プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19123,7 +19908,9 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr "Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像を作成してください。"
+msgstr ""
+"Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像"
+"を作成してください。"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19191,7 +19978,8 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
+msgstr ""
+"手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19445,6 +20233,12 @@ msgid "Switch model"
 msgstr "モデルを切り替える"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -19521,7 +20315,8 @@ msgstr "%1$sに切り替えました"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
+msgstr ""
+"切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19624,21 +20419,25 @@ msgid ""
 msgstr ""
 "同期リカバリーコード\n"
 "\n"
-""
-""
-"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同期済みのデータを回復できます。\n"
+"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複"
+"数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同"
+"期済みのデータを回復できます。\n"
 "\n"
 "この情報は安全に保管してください。\n"
-"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできます。\n"
+"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできま"
+"す。\n"
 "\n"
 "%1$s\n"
 "\n"
 "このコードの仕組みは？\n"
 "1. ブラウザでDuck.aiにアクセスし、Duck.aiの設定を開きます。\n"
-"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択します\n"
-"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付けます\n"
+"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択しま"
+"す\n"
+"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付"
+"けます\n"
 "\n"
-"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除され、復元できなくなります。"
+"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除さ"
+"れ、復元できなくなります。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19695,6 +20494,13 @@ msgid "Synced Devices"
 msgstr "同期されたデバイス"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "シリア"
 
@@ -19727,6 +20533,12 @@ msgid "TV"
 msgstr "テレビ"
 
 # smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Tahitian language
 msgctxt "language_name"
 msgid "Tahitian"
@@ -19757,7 +20569,9 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr "Duck.aiをどこへでも連れて行きましょう。どこにいても素早くアクセスできるよう、無料アプリに組み込めます。"
+msgstr ""
+"Duck.aiをどこへでも連れて行きましょう。どこにいても素早くアクセスできるよう、"
+"無料アプリに組み込めます。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -19765,7 +20579,9 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr "Duck.aiをどこへでも連れて行きましょう。無料ブラウザに組み込むことで、どこからでも素早くアクセスできます。"
+msgstr ""
+"Duck.aiをどこへでも連れて行きましょう。無料ブラウザに組み込むことで、どこから"
+"でも素早くアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19788,7 +20604,8 @@ msgstr "個人データを自己管理しましょう！"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
+msgstr ""
+"この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20008,7 +20825,10 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr "つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワードや支払い情報がこうした情報に含まれる場合もあります。"
+msgstr ""
+"つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情"
+"報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワード"
+"や支払い情報がこうした情報に含まれる場合もあります。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20016,7 +20836,9 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr "Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動保存できます。"
+msgstr ""
+"Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動"
+"保存できます。"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20045,14 +20867,18 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr "暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本人だけです。"
+msgstr ""
+"暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本"
+"人だけです。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除します。"
+msgstr ""
+"モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除しま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20066,7 +20892,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
+msgstr ""
+"モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20124,7 +20951,9 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確認し、ローカルデータの保存が有効になっていることをご確認ください。"
+msgstr ""
+"このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確"
+"認し、ローカルデータの保存が有効になっていることをご確認ください。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20138,7 +20967,9 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr "検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してください。"
+msgstr ""
+"検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20156,7 +20987,10 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr "これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加するために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoをデフォルトの検索エンジンにするために使用されます。"
+msgstr ""
+"これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加す"
+"るために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoを"
+"デフォルトの検索エンジンにするために使用されます。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20193,7 +21027,9 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみてください。"
+msgstr ""
+"このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみ"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20201,7 +21037,9 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr "このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャットを開始してください。"
+msgstr ""
+"このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャッ"
+"トを開始してください。"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20239,7 +21077,10 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr "この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
+msgstr ""
+"この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AI"
+"チャットでは不正確な情報や不快な情報が表示される場合があります（詳細について"
+"は%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20248,7 +21089,10 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr "この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な内容が表示される場合があります（詳細については%2$sを参照してください）。"
+msgstr ""
+"この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AI"
+"チャットでは不正確な情報や不快な内容が表示される場合があります（詳細について"
+"は%2$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20256,7 +21100,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr "この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
+msgstr ""
+"この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な"
+"情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20266,8 +21112,25 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI "
-"Chat（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
+"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI Chat（%1$s）で生成されま"
+"した。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細"
+"については%4$sを参照してください）。"
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20299,7 +21162,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr ""
+"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -20307,7 +21171,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr ""
+"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -20338,14 +21203,18 @@ msgstr "この画像は作成できませんでした。"
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
+msgstr ""
+"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
+msgstr ""
+"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20353,12 +21222,20 @@ msgid "This information isn’t useful"
 msgstr "この情報は役に立たない"
 
 # smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr "これはサンプルチャットです。メニュー（3つの点）を開き、「ピン留め」を選択すると、チャットの先頭に固定できます！"
+msgstr ""
+"これはサンプルチャットです。メニュー（3つの点）を開き、「ピン留め」を選択する"
+"と、チャットの先頭に固定できます！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20366,7 +21243,9 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr "これはサンプルチャットです。サイドメニューのFire Buttonを使って削除してください！"
+msgstr ""
+"これはサンプルチャットです。サイドメニューのFire Buttonを使って削除してくださ"
+"い！"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20386,7 +21265,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除します。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
+msgstr ""
+"このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除しま"
+"す。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20394,7 +21275,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "このモデルプロバイダーはこのチャットに関連するデータを保存していません。他のモデルプロバイダーは限定的なデータ保持モデルを採用しています。"
+msgstr ""
+"このモデルプロバイダーはこのチャットに関連するデータを保存していません。他の"
+"モデルプロバイダーは限定的なデータ保持モデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20430,7 +21313,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後でどのブラウザからでもアクセスできます。"
+msgstr ""
+"チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後"
+"でどのブラウザからでもアクセスできます。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20438,7 +21323,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。"
+msgstr ""
+"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
+"すると、AI支援の回答が再表示されることがあります。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20448,9 +21335,21 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。ただし、%1$s "
-"にはAI支援の回答が一切表示されないスタートページもご用意しています。"
+"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
+"すると、AI支援の回答が再表示されることがあります。ただし、%1$s にはAI支援の回"
+"答が一切表示されないスタートページもご用意しています。"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20473,13 +21372,16 @@ msgstr "この翻訳は正しくありません"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能です。"
+msgstr ""
+"この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能で"
+"す。"
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
+msgstr ""
+"このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20489,8 +21391,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除され、Sync & Backupとの接続は解除されます。Sync & "
-"Backupに接続している他のブラウザでは、引き続きチャットにアクセスできます。"
+"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除さ"
+"れ、Sync & Backupとの接続は解除されます。Sync & Backupに接続している他のブラ"
+"ウザでは、引き続きチャットにアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20498,7 +21401,9 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr "これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。この操作は取り消せません。"
+msgstr ""
+"これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。こ"
+"の操作は取り消せません。"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20635,7 +21540,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印刷アイコンをクリックします。%4$s"
+msgstr ""
+"ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印"
+"刷アイコンをクリックします。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20644,7 +21551,10 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr "同期したデータを復元するには、同期を初めて設定したときに保存したリカバリーコードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保存されている可能性があります。"
+msgstr ""
+"同期したデータを復元するには、同期を初めて設定したときに保存したリカバリー"
+"コードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保"
+"存されている可能性があります。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20652,14 +21562,18 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアップデートし、再度お試しください。"
+msgstr ""
+"チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアッ"
+"プデートし、再度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr "音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるように設定してください。"
+msgstr ""
+"音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるよ"
+"うに設定してください。"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20681,7 +21595,9 @@ msgstr "今日"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "トグルを切り替えてプライベートAIチャットを試すか、%1$s%2$sメニューで無効にできます。%3$s"
+msgstr ""
+"トグルを切り替えてプライベートAIチャットを試すか、%1$s%2$sメニューで無効にで"
+"きます。%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20854,7 +21770,9 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr "DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、ブロック件数が表示されるようになります。"
+msgstr ""
+"DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、"
+"ブロック件数が表示されるようになります。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20901,7 +21819,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
+msgstr ""
+"この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって"
+"行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20909,7 +21829,9 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
+msgstr ""
+"この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行け"
+"ばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21017,7 +21939,8 @@ msgstr "%1$sを試す"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr "このようなメッセージが表示されないようにするには、%1$sをお試しください。"
+msgstr ""
+"このようなメッセージが表示されないようにするには、%1$sをお試しください。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -21027,7 +21950,9 @@ msgstr "プロバイダーの可視性がゼロの最初のモデル%1$sをお�
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr "%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試しを！"
+msgstr ""
+"%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試し"
+"を！"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -21069,6 +21994,12 @@ msgstr "無料で試す"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "無料で試す"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21150,13 +22081,16 @@ msgstr "別のキーワードを試してみてください。"
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しください。"
+msgstr ""
+"より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しく"
+"ださい。"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
+msgstr ""
+"検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21182,6 +22116,12 @@ msgstr "無料で試す"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "無料で試す"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21283,7 +22223,8 @@ msgstr "位置情報を手動で設定してみてください。"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
+msgstr ""
+"%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -21341,7 +22282,8 @@ msgstr "最近追加されたオープンソースのLlama 3.1とMixtralをお�
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
+msgstr ""
+"まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21425,6 +22367,12 @@ msgid "Turkmenistan"
 msgstr "トルクメニスタン"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -21435,6 +22383,12 @@ msgstr "Sync & Backupをオフにする"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Sync & Backupをオフにする"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -21523,7 +22477,8 @@ msgstr "より正確な結果を得るには、「正確な位置情報」をオ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
+msgstr ""
+"より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21567,14 +22522,17 @@ msgstr "「%1$sDuckDuckGo%2$s」と %3$s フォームの最初のフィールド
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Type %sduckduckgo.com%s in the %ssecond form field"
-msgstr "「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
+msgstr ""
+"「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索してから回答が表示されるまでに、多少タイムラグが生じる場合があります。"
+msgstr ""
+"DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索して"
+"から回答が表示されるまでに、多少タイムラグが生じる場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21703,14 +22661,18 @@ msgstr "長所と短所を明らかにする"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr "%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$sページがセレクト%6$s クリックします。"
+msgstr ""
+"%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$s"
+"ページがセレクト%6$s クリックします。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr "%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと入力してください"
+msgstr ""
+"%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと"
+"入力してください"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21720,7 +22682,8 @@ msgstr "%1$s開く%2$s の中から %3$s特定のページを開く%4$s を選�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
+msgstr ""
+"%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21730,13 +22693,17 @@ msgstr "%1$s検索設定%2$sで、%3$sDuckDuckGo%4$sを選択します"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$sを選択します"
+msgstr ""
+"%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$s"
+"を選択します"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックします"
+msgstr ""
+"%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックし"
+"ます"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21825,7 +22792,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上限がPlusプランの2倍になります。"
+msgstr ""
+"Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上"
+"限がPlusプランの2倍になります。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21885,7 +22854,9 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょう。%1$s"
+msgstr ""
+"DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょ"
+"う。%1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -21898,6 +22869,12 @@ msgstr "プレミアム保護を利用する"
 msgctxt "voice chat"
 msgid "Unmute"
 msgstr "ミュート解除"
+
+# smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -21935,6 +22912,12 @@ msgid "Update Browser"
 msgstr "ブラウザを更新"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
 msgctxt "precise_user_location"
 msgid "Update Location"
@@ -21970,7 +22953,9 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr "DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度なモデルにアクセスしよう"
+msgstr ""
+"DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度な"
+"モデルにアクセスしよう"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22094,7 +23079,9 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr "ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像を作成してください。"
+msgstr ""
+"ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像"
+"を作成してください。"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -22195,7 +23182,10 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr "ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必要ありません。"
+msgstr ""
+"ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、"
+"詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必"
+"要ありません。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22207,7 +23197,8 @@ msgstr "DuckDuckGo Private Searchを使う"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
+msgstr ""
+"あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22249,14 +23240,18 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr "デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大切に保管してください。"
+msgstr ""
+"デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大"
+"切に保管してください。"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr "デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを復元してください。"
+msgstr ""
+"デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを"
+"復元してください。"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -22405,7 +23400,9 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは Microsoft の広告ネットワークで管理されています"
+msgstr ""
+"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは "
+"Microsoft の広告ネットワークで管理されています"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -22413,7 +23410,9 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックはTripAdvisorの広告ネットワークで管理されています。"
+msgstr ""
+"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは"
+"TripAdvisorの広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22424,7 +23423,9 @@ msgstr "ヴァージン諸島"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセスしてください。"
+msgstr ""
+"この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセ"
+"スしてください。"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -22432,7 +23433,9 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
+msgstr ""
+"この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにア"
+"クセスしてください。"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -22440,7 +23443,9 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従ってください。"
+msgstr ""
+"タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従って"
+"ください。"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22455,8 +23460,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s "
-"に進み、%7$s別のデバイスと同期%8$sを選択してください。"
+"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22465,7 +23471,10 @@ msgid ""
 "Visit Duck.ai in your other browser and open Duck.ai Settings. Select “Turn "
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
-msgstr "別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。または、リカバリーPDFのQRコードをスキャンしてください。"
+msgstr ""
+"別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆"
+"Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。ま"
+"たは、リカバリーPDFのQRコードをスキャンしてください。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22475,8 +23484,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してください。"
+"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s "
+"> %3$sSync & Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選"
+"択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22485,7 +23495,10 @@ msgid ""
 "Visit Duck.ai in your other browser or the DuckDuckGo app and open Duck.ai "
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
-msgstr "他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開きます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択します。または、リカバリーPDFのQRコードをスキャンします。"
+msgstr ""
+"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開き"
+"ます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択しま"
+"す。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22537,7 +23550,9 @@ msgstr "ボイスチャットは終了しました"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用"
+"されません。"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22681,8 +23696,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、YouTube "
-"のおすすめに影響されずに動画を視聴できます。"
+"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、"
+"YouTube のおすすめに影響されずに動画を視聴できます。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22701,7 +23716,11 @@ msgid ""
 "because we have to stream the content from there. DuckDuckGo is an "
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
-msgstr "このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテンツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGoは独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ございません。"
+msgstr ""
+"このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテン"
+"ツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGo"
+"は独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ござ"
+"いません。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22713,7 +23732,8 @@ msgstr "匿名化に対応"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
+msgstr ""
+"%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22724,7 +23744,10 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報するには、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してしてください。"
+msgstr ""
+"当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報する"
+"には、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してし"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22735,7 +23758,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
+msgstr ""
+"当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する"
+"場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -22748,7 +23773,9 @@ msgstr "匿名の%1$s位置情報%2$sを使用すると、おおよその結果�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることができません。"
+msgstr ""
+"添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることがで"
+"きません。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22775,7 +23802,9 @@ msgstr "私たちはあなたの個人情報を保存しません。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr "個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束します。"
+msgstr ""
+"個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束"
+"します。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22788,7 +23817,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った理由」を教えてください。"
+msgstr ""
+"私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った"
+"理由」を教えてください。"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22796,7 +23827,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと思った理由」を教えてください。"
+msgstr ""
+"私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと"
+"思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22835,18 +23868,23 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr "私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であなたを追跡して、それを広告主に販売することはありません。"
+msgstr ""
+"私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であ"
+"なたを追跡して、それを広告主に販売することはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しません。"
+msgstr ""
+"私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しま"
+"せん。"
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
+msgstr ""
+"私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22855,12 +23893,21 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "アクティビティがなかったため、チャットを終了しました。再試行しますか？"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr "チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
+msgstr ""
+"チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22884,7 +23931,9 @@ msgstr "接続が失われました。メッセージの送信をもう一度お
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr "私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索広告%2$sから収益を得ています。"
+msgstr ""
+"私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索"
+"広告%2$sから収益を得ています。"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -22892,13 +23941,25 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されます。この設定は後でいつでも変更できます。"
+msgstr ""
+"匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されま"
+"す。この設定は後でいつでも変更できます。"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名でのフィードバックを頼りにしています。"
+msgstr ""
+"DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名"
+"でのフィードバックを頼りにしています。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22918,7 +23979,9 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr "このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
+msgstr ""
+"このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご"
+"提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22926,12 +23989,22 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr "ブラウジング中にデータを収集しようとするトラッカーをブロックします。"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
 msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエラーが続く場合は、%1$sに連絡してください。"
+msgstr ""
+"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエ"
+"ラーが続く場合は、%1$sに連絡してください。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22939,7 +24012,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウザのキャッシュをクリアすると解決に役立つ場合があります。"
+msgstr ""
+"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウ"
+"ザのキャッシュをクリアすると解決に役立つ場合があります。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22953,7 +24028,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力しています。"
+msgstr ""
+"ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力していま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22961,7 +24038,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr "Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要があります。"
+msgstr ""
+"Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要"
+"があります。"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23082,7 +24161,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr "Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのト"
+"レーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23090,7 +24171,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr "DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、"
+"AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23100,14 +24183,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI "
-"Chatへようこそ！このチャットセッションは%1$sの%2$sを使用しています。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルのトレーニングに使用されたりすることはありません。"
+"DuckDuckGo AI Chatへようこそ！このチャットセッションは%1$sの%2$sを使用してい"
+"ます。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルの"
+"トレーニングに使用されたりすることはありません。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになりました。"
+msgstr ""
+"新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになり"
+"ました。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23174,7 +24260,9 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr "申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込みしてみてください。"
+msgstr ""
+"申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込"
+"みしてみてください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23188,7 +24276,9 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr "プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありますか？"
+msgstr ""
+"プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありま"
+"すか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -23208,13 +24298,21 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をどう言い換えられますか？"
+msgstr ""
+"「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をど"
+"う言い換えられますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "年金の長所と短所は何ですか？"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -23226,7 +24324,12 @@ msgid ""
 "ai integrations, and privacy protections. Keep it quite short, simple, and "
 "easy to understand for people with or without much AI, or technical, "
 "experience."
-msgstr "Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメリットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、誰でも簡単に理解できるように回答します。"
+msgstr ""
+"Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメ"
+"リットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回"
+"答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に"
+"重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、"
+"誰でも簡単に理解できるように回答します。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23461,7 +24564,9 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットとの違いは？"
+msgstr ""
+"Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットと"
+"の違いは？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23561,7 +24666,9 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr "初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何ですか？"
+msgstr ""
+"初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何です"
+"か？"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23761,13 +24868,23 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr "Duck.aiでは、チャットは匿名化されており、AIのトレーニングに使用されることはありません。「%1$s」メニューでいつでもオン/オフを切り替えられます。"
+msgstr ""
+"Duck.aiでは、チャットは匿名化されており、AIのトレーニングに使用されることはあ"
+"りません。「%1$s」メニューでいつでもオン/オフを切り替えられます。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "プロバイダーの可視性ゼロではない"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24034,7 +25151,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
+msgstr ""
+"%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合"
+"があります。"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24042,7 +25161,9 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr "%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検索できます。"
+msgstr ""
+"%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検"
+"索できます。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24055,7 +25176,8 @@ msgstr "DuckDuckGo AI Chatには%1$sから直接アクセスできます。"
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr "%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
+msgstr ""
+"%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24063,17 +25185,22 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr "Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
+msgstr ""
+"Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
+msgstr ""
+"%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできま"
+"す。"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr "%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
+msgstr ""
+"%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりする"
+"こともできます。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -24086,7 +25213,9 @@ msgstr "添付するテキストは最大%1$sまで選択できます。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりできます。"
+msgstr ""
+"Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりで"
+"きます。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24106,7 +25235,9 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr "設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任意で削除できます。"
+msgstr ""
+"設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任"
+"意で削除できます。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24135,7 +25266,8 @@ msgstr "月間制限時間を使ってチャットを続行できます。"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
+msgstr ""
+"このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24198,7 +25330,9 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr "最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトのブロックを解除する必要があります。"
+msgstr ""
+"最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトの"
+"ブロックを解除する必要があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24249,12 +25383,20 @@ msgid "You have 1 attempt left."
 msgstr "あと1回試行できます。"
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
+msgstr ""
+"これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24262,7 +25404,9 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr "高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスクリプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
+msgstr ""
+"高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスク"
+"リプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24283,7 +25427,10 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。これにより、暗号化されたサーバーからチャットデータが削除されることはありません。"
+msgstr ""
+"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
+"チャットはローカルストレージで引き続き利用可能です。これにより、暗号化された"
+"サーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24292,7 +25439,10 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。この操作により、暗号化されたサーバーからチャットデータが削除されることはありません。"
+msgstr ""
+"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
+"チャットはローカルストレージで引き続き利用可能です。この操作により、暗号化さ"
+"れたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24305,7 +25455,8 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr "最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
+msgstr ""
+"最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -24319,7 +25470,10 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを使ってもプライベートに閲覧できます。このアプリはすでにインストールされており、以下が可能になります。"
+msgstr ""
+"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを"
+"使ってもプライベートに閲覧できます。このアプリはすでにインストールされてお"
+"り、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24331,7 +25485,9 @@ msgstr "あなたは今、匿名で検索しています！"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr "今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡をもっと減らすヒントを学びましょう。"
+msgstr ""
+"今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡を"
+"もっと減らすヒントを学びましょう。"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24380,7 +25536,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
+msgstr ""
+"現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24393,12 +25550,14 @@ msgstr "1回のセッションの最大ボイスチャット時間に達しま�
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
+msgstr ""
+"本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
+msgstr ""
+"ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24407,8 +25566,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"添付ファイル付きのDuck.aiチャットのSync & "
-"Backup用ストレージ容量が不足しています。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされたチャットは削除されません。"
+"添付ファイル付きのDuck.aiチャットのSync & Backup用ストレージ容量が不足してい"
+"ます。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされ"
+"たチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24418,8 +25578,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.aiチャットのSync & "
-"Backup用ストレージ容量が不足しています。同期を再開するには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留めされたチャットは削除されません。"
+"Duck.aiチャットのSync & Backup用ストレージ容量が不足しています。同期を再開す"
+"るには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留め"
+"されたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24432,7 +25593,9 @@ msgstr "ストレージの容量がいっぱいです"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr "YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録されています。"
+msgstr ""
+"YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録"
+"されています。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24444,6 +25607,23 @@ msgstr "YouTubeの匿名性に関する警告"
 msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "標準のYouTubeライセンス"
+
+# smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24469,13 +25649,24 @@ msgid "Your actual location remains private."
 msgstr "実際の位置情報は非公開のままとなります。"
 
 # smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
 msgctxt "Body copy for the Delete Server Data confirmation modal"
 msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
+msgstr ""
+"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
+"同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージ"
+"に保存されます。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24484,7 +25675,10 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルストレージに保存されます。"
+msgstr ""
+"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
+"同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルスト"
+"レージに保存されます。"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24508,14 +25702,18 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr "お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGoがこのデータにアクセスすることはありません。"
+msgstr ""
+"お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGo"
+"がこのデータにアクセスすることはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr "ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、DuckDuckGoはこのデータにアクセスすることはできません。"
+msgstr ""
+"ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、"
+"DuckDuckGoはこのデータにアクセスすることはできません。"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24523,7 +25721,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
+msgstr ""
+"%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示さ"
+"れる場合があります。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24535,41 +25735,50 @@ msgstr "チャットが保存されるようになりました。"
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr "チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはありません。"
+msgstr ""
+"チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはあ"
+"りません。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
+msgstr ""
+"チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
+msgstr ""
+"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
+"されません。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
+msgstr ""
+"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
+"されません。"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24583,7 +25792,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr "チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されません。チャット履歴を保持するには、以下の手順に従ってください。"
+msgstr ""
+"チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されま"
+"せん。チャット履歴を保持するには、以下の手順に従ってください。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24591,7 +25802,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
+msgstr ""
+"チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24622,7 +25834,9 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
+msgstr ""
+"あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検"
+"索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24665,10 +25879,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) "
-""
-"を使用した512ビットのキーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残ります。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo "
-"がお客様のパスフレーズを知ることはありません。"
+"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) を使用した512ビットの"
+"キーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残りま"
+"す。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo がお客様の"
+"パスフレーズを知ることはありません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24682,7 +25896,10 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr "プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータが取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはできません。"
+msgstr ""
+"プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータ"
+"が取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはで"
+"きません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24695,7 +25912,9 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr "最近のチャットはここにあります！チャットはいつでも参照したり、消去したりできます。"
+msgstr ""
+"最近のチャットはここにあります！チャットはいつでも参照したり、消去したりでき"
+"ます。"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -24727,8 +25946,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に保存するには、%1$sDuckDuckGo No "
-"AI%2$s拡張機能を有効にしてください。"
+"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に"
+"保存するには、%1$sDuckDuckGo No AI%2$s拡張機能を有効にしてください。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -24737,8 +25956,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に保存するには、%1$sDuckDuckGo No "
-"AI%2$s拡張機能をインストールしてください。%3$s詳細情報%4$s"
+"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に"
+"保存するには、%1$sDuckDuckGo No AI%2$s拡張機能をインストールしてくださ"
+"い。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -24757,7 +25977,10 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにインストールされており、以下が可能になります。"
+msgstr ""
+"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウ"
+"ザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにイン"
+"ストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -24765,7 +25988,9 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直してください。"
+msgstr ""
+"メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直して"
+"ください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24773,7 +25998,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr "この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして続行します。"
+msgstr ""
+"この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして"
+"続行します。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24781,7 +26008,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr "この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始します。"
+msgstr ""
+"この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始"
+"します。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24795,13 +26024,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr ""
+"1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
+msgstr ""
+"ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24884,7 +26115,9 @@ msgstr "（%1$s）"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されています。"
+msgstr ""
+"DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されて"
+"います。"
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25097,7 +26330,9 @@ msgstr "公式ウェブサイト"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードしたものです)"
+msgstr ""
+"あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードし"
+"たものです)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ka_GE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ka_GE/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "დაამატე %s-ში"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "ჩასადგმელები"
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4195,6 +4229,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4227,6 +4266,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4787,6 +4845,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4795,6 +4860,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5001,6 +5073,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5648,6 +5726,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6310,9 +6394,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7403,6 +7500,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7487,6 +7591,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9073,6 +9182,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9590,6 +9704,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9795,6 +9915,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10097,6 +10222,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10254,6 +10384,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "მდუმარე წითელი"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11131,6 +11266,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11735,6 +11891,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11743,6 +11904,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11787,6 +11953,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12801,6 +12979,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12950,6 +13133,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13157,6 +13345,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13190,6 +13383,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13738,6 +13941,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14502,6 +14710,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14626,6 +14840,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14745,6 +14966,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15292,6 +15523,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15981,6 +16217,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16178,6 +16419,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16202,6 +16449,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16655,6 +16907,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16723,6 +16989,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16806,6 +17077,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17320,6 +17601,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17412,6 +17698,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17611,6 +17902,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17619,6 +17915,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -17996,6 +18297,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18023,6 +18329,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18789,6 +19100,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18823,6 +19141,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18847,6 +19172,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19091,6 +19423,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19553,6 +19890,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19953,6 +20297,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20117,6 +20467,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20134,6 +20499,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
@@ -37,6 +37,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% creḍ"
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%sSselmed amek aneɣ ɛass nwen ɣben%s"
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Rnu ɣer %s"
 msgid "Add to Home Screen"
 msgstr "Rnu ɣer ugdil agejdan"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Izegrar"
@@ -1472,6 +1495,12 @@ msgstr "Ameqran akk"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Tawsit akk"
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
@@ -1883,6 +1912,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4208,6 +4242,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4240,6 +4279,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4800,6 +4858,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4808,6 +4873,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5014,6 +5086,12 @@ msgstr "Agi"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5661,6 +5739,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6323,9 +6407,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7420,6 +7517,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7504,6 +7608,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9096,6 +9205,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Issin %sugar%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9613,6 +9727,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9819,6 +9939,11 @@ msgstr "Umuɣ"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Umuɣ"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10120,6 +10245,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Ugar deg"
@@ -10277,6 +10407,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Azeggaɣ afessas"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11156,6 +11291,27 @@ msgstr ""
 "Deg Mac, %sTekki ɣef Maxthon > Ismenyifen%s, Deg Windows, %sTekki ɣef tignit "
 "%s> Iɣewwaren%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11765,6 +11921,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11773,6 +11934,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11817,6 +11983,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12831,6 +13009,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12980,6 +13163,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13187,6 +13375,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13220,6 +13413,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13768,6 +13971,11 @@ msgstr "Sekles iɣewwaren-ik s wudem udrig deg usigna"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14543,6 +14751,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14667,6 +14881,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14786,6 +15007,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15333,6 +15564,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16022,6 +16258,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16219,6 +16460,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16244,6 +16491,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Tiliẓri"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16703,6 +16955,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16771,6 +17037,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16854,6 +17125,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17370,6 +17651,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17462,6 +17748,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17661,6 +17952,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17669,6 +17965,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18050,6 +18351,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18077,6 +18383,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18851,6 +19162,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18885,6 +19203,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18909,6 +19234,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19153,6 +19485,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19615,6 +19952,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20017,6 +20361,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20186,6 +20536,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube Standard"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20203,6 +20568,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/kn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/kn_IN/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1181,6 +1199,11 @@ msgstr "%s ಗೆ ಸೇರಿಸು"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "ಆಡ್ ಆನ್ಸ್ (ಅಧಿಕಗಳು)"
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4198,6 +4232,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4230,6 +4269,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4790,6 +4848,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4798,6 +4863,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5004,6 +5076,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5651,6 +5729,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6315,9 +6399,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7410,6 +7507,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7494,6 +7598,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9081,6 +9190,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "%sಇನ್ನಷ್ಟು%s ತಿಳಿಯಿರಿ"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9598,6 +9712,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9803,6 +9923,11 @@ msgstr "ಮೆನು"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10105,6 +10230,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "ಇನ್ನಷ್ಟು "
@@ -10262,6 +10392,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "ಮ್ಯೂಟ್ ಕೆಂಪು"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11139,6 +11274,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11743,6 +11899,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11751,6 +11912,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11795,6 +11961,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12809,6 +12987,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12958,6 +13141,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13165,6 +13353,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13198,6 +13391,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13746,6 +13949,11 @@ msgstr "ನಿಮ್ಮ ಸೆಟ್ಟಿಂಗ್ಗಳನ್ನು ಅನಾ�
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14512,6 +14720,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14636,6 +14850,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14755,6 +14976,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15302,6 +15533,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15991,6 +16227,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16188,6 +16429,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16213,6 +16460,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "ಟಿವಿ"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16665,6 +16917,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16733,6 +16999,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16816,6 +17087,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17330,6 +17611,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17422,6 +17708,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17621,6 +17912,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17629,6 +17925,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18006,6 +18307,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18033,6 +18339,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18799,6 +19110,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18833,6 +19151,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18857,6 +19182,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19101,6 +19433,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19563,6 +19900,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19965,6 +20309,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20132,6 +20482,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20149,6 +20514,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "완전 접종 완료 %"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "접종 완료 %"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -182,8 +190,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
-"이용하거나, Plus 또는 무료 모델로 전환하세요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
+"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -193,8 +202,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
-"이용하거나, Plus 또는 무료 모델로 전환하세요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
+"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -210,8 +220,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구독을 다시 활성화해서 채팅을 계속 이용하거나, "
-"무료 모델로 전환하세요."
+"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구"
+"독을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -219,7 +229,9 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다시 시도하세요."
+msgstr ""
+"%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다"
+"시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -316,8 +328,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사용자의 메시지나 모델의 응답을 보거나 서버에 이 "
-"채팅을 저장할 수 없습니다."
+"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사"
+"용자의 메시지나 모델의 응답을 보거나 서버에 이 채팅을 저장할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -364,7 +376,8 @@ msgstr "%1$s 사용"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s은(는) 기본 모델보다 사용 한도를 최대 2~5배 더 빠르게 소진합니다. %2$s"
+msgstr ""
+"%1$s은(는) 기본 모델보다 사용 한도를 최대 2~5배 더 빠르게 소진합니다. %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -402,7 +415,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr "%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
+msgstr ""
+"%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔"
+"서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -412,7 +427,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
+msgstr ""
+"%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채"
+"팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -424,7 +441,9 @@ msgstr "단어 %1$s개"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합니다.%7$s"
+msgstr ""
+"%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합"
+"니다.%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -432,8 +451,8 @@ msgstr "%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 표시한 후 %8$s확인%9$s을 "
-"클릭합니다."
+"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 "
+"표시한 후 %8$s확인%9$s을 클릭합니다."
 
 # Firefox
 # smartling.placeholder_format=C
@@ -443,8 +462,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s에 체크 표시한 후 "
-"%8$s확인%9$s을 클릭합니다."
+"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s"
+"에 체크 표시한 후 %8$s확인%9$s을 클릭합니다."
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -452,7 +471,9 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr "이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 시도해 보세요."
+msgstr ""
+"이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 "
+"시도해 보세요."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -470,14 +491,23 @@ msgstr "%1$s더 알아보기%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
+msgstr ""
+"%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
+
+# smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
+msgstr ""
+"DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -495,7 +525,8 @@ msgstr "홈 화면에서 DuckDuckGo 앱 아이콘을 %1$s길게 누릅니다%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
+msgstr ""
+"%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -759,6 +790,12 @@ msgid "2nd in Group %s"
 msgstr "%1$s조 2위"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -840,14 +877,17 @@ msgstr "6시간 사용 제한에 도달했습니다."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr ""
+"6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr "6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니다."
+msgstr ""
+"6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -900,14 +940,17 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 확인하고 다시 시도하세요."
+msgstr ""
+"Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 "
+"확인하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
+msgstr ""
+"새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -958,9 +1001,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능을 끄면 DuckDuckGo Search의 AI "
-"Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 %1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 "
-"이용할 수 있습니다."
+"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능"
+"을 끄면 DuckDuckGo Search의 AI Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 "
+"%1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1021,9 +1064,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 "
-"제공하는 경우는 많습니다. Duck.ai는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI "
-"기반 채팅 서비스입니다."
+"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문"
+"을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 제공하는 경우는 많습니다. Duck.ai"
+"는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI 기반 "
+"채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1207,7 +1251,9 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr "이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
+msgstr ""
+"이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전"
+"환하세요."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1242,14 +1288,18 @@ msgstr "광고"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr "광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
+msgstr ""
+"광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사"
+"용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr "광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
+msgstr ""
+"광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 "
+"데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1299,7 +1349,9 @@ msgstr "DuckDuckGo 확장 프로그램 추가"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세요."
+msgstr ""
+"다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세"
+"요."
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1426,6 +1478,12 @@ msgid "Add to Home Screen"
 msgstr "홈 화면에 추가"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "추가 기능"
@@ -1526,7 +1584,9 @@ msgctxt ""
 "model picker dropdown"
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
-msgstr "고급 모델은 다른 모델보다 사용 한도에 2~5배 더 빠르게 도달할 수 있습니다. %1$s"
+msgstr ""
+"고급 모델은 다른 모델보다 사용 한도에 2~5배 더 빠르게 도달할 수 있습니다. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1534,7 +1594,8 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "고급 모델은 다른 모델보다 한도를 2~5배 더 빠르게 소진할 수 있습니다. %1$s"
+msgstr ""
+"고급 모델은 다른 모델보다 한도를 2~5배 더 빠르게 소진할 수 있습니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1576,7 +1637,8 @@ msgstr "다운로드가 완료되고 파일이 열리면 %1$s설치%2$s를 클�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
+msgstr ""
+"다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1712,8 +1774,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 대화 내용을 채팅 모델 훈련에 사용하지 "
-"않습니다."
+"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 "
+"대화 내용을 채팅 모델 훈련에 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1745,7 +1807,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
+msgstr ""
+"모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1759,7 +1822,9 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr "AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니다."
+msgstr ""
+"AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니"
+"다."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1780,6 +1845,13 @@ msgid "All types"
 msgstr "모든 종류"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1790,7 +1862,8 @@ msgstr "허용"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr "음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
+msgstr ""
+"음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1822,15 +1895,17 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 "
-"보냅니다. %2$s 모델의 프롬프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
+"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이"
+"터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 보냅니다. %2$s 모델의 프롬"
+"프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr "Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
+msgstr ""
+"Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1967,7 +2042,8 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr ""
+"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1975,7 +2051,8 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr ""
+"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1988,7 +2065,9 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr "웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택하거나 완전히 비활성화할 수 있습니다."
+msgstr ""
+"웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택"
+"하거나 완전히 비활성화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2034,7 +2113,9 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr "Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보를 들려줘)?"
+msgstr ""
+"Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보"
+"를 들려줘)?"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2199,8 +2280,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거나 공유하지 않습니다. 모든 개인정보 보호는 "
-"사용자의 기기에서 이루어집니다."
+"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거"
+"나 공유하지 않습니다. 모든 개인정보 보호는 사용자의 기기에서 이루어집니다."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2281,6 +2362,12 @@ msgid "Ask anything privately"
 msgstr "무엇이든 비공개로 물어보세요"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2336,10 +2423,11 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 생성할 수 있습니다. Assist 표시 빈도 선택 "
-"가능: 안 함(검색 결과에서 Assist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), "
-"가끔(관련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표시). 현재 AI 지원 답변은 미국(영어) "
-"지역에서만 이용 가능합니다."
+"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 "
+"생성할 수 있습니다. Assist 표시 빈도 선택 가능: 안 함(검색 결과에서 Assist UI"
+"를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), 가끔(관"
+"련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표"
+"시). 현재 AI 지원 답변은 미국(영어) 지역에서만 이용 가능합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2351,9 +2439,10 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 "
-"자연어 기술을 사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 "
-"자동 생성합니다."
+"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이"
+"며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관"
+"련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤"
+"링%2$s을 기반으로 자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2378,7 +2467,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr "카페, 공항, 호텔에서 DuckDuckGo VPN을 사용하면 연결을 암호화하고 와이파이에서 IP 주소를 감출 수 있습니다."
+msgstr ""
+"카페, 공항, 호텔에서 DuckDuckGo VPN을 사용하면 연결을 암호화하고 와이파이에"
+"서 IP 주소를 감출 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2493,13 +2584,17 @@ msgstr "자동 응답"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다."
+msgstr ""
+"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 있습니다."
+msgstr ""
+"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 "
+"있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2524,8 +2619,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
-"현재 Assist 서비스는 영어 사용 지역에서만 제공됩니다."
+"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 "
+"익명으로 정보를 조회하고 요약할 수 있습니다. 현재 Assist 서비스는 영어 사용 "
+"지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2534,14 +2630,16 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 "
-"수 있습니다. 현재 DuckAssist 서비스는 영어 사용 지역에서만 제공됩니다."
+"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색"
+"에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. 현재 DuckAssist 서비스"
+"는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
+msgstr ""
+"영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2741,8 +2839,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데이터와 같은 개인정보(PII)를 제거하여 대화 "
-"내용을 익명화합니다."
+"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데"
+"이터와 같은 개인정보(PII)를 제거하여 대화 내용을 익명화합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2871,7 +2969,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr "구독을 통해 유해 사이트 차단, IP 주소 숨기기, 더 많은 프리미엄 보호 기능을 이용하세요."
+msgstr ""
+"구독을 통해 유해 사이트 차단, IP 주소 숨기기, 더 많은 프리미엄 보호 기능을 이"
+"용하세요."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3131,16 +3231,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
-"암호화 보호 강화 기능을 이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 "
+"%1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 "
+"이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
-"암호화 보호 강화 기능을 이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확"
+"장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 이용할 수 "
+"있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3148,8 +3250,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 "
-"차단, 사이트 암호화 기능을 이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으"
+"로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 차단, 사이트 암호화 기능을 이"
+"용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3256,9 +3359,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 Cloud Save를 사용하여 설정을 보다 영구적으로 "
-"저장할 수 있습니다(클라우드의 원격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호 또한 서버에 저장되지 "
-"않습니다."
+"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 "
+"Cloud Save를 사용하여 설정을 보다 영구적으로 저장할 수 있습니다(클라우드의 원"
+"격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암"
+"호 또한 서버에 저장되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3266,8 +3370,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s "
-"페이지를 확인하세요."
+"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
+"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3276,8 +3380,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 "
-"%1$s 페이지를 확인하세요."
+"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
+"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3312,7 +3416,8 @@ msgstr "카메룬"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
+msgstr ""
+"닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3632,7 +3737,9 @@ msgstr "전체 사이트에 적용되는 배경 색상을 변경합니다."
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경합니다."
+msgstr ""
+"검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경"
+"합니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3761,8 +3868,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 타사 AI 채팅 모델과 익명으로 대화할 "
-"수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 "
+"타사 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 DuckDuckGo "
+"Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
 "%1$shttps://duck.ai%2$s에 바로 접속해서 채팅을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
@@ -3818,14 +3926,18 @@ msgstr "비공개로 채팅하기"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅하세요."
+msgstr ""
+"DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅"
+"하세요."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공개로 채팅하세요."
+msgstr ""
+"DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공"
+"개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3893,7 +4005,9 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
+msgstr ""
+"채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채"
+"팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3905,9 +4019,10 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
-"암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 "
-"저장이 중단됩니다."
+"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅"
+"을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버"
+"에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로"
+"운 프롬프트와 응답의 임시 저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3930,15 +4045,17 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일은 %2$s의 콘텐츠 조정 공급자에 의한 익명 "
-"검토를 거칩니다."
+"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일"
+"은 %2$s의 콘텐츠 조정 공급자에 의한 익명 검토를 거칩니다."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr "첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화를 재개할 수 있습니다."
+msgstr ""
+"첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화"
+"를 재개할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -3991,7 +4108,8 @@ msgstr "철자 검사"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
+msgstr ""
+"DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4093,7 +4211,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
-msgstr "전 세계 40개 이상의 서버 위치를 사용하며 유해 사이트와 온라인 사기를 차단하세요."
+msgstr ""
+"전 세계 40개 이상의 서버 위치를 사용하며 유해 사이트와 온라인 사기를 차단하세"
+"요."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4291,8 +4411,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무기한으로 보관하거나, AI Chat을 7일 이상 사용하지 "
-"않으면 자동으로 삭제할 수 있습니다."
+"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무"
+"기한으로 보관하거나, AI Chat을 7일 이상 사용하지 않으면 자동으로 삭제할 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4302,8 +4423,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 "
-"사용하지 않으면 자동으로 삭제될 수도 있습니다."
+"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅"
+"이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 사용하지 않으면 자동으로 "
+"삭제될 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4311,7 +4433,9 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr "브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 DuckDuckGo 무료 브라우저에"
+msgstr ""
+"브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 "
+"DuckDuckGo 무료 브라우저에"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4320,8 +4444,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 "
-"AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 후속 질문을 하세요."
+"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모"
+"델을 지원하는 DuckDuckGo의 비공개 AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 "
+"후속 질문을 하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4362,7 +4487,9 @@ msgstr "드롭다운 메뉴에서 %1$s검색 설정 변경%2$s을 클릭하세�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr "Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환경설정%4$s을 클릭하세요."
+msgstr ""
+"Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환"
+"경설정%4$s을 클릭하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4378,7 +4505,9 @@ msgstr "DuckDuckGo 확장 프로그램을 다운로드하려면 %1$s여기%2$s�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세요."
+msgstr ""
+"%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세"
+"요."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4392,7 +4521,9 @@ msgstr "왼쪽 사이드바에서 %1$s개인정보 및 서비스%2$s를 클릭�
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr "상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s기어 모양 아이콘%4$s을 클릭하세요)."
+msgstr ""
+"상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s"
+"기어 모양 아이콘%4$s을 클릭하세요)."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4421,7 +4552,8 @@ msgstr "%1$s예%2$s를 클릭하세요."
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
+msgstr ""
+"Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4483,8 +4615,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지만 브라우저에는 남아있습니다. 남아있는 데이터를 "
-"제거하려면 %3$s모든 검색 설정 초기화%4$s를 클릭하거나 누르세요."
+"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지"
+"만 브라우저에는 남아있습니다. 남아있는 데이터를 제거하려면 %3$s모든 검색 설"
+"정 초기화%4$s를 클릭하거나 누르세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4495,8 +4628,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서는 데이터가 삭제되지만, %3$s모든 설정 "
-"초기화%4$s를 클릭하거나 누를 때까지 브라우저에는 데이터가 남아 있게 됩니다."
+"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서"
+"는 데이터가 삭제되지만, %3$s모든 설정 초기화%4$s를 클릭하거나 누를 때까지 브"
+"라우저에는 데이터가 남아 있게 됩니다."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4564,14 +4698,18 @@ msgstr "검색 창에서 드롭다운을 클릭하세요."
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr "주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 %3$sDuckDuckGo%4$s를 선택하세요."
+msgstr ""
+"주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 "
+"%3$sDuckDuckGo%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr "광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리에 있습니다."
+msgstr ""
+"광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리"
+"에 있습니다."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4771,7 +4909,9 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr "Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
+msgstr ""
+"Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 "
+"수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5042,7 +5182,8 @@ msgstr "광고 차단 계속하기"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "최근 채팅을 여기서 계속 이어가거나, Fire Button을 눌러 삭제할 수 있습니다."
+msgstr ""
+"최근 채팅을 여기서 계속 이어가거나, Fire Button을 눌러 삭제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5146,6 +5287,12 @@ msgid "Copy"
 msgstr "복사"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5154,7 +5301,8 @@ msgstr "복사"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
+msgstr ""
+"주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5185,6 +5333,28 @@ msgstr "이 코드 복사 또는 저장"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "복구 코드 복사"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5336,7 +5506,8 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr "링크를 생성하면 링크를 연 모든 사람이 볼 수 있는 채팅 사본이 생성됩니다."
+msgstr ""
+"링크를 생성하면 링크를 연 모든 사람이 볼 수 있는 채팅 사본이 생성됩니다."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5568,14 +5739,17 @@ msgstr "일일 한도에 도달했습니다."
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr ""
+"일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr "일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있습니다."
+msgstr ""
+"일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5860,6 +6034,14 @@ msgid "Delete recent chats?"
 msgstr "최근 채팅을 삭제할래?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -5870,6 +6052,14 @@ msgstr "이 채팅을 삭제할까요?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "삭제된 채팅"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5965,7 +6155,8 @@ msgstr "Duck.ai 받아쓰기"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr ""
+"당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5982,7 +6173,9 @@ msgstr "받아쓰기를 일시적으로 사용할 수 없습니다"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
+msgstr ""
+"받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력"
+"하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6123,6 +6316,13 @@ msgid "Dismiss"
 msgstr "닫기"
 
 # smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
 msgctxt "duckassist"
 msgid "Dismiss"
@@ -6256,7 +6456,9 @@ msgstr "목록에 DuckDuckGo가 보이지 않으시나요?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요.%4$s"
+msgstr ""
+"파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요."
+"%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6294,8 +6496,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 AI 이미지를 걸러냅니다. "
-"%3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 "
+"AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6304,8 +6506,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하지 않고 AI 이미지를 걸러냅니다. "
-"%3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하"
+"지 않고 AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6420,7 +6622,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr "실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
+msgstr ""
+"실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하"
+"세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6428,7 +6632,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr "가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
+msgstr ""
+"가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 "
+"작성하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6448,7 +6654,9 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr "다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성하세요."
+msgstr ""
+"다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성"
+"하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6456,7 +6664,9 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr "팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써보세요."
+msgstr ""
+"팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써"
+"보세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6588,8 +6798,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있습니다. 페이지 내용은 사용자가 첨부할 때만 "
-"포함됩니다. 또는 설정에서 페이지 자동 첨부를 선택하세요."
+"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있"
+"습니다. 페이지 내용은 사용자가 첨부할 때만 포함됩니다. 또는 설정에서 페이지 "
+"자동 첨부를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6599,8 +6810,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 "
-"시도하세요."
+"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 "
+"설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6608,13 +6819,16 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr "Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
+msgstr ""
+"Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합니다!"
+msgstr ""
+"Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합"
+"니다!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6623,7 +6837,9 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr "Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사람들을 위한 독립된 온라인 보호 기업입니다."
+msgstr ""
+"Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사"
+"람들을 위한 독립된 온라인 보호 기업입니다."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6637,7 +6853,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기억하기 쉽게 바뀌었습니다."
+msgstr ""
+"Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기"
+"억하기 쉽게 바뀌었습니다."
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6651,14 +6869,18 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
+msgstr ""
+"Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)"
+"를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
+msgstr ""
+"Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6672,8 +6894,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄면 Duck.ai 버튼과 링크가 숨겨지지만 "
-"%1$sduck.ai%2$s에 들어가서 직접 기능을 이용할 수 있습니다."
+"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄"
+"면 Duck.ai 버튼과 링크가 숨겨지지만 %1$sduck.ai%2$s에 들어가서 직접 기능을 이"
+"용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6684,9 +6907,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 "
-"DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
-"%1$shttps://duck.ai%2$s에 바로 접속해서 Duck.ai를 이용할 수 있습니다."
+"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화"
+"할 수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보"
+"이지 않습니다. 하지만 이 설정이 꺼져 있어도 %1$shttps://duck.ai%2$s에 바로 접"
+"속해서 Duck.ai를 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6700,7 +6924,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr "Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하실 수 있습니다."
+msgstr ""
+"Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하"
+"실 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6737,7 +6963,8 @@ msgstr "Duck.ai가 업그레이드되었습니다!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
+msgstr ""
+"Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6747,8 +6974,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필요 없는 AI 채팅, "
-"OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이버시 중심 AI, 계정 필요 없는 AI 채팅"
+"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필"
+"요 없는 AI 채팅, OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이"
+"버시 중심 AI, 계정 필요 없는 AI 채팅"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6776,9 +7004,11 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. DuckAssist 표시 빈도 선택 가능: 안 "
-"함(검색 결과에서 DuckAssist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 "
-"표시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영어) 지역에서만 제공됩니다."
+"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
+"DuckAssist 표시 빈도 선택 가능: 안 함(검색 결과에서 DuckAssist UI를 완전히 제"
+"거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 표"
+"시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영"
+"어) 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6787,8 +7017,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
+"지원하는 비공개 AI 기반 채팅 서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니"
+"다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6797,8 +7028,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
+"지원하는 비공개 AI 기반 채팅 서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니"
+"다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6810,9 +7042,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 관련 사이트에서 의미있는 콘텐츠를 검색한 "
-"다음 AI 기반 자연어 기술을 사용하여 해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용을 기반으로 "
-"답변을 제공하며 정확성 검사는 하지 않습니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 "
+"관련 사이트에서 의미있는 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여 "
+"해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용"
+"을 기반으로 답변을 제공하며 정확성 검사는 하지 않습니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6826,17 +7059,21 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 "
-"사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 바로 링크하고 "
-"답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 "
-"기반으로 자동 생성합니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관"
+"련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관련 정보를 바"
+"탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 "
+"바로 링크하고 답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정"
+"보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 자"
+"동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr "DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습니다."
+msgstr ""
+"DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6844,7 +7081,9 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr "하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
+msgstr ""
+"하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채"
+"팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6853,8 +7092,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
+"개 AI 기반 채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6863,8 +7102,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
+"개 AI 기반 채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6872,7 +7111,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr "DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있습니다."
+msgstr ""
+"DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6880,7 +7121,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
+msgstr ""
+"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 "
+"코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6888,13 +7131,16 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
+msgstr ""
+"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다"
+"시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
+msgstr ""
+"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6921,6 +7167,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo 브라우저 %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7037,15 +7290,17 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정보(PII)를 자동으로 제거해 이러한 보고서를 "
-"익명화합니다."
+"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정"
+"보(PII)를 자동으로 제거해 이러한 보고서를 익명화합니다."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동의합니다."
+msgstr ""
+"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동"
+"의합니다."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7053,7 +7308,9 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s에 동의합니다."
+msgstr ""
+"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s"
+"에 동의합니다."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7062,8 +7319,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에서 사용자 추적을 시도하는 Google과 "
-"Facebook 등의 추적기도 차단합니다."
+"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에"
+"서 사용자 추적을 시도하는 Google과 Facebook 등의 추적기도 차단합니다."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7075,10 +7332,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위치 정보는 로컬 기기에만 저장됩니다. 사용자가 "
-"검색을 하면 사용자의 기기는 해당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 데 사용한 "
-"후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 "
-"알아보세요%2$s."
+"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위"
+"치 정보는 로컬 기기에만 저장됩니다. 사용자가 검색을 하면 사용자의 기기는 해"
+"당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 "
+"데 사용한 후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보"
+"를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7098,8 +7356,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋은 결과를 제공할 수 있습니다. %1$s자세히 "
-"알아보세요%2$s."
+"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋"
+"은 결과를 제공할 수 있습니다. %1$s자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7191,8 +7449,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 목록을 받습니다. 그러 다음 브라우저에서 목록에 "
-"포함된 4~5개의 무작위 단어를 선택하여 최소 18~20자 이상의 암호를 만듭니다."
+"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 "
+"목록을 받습니다. 그러 다음 브라우저에서 목록에 포함된 4~5개의 무작위 단어를 "
+"선택하여 최소 18~20자 이상의 암호를 만듭니다."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7399,7 +7658,9 @@ msgstr "웹 검색 활성화"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr "보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변경할 수 있습니다."
+msgstr ""
+"보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변"
+"경할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7441,7 +7702,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위치는 DuckDuckGo에 공개하지 않을 수 있습니다."
+msgstr ""
+"익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위"
+"치는 DuckDuckGo에 공개하지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7602,7 +7865,9 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr "새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이터가 새 암호로 저장됩니다."
+msgstr ""
+"새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이"
+"터가 새 암호로 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7627,7 +7892,9 @@ msgstr "번역할 내용 입력하기"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네임%6$s: d%7$s"
+msgstr ""
+"다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네"
+"임%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7727,13 +7994,30 @@ msgstr "지도 확장하기"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습니다."
+msgstr ""
+"개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습"
+"니다."
+
+# smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "만료됨"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7995,7 +8279,8 @@ msgstr "피드백이 성공적으로 전송되었습니다."
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
+msgstr ""
+"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8003,7 +8288,9 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
+msgstr ""
+"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사"
+"용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8093,13 +8380,16 @@ msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니�
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
+msgstr ""
+"이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr "이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세요%2$s"
+msgstr ""
+"이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세"
+"요%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8140,7 +8430,8 @@ msgstr "다운로드 폴더에서 <b>%1$s</b> 파일을 찾으세요"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
+msgstr ""
+"표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8177,7 +8468,8 @@ msgstr "여러분과 보다 관련있는 결과를 찾아보세요."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
+msgstr ""
+"내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8240,7 +8532,9 @@ msgstr "안개"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr "안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 클릭해야 할 수도 있습니다."
+msgstr ""
+"안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 "
+"클릭해야 할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8357,7 +8651,8 @@ msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
+msgstr ""
+"DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8468,8 +8763,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 "
-"확인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
+"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 확"
+"인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8762,7 +9057,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "DuckDuckGo VPN, 고급 Duck.ai, Identity Theft Restoration을 이용해 보세요."
+msgstr ""
+"DuckDuckGo VPN, 고급 Duck.ai, Identity Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8842,8 +9138,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Personal Info Removal, Identity Theft "
-"Restoration을 이용해 보세요."
+"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Personal Info Removal, "
+"Identity Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -8851,7 +9147,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr "빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Identity Theft Restoration을 이용해 보세요."
+msgstr ""
+"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Identity Theft Restoration"
+"을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -8859,7 +9157,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr ""
+"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 "
+"Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8869,7 +9169,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr ""
+"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 "
+"Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8912,7 +9214,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr "빠른 노로그 VPN, 옵션으로 이용 가능한 고급 AI 모델(채팅 한도 더 높음), 그 외 다양한 프리미엄 보호 기능을 이용해 보세요."
+msgstr ""
+"빠른 노로그 VPN, 옵션으로 이용 가능한 고급 AI 모델(채팅 한도 더 높음), 그 외 "
+"다양한 프리미엄 보호 기능을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -8921,20 +9225,24 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"안전한 노로그 VPN, 고급 Duck.ai를 사용해 보세요. Personal Information Removal 및 Identity "
-"Theft Restoration을 이용해 보세요."
+"안전한 노로그 VPN, 고급 Duck.ai를 사용해 보세요. Personal Information "
+"Removal 및 Identity Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "안전한 노로그 VPN, 고급 Duck.ai, Identity Theft Restoration 서비스를 이용해 보세요."
+msgstr ""
+"안전한 노로그 VPN, 고급 Duck.ai, Identity Theft Restoration 서비스를 이용해 "
+"보세요."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 수 있습니다."
+msgstr ""
+"다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8970,7 +9278,8 @@ msgstr "앱 받기"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "무료 DuckDuckGo 브라우저를 다운로드하여 %1$sYouTube 광고를 차단하세요.%2$s"
+msgstr ""
+"무료 DuckDuckGo 브라우저를 다운로드하여 %1$sYouTube 광고를 차단하세요.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9029,8 +9338,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
-"Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
+"Backup › Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9039,8 +9348,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
-"Sync With Another Device%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
+"Backup › Sync With Another Device%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9050,8 +9359,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
-"Sync With Another Device%4$s로 들어가서 코드 스캔:"
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
+"Backup › Sync With Another Device%4$s로 들어가서 코드 스캔:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9061,8 +9370,17 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
-"Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
+"Backup › Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR"
+"을 스캔하세요."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9076,7 +9394,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr "%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비스'가 켜져 있는지 확인합니다."
+msgstr ""
+"%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비"
+"스'가 켜져 있는지 확인합니다."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9084,7 +9404,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr "%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 %3$sDuckDuckGo%4$s를 찾습니다."
+msgstr ""
+"%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 "
+"%3$sDuckDuckGo%4$s를 찾습니다."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9169,6 +9491,12 @@ msgstr "이해했습니다."
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "이해했습니다."
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9766,7 +10094,9 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr "중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 강조 표시합니다."
+msgstr ""
+"중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 "
+"강조 표시합니다."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9793,8 +10123,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그런 다음 %5$s기본값으로 "
-"설정%6$s을 클릭하세요"
+"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그"
+"런 다음 %5$s기본값으로 설정%6$s을 클릭하세요"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9807,7 +10137,9 @@ msgstr "몽족어"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr "잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 보호 기능을 사용할 수 없게 됩니다."
+msgstr ""
+"잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 "
+"보호 기능을 사용할 수 없게 됩니다."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9856,7 +10188,9 @@ msgstr "더움"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr "호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
+msgstr ""
+"호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수"
+"집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10118,7 +10452,9 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr "바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으며, 그 이유는 무엇인가요?"
+msgstr ""
+"바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으"
+"며, 그 이유는 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10152,7 +10488,9 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr "여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 및 개인정보 보호 재설정%2$s으로 이동하세요."
+msgstr ""
+"여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 "
+"및 개인정보 보호 재설정%2$s으로 이동하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10162,8 +10500,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사이트 설정 > 위치%2$s로 이동하여 "
-"DuckDuckGo의 위치 접근을 허용하세요."
+"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사"
+"이트 설정 > 위치%2$s로 이동하여 DuckDuckGo의 위치 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10177,7 +10515,9 @@ msgstr "이 오류가 계속되면 %1$s에 문의하세요."
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가해야 합니다."
+msgstr ""
+"만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가"
+"해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10185,7 +10525,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr "채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이지에 직접 문의하실 수도 있습니다."
+msgstr ""
+"채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이"
+"지에 직접 문의하실 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10193,13 +10535,17 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
+msgstr ""
+"기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니"
+"다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주세요%2$s"
+msgstr ""
+"저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주"
+"세요%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10208,7 +10554,8 @@ msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
+msgstr ""
+"JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10356,8 +10703,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 서버를 통해 처리되도록 경로 변경이 필요합니다. "
-"%1$s자세히 알아보세요%2$s."
+"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 "
+"서버를 통해 처리되도록 경로 변경이 필요합니다. %1$s자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10367,7 +10714,9 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동기화”로 이동하세요."
+msgstr ""
+"DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동"
+"기화”로 이동하세요."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10381,7 +10730,9 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr "투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개됩니다."
+msgstr ""
+"투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개"
+"됩니다."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10786,8 +11137,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 "
-"연결되며, 광고와는 달리 DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
+"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 "
+"통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 연결되며, 광고와는 달리 "
+"DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10795,7 +11147,8 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr "임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
+msgstr ""
+"임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10867,7 +11220,8 @@ msgstr "두 기기 모두에서 Sync & Backup을 열어둘 수 있습니다."
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr "한번에 최대 5대의 기기에서 모든 앱과 온라인 활동을 비공개로 유지하세요."
+msgstr ""
+"한번에 최대 5대의 기기에서 모든 앱과 온라인 활동을 비공개로 유지하세요."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11099,6 +11453,12 @@ msgstr "%1$s더%2$s 알아보기"
 msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "%1$s더%2$s 알아보기"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11730,6 +12090,13 @@ msgid "Manage"
 msgstr "관리"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -11981,6 +12348,12 @@ msgid "Menu"
 msgstr "메뉴"
 
 # smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
 msgstr "미터법(킬로그램, 미터, 섭씨)"
@@ -12008,7 +12381,8 @@ msgstr "미크로네시아"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
+msgstr ""
+"마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12347,6 +12721,12 @@ msgid "More about Duck.ai"
 msgstr "Duck.ai 더 알아보기"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "자세히 보기:"
@@ -12539,6 +12919,12 @@ msgstr "음소거됨"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "톤 다운된 빨간색"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -12780,8 +13166,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버에 임시로 "
-"저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니다."
+"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트"
+"와 응답을 암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성"
+"화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니"
+"다."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13096,7 +13484,8 @@ msgstr "검색 결과가 없습니다."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
+msgstr ""
+"음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13602,7 +13991,33 @@ msgstr "요청 시"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이콘 > 설정을 클릭하세요.%5$s"
+msgstr ""
+"Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이"
+"콘 > 설정을 클릭하세요.%5$s"
+
+# smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13629,7 +14044,9 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr "첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 파일을 업로드하세요."
+msgstr ""
+"첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 "
+"파일을 업로드하세요."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13655,7 +14072,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지를 참고하세요."
+msgstr ""
+"사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지"
+"를 참고하세요."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13669,7 +14088,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
+msgstr ""
+"이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13991,7 +14411,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 추적하지 않습니다."
+msgstr ""
+"다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 "
+"추적하지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14004,14 +14426,18 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr "빠른 노로그 VPN과 함께 더 높은 한도의 스마트한 AI 채팅, 그 외 다양한 프리미엄 보호 기능을 올인원 구독으로 이용해 보세요."
+msgstr ""
+"빠른 노로그 VPN과 함께 더 높은 한도의 스마트한 AI 채팅, 그 외 다양한 프리미"
+"엄 보호 기능을 올인원 구독으로 이용해 보세요."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr "DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공유하지 않습니다."
+msgstr ""
+"DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공"
+"유하지 않습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14019,8 +14445,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강화 등의 기능이 탑재되어 있습니다. %1$siOS "
-"및 Android%2$s에서 다운로드하세요."
+"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강"
+"화 등의 기능이 탑재되어 있습니다. %1$siOS 및 Android%2$s에서 다운로드하세요."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14272,7 +14698,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 않기 때문에 암호를 복구할 수 없습니다."
+msgstr ""
+"해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 "
+"않기 때문에 암호를 복구할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14339,6 +14767,12 @@ msgid "Past year"
 msgstr "최근 일 년"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14349,6 +14783,12 @@ msgstr "붙여넣기"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "동기화 코드 붙여넣기"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14402,6 +14842,20 @@ msgstr "영구적으로 폐쇄됨"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "페르시아어"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14472,8 +14926,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 답변 수준이 높아질 수 있습니다. 이 기능을 끄고 "
-"Assist 버튼을 숨기려면 %1$s검색 설정%2$s으로 들어가세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 "
+"답변 수준이 높아질 수 있습니다. 이 기능을 끄고 Assist 버튼을 숨기려면 %1$s검"
+"색 설정%2$s으로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14482,8 +14937,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어난 답을 얻을 가능성이 높아집니다. "
-"%1$sDuckAssist 설정%2$s에서 이 기능을 끄거나 작동 방식을 조정할 수 있습니다."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어"
+"난 답을 얻을 가능성이 높아집니다. %1$sDuckAssist 설정%2$s에서 이 기능을 끄거"
+"나 작동 방식을 조정할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14493,8 +14949,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 "
-"끄고 Assist 버튼을 감추려면 %1$sDuckAssist 설정%2$s을 방문하세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 "
+"더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 끄고 Assist 버튼을 감추려면 "
+"%1$sDuckAssist 설정%2$s을 방문하세요."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14526,7 +14983,9 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
+msgstr ""
+"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
+"보세요."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14534,7 +14993,9 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
+msgstr ""
+"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
+"보세요."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14542,7 +15003,9 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보호 기능이 제공되지 않습니다."
+msgstr ""
+"목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보"
+"호 기능이 제공되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14690,7 +15153,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해하거나 불법적인 이유를 설명해 주세요."
+msgstr ""
+"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해"
+"하거나 불법적인 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14698,7 +15163,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법이거나 해로운 이유를 설명해 주세요."
+msgstr ""
+"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법"
+"이거나 해로운 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14850,7 +15317,9 @@ msgstr "DuckDuckGo를 구독하면 더 많은 프리미엄 기능들도 따라�
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr "또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
+msgstr ""
+"또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니"
+"다."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14912,7 +15381,9 @@ msgstr "형식이 조악함"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr "인기 있는 AI 모델을 사용할 수 있습니다. 계정이 없어도 괜찮습니다. DuckDuckGo가 익명화하는 채팅입니다."
+msgstr ""
+"인기 있는 AI 모델을 사용할 수 있습니다. 계정이 없어도 괜찮습니다. DuckDuckGo"
+"가 익명화하는 채팅입니다."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15349,7 +15820,8 @@ msgstr "DuckDuckGo는 절대 저장하지 않는 비공개 채팅"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr "DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
+msgstr ""
+"DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -15421,7 +15893,9 @@ msgstr "재생하기 전에 물어보기"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니다."
+msgstr ""
+"내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니"
+"다."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15439,7 +15913,8 @@ msgstr "검색과 인터넷 이용 과정에서 데이터를 보호하세요."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
+msgstr ""
+"검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15463,7 +15938,9 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입력]"
+msgstr ""
+"다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입"
+"력]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15635,6 +16112,12 @@ msgid "Reading website…"
 msgstr "웹사이트 읽는 중…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -15674,7 +16157,8 @@ msgstr "추론을 통해 복잡한 질문에 대해 더 나은 답변을 얻을 
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "추론 기능이 더 뛰어나지만, 사용 한도에 2~5배 더 빠르게 도달합니다. %1$s"
+msgstr ""
+"추론 기능이 더 뛰어나지만, 사용 한도에 2~5배 더 빠르게 도달합니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -15729,7 +16213,9 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
+msgstr ""
+"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
+"됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15737,7 +16223,9 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
+msgstr ""
+"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
+"됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15747,8 +16235,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
-"암호화하여 DuckDuckGo 서버에 임시로 저장합니다."
+"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 "
+"때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 "
+"DuckDuckGo 서버에 임시로 저장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15817,6 +16306,12 @@ msgstr "복구"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "복구 코드"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16023,7 +16518,9 @@ msgstr "Duck.ai를 다시 불러오기"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr "안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 DuckDuckGo를 새로고침하세요."
+msgstr ""
+"안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 "
+"DuckDuckGo를 새로고침하세요."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16064,6 +16561,12 @@ msgstr "%1$s 삭제"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "%1$s 삭제"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16108,18 +16611,34 @@ msgid "Remove unnecessary punctuation"
 msgstr "불필요한 문장 부호를 제거해 보세요"
 
 # smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr "'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
+msgstr ""
+"'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 "
+"항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr "'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
+msgstr ""
+"'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변"
+"이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16177,15 +16696,18 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. 사용자님이 익명으로 보내주신 의견은 %1$s "
-"사에도 서비스 개선을 위해 제공됩니다."
+"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. "
+"사용자님이 익명으로 보내주신 의견은 %1$s 사에도 서비스 개선을 위해 제공됩니"
+"다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
+msgstr ""
+"DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 "
+"기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16194,8 +16716,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 요청하는 모든 텍스트가 들어있으며, 이 텍스트는 "
-"익명 상태입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
+"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 "
+"요청하는 모든 텍스트가 들어있으며, 이 텍스트는 익명 상태입니다. 피드백에 개"
+"인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16287,8 +16810,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. AI 지원 "
-"답변에는 %1$s서비스 약관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
+"인 조언을 제공하기 위한 것이 아닙니다. AI 지원 답변에는 %1$s서비스 약관%2$s"
+"이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16297,8 +16821,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. "
-"DuckAssist에는 %1$s서비스 약관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
+"인 조언을 제공하기 위한 것이 아닙니다. DuckAssist에는 %1$s서비스 약관%2$s이 "
+"적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16308,8 +16833,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 "
-"바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
+"인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 바탕으로 자동 생성된 응답"
+"이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약"
+"관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16733,7 +17260,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많이 저장할 수도 있습니다."
+msgstr ""
+"최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많"
+"이 저장할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16777,6 +17306,12 @@ msgstr "클라우드에 익명으로 설정을 저장하세요."
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "안녕하세요, Duck.ai입니다!"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -16893,7 +17428,9 @@ msgstr "아래로 스크롤하여 %1$s고급 설정 보기%2$s를 클릭하세�
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
+msgstr ""
+"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변"
+"경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16901,7 +17438,9 @@ msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾�
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
+msgstr ""
+"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 "
+"%5$s새로 추가%6$s)을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16925,7 +17464,9 @@ msgstr "%1$sDuckDuckGo%2$s로 스크롤하여 사용자의 위치를 사용하�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클릭하세요."
+msgstr ""
+"아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클"
+"릭하세요."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16979,10 +17520,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 콘텐츠를 검색한 다음 AI를 사용하여 간단한 "
-"답변을 생성합니다. 답변 표시 빈도는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클릭했을 때만), "
-"가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 때 표시) 중 선택하세요. 현재 Search Assist는 영어를 "
-"사용하는 일부 지역에만 제공됩니다."
+"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 "
+"콘텐츠를 검색한 다음 AI를 사용하여 간단한 답변을 생성합니다. 답변 표시 빈도"
+"는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클"
+"릭했을 때만), 가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 "
+"때 표시) 중 선택하세요. 현재 Search Assist는 영어를 사용하는 일부 지역에만 제"
+"공됩니다."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16990,8 +17533,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 충분히 찾지 못했습니다. 다른 검색을 시도해 "
-"보세요."
+"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 "
+"충분히 찾지 못했습니다. 다른 검색을 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17000,8 +17543,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s "
-"한 다음 AI를 사용하여 찾은 정보를 기반으로 간단한 답변을 생성합니다."
+"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이"
+"를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s 한 다음 AI를 사용하여 찾은 정보를 "
+"기반으로 간단한 답변을 생성합니다."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17122,8 +17666,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 위키피디아에서 바로 'ducks'를 바로 "
-"검색합니다."
+"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 "
+"위키피디아에서 바로 'ducks'를 바로 검색합니다."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17142,15 +17686,18 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하는 브라우저에 비공개 웹 검색 기능을 설치하거나, "
-"%1$sduckduckgo.com%2$s에서 바로 검색하세요."
+"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하"
+"는 브라우저에 비공개 웹 검색 기능을 설치하거나, %1$sduckduckgo.com%2$s에서 바"
+"로 검색하세요."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
 msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
-msgstr "검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용합니다)."
+msgstr ""
+"검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용"
+"합니다)."
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17162,9 +17709,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저장됩니다. 하지만 Cloud Save를 사용하여 클라우드 "
-"원격 서버에 설정을 익명으로 저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호가 브라우저 밖으로 "
-"유출되지 않습니다."
+"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저"
+"장됩니다. 하지만 Cloud Save를 사용하여 클라우드 원격 서버에 설정을 익명으로 "
+"저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으"
+"며, 암호가 브라우저 밖으로 유출되지 않습니다."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17266,7 +17814,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
+"고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17274,7 +17824,9 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
+"고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17282,7 +17834,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 동기화된 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
+"고 모든 동기화된 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17290,7 +17844,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 "
+"기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17304,7 +17860,9 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데이터는 본인 외에 누구도 볼 수 없습니다."
+msgstr ""
+"DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데"
+"이터는 본인 외에 누구도 볼 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -17454,7 +18012,9 @@ msgstr "Safari 메뉴에서 %1$s'이 웹사이트의 설정'%2$s을 선택하세
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입력하세요."
+msgstr ""
+"%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입"
+"력하세요."
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17518,14 +18078,18 @@ msgstr "드롭다운 메뉴에서 %1$s추가 기능 관리%2$s를 선택하세�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설정%4$s을 선택하세요."
+msgstr ""
+"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설"
+"정%4$s을 선택하세요."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵션%4$s을 선택하세요."
+msgstr ""
+"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵"
+"션%4$s을 선택하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17589,7 +18153,8 @@ msgstr "%1$s설정%2$s을 선택한 다음 %3$s검색 엔진%4$s을 선택하세
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr "%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
+msgstr ""
+"%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17710,7 +18275,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞으로 나와 나누는 모든 대화에 적용됩니다."
+msgstr ""
+"AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞"
+"으로 나와 나누는 모든 대화에 적용됩니다."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17731,6 +18298,13 @@ msgstr "세르비아어(키릴)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "세르비아어(라틴)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -17825,7 +18399,9 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr "채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지하세요."
+msgstr ""
+"채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지"
+"하세요."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17883,6 +18459,14 @@ msgid "Share"
 msgstr "공유"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -17897,7 +18481,9 @@ msgstr "공유"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세요!"
+msgstr ""
+"DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세"
+"요!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17924,8 +18510,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용자의 정확한 위치를 우리에게나 AI 모델에게나 "
-"절대 공개하지 않습니다."
+"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용"
+"자의 정확한 위치를 우리에게나 AI 모델에게나 절대 공개하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18020,7 +18606,8 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr "DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
+msgstr ""
+"DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18029,12 +18616,26 @@ msgid "Share your thoughts on the search box."
 msgstr "검색창에 당신의 생각을 적어주세요."
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr "로그를 남기지 않는 빠른 VPN으로 온라인 활동을 보호하세요. 설정이 간편하고 언제든 쉽게 켜고 끌 수 있어요."
+msgstr ""
+"로그를 남기지 않는 빠른 VPN으로 온라인 활동을 보호하세요. 설정이 간편하고 언"
+"제든 쉽게 켜고 끌 수 있어요."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18392,15 +18993,17 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알림을 숨기며 검색 개인정보에는 영향을 주지 "
-"않습니다."
+"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알"
+"림을 숨기며 검색 개인정보에는 영향을 주지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
+msgstr ""
+"DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림"
+"만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18545,7 +19148,8 @@ msgstr "사이트 이름"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
+msgstr ""
+"사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18694,6 +19298,12 @@ msgid "Something went wrong"
 msgstr "문제가 발생했습니다"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -18771,7 +19381,8 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
+msgstr ""
+"업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18779,7 +19390,9 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는지 확인하세요."
+msgstr ""
+"죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는"
+"지 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18793,7 +19406,9 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여기를 클릭%2$s하세요."
+msgstr ""
+"죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여"
+"기를 클릭%2$s하세요."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -18853,7 +19468,8 @@ msgstr "원문 지움"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
+msgstr ""
+"원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19202,7 +19818,9 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr "DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
+msgstr ""
+"DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많"
+"이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19524,6 +20142,12 @@ msgid "Switch model"
 msgstr "모델 전환"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -19703,11 +20327,13 @@ msgid ""
 msgstr ""
 "동기화 복구 코드\n"
 "\n"
-"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅을 동기화할 수 있으며, 장치에 액세스할 수 없는 "
-"경우 동기화된 데이터를 복구할 수 있습니다.\n"
+"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅"
+"을 동기화할 수 있으며, 장치에 액세스할 수 없는 경우 동기화된 데이터를 복구할 "
+"수 있습니다.\n"
 "\n"
 "이 정보를 안전하게 보관하세요.\n"
-"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니다.\n"
+"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니"
+"다.\n"
 "\n"
 "%1$s\n"
 "\n"
@@ -19716,8 +20342,8 @@ msgstr ""
 "2. \"Sync & Backup\"를 선택한 다음, \"동기화된 데이터 복구\"를 선택합니다.\n"
 "3. 위 복구 코드를 복사하여 \"여기에 코드 붙여넣기\"에 붙여넣습니다.\n"
 "\n"
-"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 않으면 서버에서 데이터가 삭제되어 "
-"복원할 수 없습니다."
+"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 "
+"않으면 서버에서 데이터가 삭제되어 복원할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19774,6 +20400,13 @@ msgid "Synced Devices"
 msgstr "동기화된 기기"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "시리아"
 
@@ -19806,6 +20439,12 @@ msgid "TV"
 msgstr "TV"
 
 # smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Tahitian language
 msgctxt "language_name"
 msgid "Tahitian"
@@ -19836,7 +20475,9 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr "어디서나 Duck.ai를 이용해 보세요. 어디서든 더 빠르게 이용할 수 있도록 무료 앱에 내장하세요."
+msgstr ""
+"어디서나 Duck.ai를 이용해 보세요. 어디서든 더 빠르게 이용할 수 있도록 무료 앱"
+"에 내장하세요."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -19844,7 +20485,9 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr "어디서나 Duck.ai를 이용해 보세요. 어디서 웹서핑을 하든 더 빠르게 이용할 수 있도록 무료 브라우저에 내장하세요."
+msgstr ""
+"어디서나 Duck.ai를 이용해 보세요. 어디서 웹서핑을 하든 더 빠르게 이용할 수 있"
+"도록 무료 브라우저에 내장하세요."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20088,8 +20731,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 "
-"비밀번호 또는 결제 세부 정보가 이에 포함됩니다."
+"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 "
+"가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 비밀번호 또는 결제 세부 정"
+"보가 이에 포함됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20097,7 +20741,9 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr "Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으로 저장할 수 있습니다."
+msgstr ""
+"Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으"
+"로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20126,7 +20772,8 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr "암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
+msgstr ""
+"암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -20205,7 +20852,9 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활성화되어 있는지 브라우저 설정에서 확인하세요."
+msgstr ""
+"이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활"
+"성화되어 있는지 브라우저 설정에서 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20219,7 +20868,8 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr "검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
+msgstr ""
+"검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20238,8 +20888,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 "
-"웹사이트의 개인정보 보호를 강화하는 데 적용됩니다."
+"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, "
+"DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 웹사이트의 개인정보 보호를 "
+"강화하는 데 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20276,7 +20927,9 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세요."
+msgstr ""
+"이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세"
+"요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20284,7 +20937,9 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr "이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅을 시작해 보세요."
+msgstr ""
+"이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅"
+"을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20323,8 +20978,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 "
-"수 있습니다(자세한 내용은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
+"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20334,8 +20989,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 "
-"있습니다(자세한 내용은 %2$s 참조)."
+"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
+"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %2$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20344,8 +20999,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌한 정보를 제공할 수 있습니다(자세한 내용은 "
-"%2$s 참고)."
+"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌"
+"한 정보를 제공할 수 있습니다(자세한 내용은 %2$s 참고)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20355,8 +21010,25 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습니다. AI 채팅은 부정확하거나 "
-"공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습"
+"니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용"
+"은 %4$s 참조)."
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20427,14 +21099,16 @@ msgstr "이 이미지를 만들 수 없습니다."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
+msgstr ""
+"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
+msgstr ""
+"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20442,12 +21116,20 @@ msgid "This information isn’t useful"
 msgstr "이 정보는 유용하지 않습니다."
 
 # smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr "샘플 채팅입니다. 메뉴(점 3개)를 열고 '고정'을 선택하여 채팅 목록 맨 위에 계속 표시되도록 하세요."
+msgstr ""
+"샘플 채팅입니다. 메뉴(점 3개)를 열고 '고정'을 선택하여 채팅 목록 맨 위에 계"
+"속 표시되도록 하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20455,7 +21137,8 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr "샘플 채팅입니다. 측면 메뉴에 있는 Fire Button을 사용하여 삭제해 보세요!"
+msgstr ""
+"샘플 채팅입니다. 측면 메뉴에 있는 Fire Button을 사용하여 삭제해 보세요!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20475,7 +21158,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 제공사는 데이터를 보유하지 않는 모델을 따릅니다."
+msgstr ""
+"이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 "
+"제공사는 데이터를 보유하지 않는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20483,7 +21168,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
+msgstr ""
+"이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공"
+"사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20519,7 +21206,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 모든 브라우저에서 접근할 수 있습니다."
+msgstr ""
+"이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 "
+"모든 브라우저에서 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20527,7 +21216,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다."
+msgstr ""
+"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
+"면 AI 지원 답변이 다시 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20537,8 +21228,21 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다. "
-"하지만 AI 지원 답변이 절대 표시되지 않는 시작 페이지(%1$s)도 있습니다."
+"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
+"면 AI 지원 답변이 다시 표시될 수 있습니다. 하지만 AI 지원 답변이 절대 표시되"
+"지 않는 시작 페이지(%1$s)도 있습니다."
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20561,13 +21265,17 @@ msgstr "이 번역은 잘못되었습니다."
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 수 있습니다."
+msgstr ""
+"아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 사용하지 않고 있습니다."
+msgstr ""
+"이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 "
+"사용하지 않고 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20577,8 +21285,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결이 끊깁니다. Sync & Backup에 "
-"연결된 다른 브라우저에서는 계속 채팅을 볼 수 있습니다."
+"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결"
+"이 끊깁니다. Sync & Backup에 연결된 다른 브라우저에서는 계속 채팅을 볼 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20586,7 +21295,9 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr "이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
+msgstr ""
+"이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌"
+"릴 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20678,7 +21389,9 @@ msgstr "팁"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니다.%2$s"
+msgstr ""
+"개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니"
+"다.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20723,7 +21436,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인쇄 아이콘을 클릭하세요.%4$s"
+msgstr ""
+"경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인"
+"쇄 아이콘을 클릭하세요.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20733,8 +21448,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합니다. 이 코드는 Sync를 설치할 때 원래 사용한 "
-"기기에 PDF로 저장되었을 수 있습니다."
+"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합"
+"니다. 이 코드는 Sync를 설치할 때 원래 사용한 기기에 PDF로 저장되었을 수 있습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20742,14 +21458,18 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트하고 다시 시도하세요."
+msgstr ""
+"채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트"
+"하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr "받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허용해 주세요."
+msgstr ""
+"받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허"
+"용해 주세요."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20771,7 +21491,9 @@ msgstr "오늘"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "전환하여 비공개 AI 채팅을 사용해 보거나 %1$s %2$s 메뉴에서 비활성화하세요.%3$s"
+msgstr ""
+"전환하여 비공개 AI 채팅을 사용해 보거나 %1$s %2$s 메뉴에서 비활성화하세요."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20944,7 +21666,9 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr "DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되었는지 둘러보세요."
+msgstr ""
+"DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되"
+"었는지 둘러보세요."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20991,7 +21715,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
+msgstr ""
+"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
+"주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20999,7 +21725,9 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
+msgstr ""
+"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
+"주세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21161,6 +21889,12 @@ msgid "Try Free"
 msgstr "무료 체험"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21274,6 +22008,12 @@ msgid "Try for Free"
 msgstr "무료 체험"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
 msgctxt ""
 "Link text shown to unauthenticated users in the subscription promo card to "
@@ -21373,7 +22113,9 @@ msgstr "위치를 수동으로 설정하세요."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 보호."
+msgstr ""
+"%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 "
+"보호."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -21465,8 +22207,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 설치하면 설정을 기억시킬 수 "
-"있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 "
+"설치하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21475,8 +22217,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 전환하면 설정을 기억시킬 수 "
-"있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 "
+"전환하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21515,6 +22257,12 @@ msgid "Turkmenistan"
 msgstr "투르크메니스탄"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -21525,6 +22273,12 @@ msgstr "Sync & Backup 끄기"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Sync & Backup 끄기"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -21664,7 +22418,9 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표시되기까지 시간이 조금 지연될 수 있습니다."
+msgstr ""
+"DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표"
+"시되기까지 시간이 조금 지연될 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21793,24 +22549,30 @@ msgstr "장점과 단점 파악"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr "%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이지 설정%6$s을 클릭하세요."
+msgstr ""
+"%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이"
+"지 설정%6$s을 클릭하세요."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr "%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com을 입력하세요."
+msgstr ""
+"%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com"
+"을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
+msgstr ""
+"%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
+msgstr ""
+"%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21820,7 +22582,8 @@ msgstr "%1$s검색 설정%2$s에서 %3$sDuckDuckGo%4$s를 선택하세요."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
+msgstr ""
+"%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -21832,7 +22595,8 @@ msgstr "%1$s검색%2$s 섹션에서, %3$s검색 엔진 관리...%4$s를 클릭�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
+msgstr ""
+"시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21915,7 +22679,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사용 한도를 이용하세요."
+msgstr ""
+"Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사"
+"용 한도를 이용하세요."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21990,6 +22756,12 @@ msgid "Unmute"
 msgstr "음소거 해제"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22023,6 +22795,12 @@ msgstr "업데이트"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "브라우저 업데이트"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22060,7 +22838,9 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr "DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 이용하세요."
+msgstr ""
+"DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 "
+"이용하세요."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22184,7 +22964,9 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr "Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
+msgstr ""
+"Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 "
+"더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -22286,8 +23068,8 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채팅을 보호하세요. 정보를 기밀로 유지하세요. "
-"무료로. 계정이 없어도 괜찮습니다."
+"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채"
+"팅을 보호하세요. 정보를 기밀로 유지하세요. 무료로. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22341,14 +23123,17 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 보관하세요."
+msgstr ""
+"기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 "
+"보관하세요."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
+msgstr ""
+"기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -22497,7 +23282,9 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소프트의 광고 네트워크에서 관리합니다."
+msgstr ""
+"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소"
+"프트의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -22505,7 +23292,9 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 TripAdvisor의 광고 네트워크에서 관리합니다."
+msgstr ""
+"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 "
+"TripAdvisor의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22532,7 +23321,9 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명을 따르세요."
+msgstr ""
+"휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명"
+"을 따르세요."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22547,8 +23338,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & Backup%4$s > "
-"%5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
+"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
+"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22558,8 +23349,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 '켜기'를 선택하고 "
-"''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아"
+"래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF"
+"에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22569,8 +23361,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
-"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > "
+"%3$sSync & Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선"
+"택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22580,8 +23373,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 "
-"'켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. "
+"Sync & Backup 아래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세"
+"요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22633,7 +23427,8 @@ msgstr "음성 채팅이 끝났습니다"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr ""
+"당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22776,7 +23571,9 @@ msgstr "Duck Player에서 보기"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr "Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 YouTube 추천 영상이 달라지지 않습니다."
+msgstr ""
+"Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 "
+"YouTube 추천 영상이 달라지지 않습니다."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22796,8 +23593,9 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하는 웹사이트에서 사용자를 추적할 수 있습니다. "
-"DuckDuckGo는 동영상 대부분을 호스팅하는 YouTube와 무관한 독립적인 기업입니다."
+"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하"
+"는 웹사이트에서 사용자를 추적할 수 있습니다. DuckDuckGo는 동영상 대부분을 호"
+"스팅하는 YouTube와 무관한 독립적인 기업입니다."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22809,7 +23607,9 @@ msgstr "DuckDuckGo의 익명화"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니다."
+msgstr ""
+"더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22821,8 +23621,8 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저희가 문제를 조사하고 해결할 수 있도록 이대화를 "
-"DuckDuckGo와 공유해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저"
+"희가 문제를 조사하고 해결할 수 있도록 이대화를 DuckDuckGo와 공유해 주세요."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22834,8 +23634,9 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저희가 문제를 조사하고 해결할 수 있도록 사용하신 "
-"프롬프트와 응답 내용을 보내서 신고해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저"
+"희가 문제를 조사하고 해결할 수 있도록 사용하신 프롬프트와 응답 내용을 보내서 "
+"신고해 주세요."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -22876,8 +23677,9 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따라다니며 광고를 게재하지 않습니다. "
-"DuckDuckGo는 사용자를 추적하지 않습니다. 절대."
+"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따"
+"라다니며 광고를 게재하지 않습니다. DuckDuckGo는 사용자를 추적하지 않습니다. "
+"절대."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22890,7 +23692,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 알려주시면 도움이 될 것 같습니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 "
+"알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22898,7 +23702,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알려주시면 도움이 될 것 같습니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알"
+"려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22909,7 +23715,9 @@ msgstr "DuckDuckGo는 절대로 사용자를 추적하지 않습니다."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
+"니다."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22938,19 +23746,24 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사용자를 추적하는 광고주에게 판매할 수 있는 어떠한 "
-"정보도 보유하고 있지 않습니다."
+"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사"
+"용자를 추적하는 광고주에게 판매할 수 있는 어떠한 정보도 보유하고 있지 않습니"
+"다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하지 않습니다."
+msgstr ""
+"DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
+"니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22959,12 +23772,22 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "활동이 없어 채팅이 종료되었습니다. 다시 시도하시겠어요?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr "DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않도록 보장합니다."
+msgstr ""
+"DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않"
+"도록 보장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22988,7 +23811,9 @@ msgstr "연결이 끊겼습니다. 메시지를 다시 보내 보세요."
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr "우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터를 악용하지 않습니다."
+msgstr ""
+"우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터"
+"를 악용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -22996,18 +23821,32 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든지 설정을 변경할 수 있습니다."
+msgstr ""
+"익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든"
+"지 설정을 변경할 수 있습니다."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 좋게 발전시킵니다."
+msgstr ""
+"여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 "
+"좋게 발전시킵니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 포함해서 말이죠."
+msgstr ""
+"여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 "
+"포함해서 말이죠."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23023,8 +23862,8 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s의 재량에 따라 적용됩니다. 정정 사항이 결과에 "
-"바로 나타나지 않을 수 있습니다."
+"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s"
+"의 재량에 따라 적용됩니다. 정정 사항이 결과에 바로 나타나지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23032,12 +23871,22 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr "인터넷을 이용하는 동안 개인정보를 수집하려는 추적기를 차단합니다."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
 msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문의하세요."
+msgstr ""
+"현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문"
+"의하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23045,7 +23894,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제가 해결되는 경우도 있습니다."
+msgstr ""
+"현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제"
+"가 해결되는 경우도 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23059,7 +23910,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노력 중입니다."
+msgstr ""
+"불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노"
+"력 중입니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23067,7 +23920,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr "Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치세요."
+msgstr ""
+"Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치"
+"세요."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23175,7 +24030,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
+msgstr ""
+"주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23189,8 +24045,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 "
-"사용되지 않습니다."
+"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되"
+"며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23199,8 +24055,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 "
-"저장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공"
+"개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23210,8 +24066,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 세션입니다. 여기서 이루어지는 모든 "
-"채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 "
+"세션입니다. 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저"
+"장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23284,7 +24141,9 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr "정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로고침해 보세요."
+msgstr ""
+"정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로"
+"고침해 보세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23318,13 +24177,21 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 개 알려 주세요."
+msgstr ""
+"“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 "
+"개 알려 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "연금의 장단점은 무엇인가요?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -23337,9 +24204,10 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? DuckDuckGo 공식 출처만 참고하세요. "
-"답변은 명료하게 섹션을 나누어 작성하고 제목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 유무에 "
-"관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
+"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? "
+"DuckDuckGo 공식 출처만 참고하세요. 답변은 명료하게 섹션을 나누어 작성하고 제"
+"목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 "
+"유무에 관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23574,7 +24442,8 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
+msgstr ""
+"Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23649,7 +24518,8 @@ msgstr "무엇에 대해 피드백을 주고 싶으세요?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
+msgstr ""
+"DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23674,7 +24544,9 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr "초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나요?"
+msgstr ""
+"초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나"
+"요?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23875,14 +24747,22 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai를 사용하면 채팅 내용이 익명화되며, AI 학습에 절대 사용되지 않습니다. '%1$s' 메뉴에서 언제든지 켜거나 끌 수 "
-"있습니다."
+"Duck.ai를 사용하면 채팅 내용이 익명화되며, AI 학습에 절대 사용되지 않습니다. "
+"'%1$s' 메뉴에서 언제든지 켜거나 끌 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "제공자 가시성 제로 아님"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24149,7 +25029,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
+msgstr ""
+"%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24157,7 +25039,9 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr "%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 검색할 수 있습니다."
+msgstr ""
+"%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 "
+"검색할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24170,7 +25054,8 @@ msgstr "%1$s에서 DuckDuckGo AI Chat에 바로 접속할 수 있습니다."
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr "%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
+msgstr ""
+"%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24178,17 +25063,22 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr "%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니다."
+msgstr ""
+"%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니"
+"다."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
+msgstr ""
+"%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr "%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
+msgstr ""
+"%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 "
+"있습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -24201,7 +25091,9 @@ msgstr "텍스트 선택은 %1$s개까지 첨부할 수 있습니다."
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 수 있습니다."
+msgstr ""
+"%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24221,7 +25113,9 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr "다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트를 삭제할 수도 있습니다."
+msgstr ""
+"다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트"
+"를 삭제할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24250,7 +25144,8 @@ msgstr "월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
+msgstr ""
+"이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24313,7 +25208,9 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr "차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이트 차단을 먼저 해제해야 합니다."
+msgstr ""
+"차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이"
+"트 차단을 먼저 해제해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24364,12 +25261,21 @@ msgid "You have 1 attempt left."
 msgstr "1번 다시 시도할 수 있습니다."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습니다."
+msgstr ""
+"이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24378,8 +25284,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 DuckDuckGo 구독 보호 기능을 이용할 "
-"수 있습니다."
+"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 "
+"DuckDuckGo 구독 보호 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24401,8 +25307,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
-"채팅이 삭제되지는 않습니다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
+"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24412,8 +25319,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
-"채팅이 삭제되지는 않습니다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
+"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24441,8 +25349,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용해 보세요. 이미 설치되어 있으며 "
-"다음과 같은 기능이 제공됩니다."
+"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용"
+"해 보세요. 이미 설치되어 있으며 다음과 같은 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24454,7 +25362,9 @@ msgstr "이제 개인정보 보호를 받으며 검색할 수 있습니다!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr "현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 팁을 알아보세요."
+msgstr ""
+"현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 "
+"팁을 알아보세요."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24530,8 +25440,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화를 재개하려면 가장 오래된 채팅 "
-"%1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
+"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화"
+"를 재개하려면 가장 오래된 채팅 %1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24541,8 +25452,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 첨부 파일이 있는 채팅을 오래된 순으로 "
-"%1$s개 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
+"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 "
+"첨부 파일이 있는 채팅을 오래된 순으로 %1$s개 삭제하세요. 고정된 채팅은 삭제되"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24556,8 +25468,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기서 YouTube 동영상을 시청하면 "
-"YouTube나 Google의 추적을 받게 됩니다."
+"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기"
+"서 YouTube 동영상을 시청하면 YouTube나 Google의 추적을 받게 됩니다."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24569,6 +25481,23 @@ msgstr "YouTube 개인정보 관련 경고"
 msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube 표준"
+
+# smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24594,6 +25523,14 @@ msgid "Your actual location remains private."
 msgstr "실제 위치는 비공개로 유지됩니다."
 
 # smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
 msgctxt "Body copy for the Delete Server Data confirmation modal"
 msgid ""
@@ -24601,8 +25538,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 %1$s개가 로컬 "
-"저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
+"브라우저에서는 최근 채팅 %1$s개가 로컬 저장소에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24612,8 +25549,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 100개가 로컬 저장소에 "
-"저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
+"브라우저에서는 최근 채팅 100개가 로컬 저장소에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24637,14 +25574,18 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr "가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo는 절대 이 데이터에 접근할 수 없습니다."
+msgstr ""
+"가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo"
+"는 절대 이 데이터에 접근할 수 없습니다."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr "브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터에 절대 액세스할 수 없습니다."
+msgstr ""
+"브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터"
+"에 절대 액세스할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24652,7 +25593,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
+msgstr ""
+"%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표"
+"시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24677,28 +25620,36 @@ msgstr "사용자의 채팅은 비공개로 처리되며 AI 모델 훈련에 사
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24713,8 +25664,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 "
-"다음과 같습니다."
+"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련"
+"에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 다음과 같습니다."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24753,7 +25704,9 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. [%2$s메시지 예시%3$s]"
+msgstr ""
+"사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. "
+"[%2$s메시지 예시%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24796,9 +25749,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 키를 생성합니다. 키와 연관된 설정 파일만 "
-"브라우저 외부로 전송됩니다. DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 암호를 절대 알 수 "
-"없습니다."
+"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 "
+"키를 생성합니다. 키와 연관된 설정 파일만 브라우저 외부로 전송됩니다. "
+"DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 "
+"암호를 절대 알 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24813,8 +25767,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데이터는 제거됩니다. 따라서 모델 제공사는 대화를 "
-"특정 사용자에 연결할 수 없습니다."
+"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데"
+"이터는 제거됩니다. 따라서 모델 제공사는 대화를 특정 사용자에 연결할 수 없습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24859,8 +25814,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 %1$sDuckDuckGo No AI%2$s 확장 프로그램을 "
-"사용 설정하세요."
+"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 "
+"%1$sDuckDuckGo No AI%2$s 확장 프로그램을 사용 설정하세요."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -24869,8 +25824,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 %1$sDuckDuckGo No AI%2$s 확장 프로그램을 "
-"설치하세요. %3$s자세히 알아보기%4$s"
+"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 "
+"%1$sDuckDuckGo No AI%2$s 확장 프로그램을 설치하세요. %3$s자세히 알아보기%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -24890,8 +25845,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 DuckDuckGo 브라우저를 이용해서 더 철저하게 "
-"보호받으세요. 이미 설치되어 있으며 다음 기능이 제공됩니다."
+"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 "
+"DuckDuckGo 브라우저를 이용해서 더 철저하게 보호받으세요. 이미 설치되어 있으"
+"며 다음 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -24907,7 +25863,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌러 이 대화를 지우세요."
+msgstr ""
+"이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌"
+"러 이 대화를 지우세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24915,7 +25873,8 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
+msgstr ""
+"이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24929,7 +25888,9 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
+msgstr ""
+"하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25231,7 +26192,9 @@ msgstr "공식 웹사이트"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s 문자입니다)"
+msgstr ""
+"또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s "
+"문자입니다)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (이 장치)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -190,9 +190,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
-"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
-"요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
+"이용하거나, Plus 또는 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -202,9 +201,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
-"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
-"요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
+"이용하거나, Plus 또는 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -220,8 +218,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구"
-"독을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
+"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구독을 다시 활성화해서 채팅을 계속 이용하거나, "
+"무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -229,9 +227,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다"
-"시 시도하세요."
+msgstr "%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -328,8 +324,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사"
-"용자의 메시지나 모델의 응답을 보거나 서버에 이 채팅을 저장할 수 없습니다."
+"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사용자의 메시지나 모델의 응답을 보거나 서버에 이 "
+"채팅을 저장할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -376,8 +372,7 @@ msgstr "%1$s 사용"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s은(는) 기본 모델보다 사용 한도를 최대 2~5배 더 빠르게 소진합니다. %2$s"
+msgstr "%1$s은(는) 기본 모델보다 사용 한도를 최대 2~5배 더 빠르게 소진합니다. %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -415,9 +410,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔"
-"서 이 채팅을 계속할 수 있습니다."
+msgstr "%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -427,9 +420,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채"
-"팅을 계속할 수 있습니다."
+msgstr "%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -441,9 +432,7 @@ msgstr "단어 %1$s개"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합"
-"니다.%7$s"
+msgstr "%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합니다.%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -451,8 +440,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 "
-"표시한 후 %8$s확인%9$s을 클릭합니다."
+"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 표시한 후 %8$s확인%9$s을 "
+"클릭합니다."
 
 # Firefox
 # smartling.placeholder_format=C
@@ -462,8 +451,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s"
-"에 체크 표시한 후 %8$s확인%9$s을 클릭합니다."
+"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s에 체크 표시한 후 "
+"%8$s확인%9$s을 클릭합니다."
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -471,9 +460,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 "
-"시도해 보세요."
+msgstr "이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -491,23 +478,21 @@ msgstr "%1$s더 알아보기%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
+msgstr "%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
+msgstr "DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -525,8 +510,7 @@ msgstr "홈 화면에서 DuckDuckGo 앱 아이콘을 %1$s길게 누릅니다%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
+msgstr "%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -793,7 +777,7 @@ msgstr "%1$s조 2위"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "다른 답변"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -877,17 +861,14 @@ msgstr "6시간 사용 제한에 도달했습니다."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr "6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니"
-"다."
+msgstr "6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -940,17 +921,14 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 "
-"확인하고 다시 시도하세요."
+msgstr "Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 확인하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
+msgstr "새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1001,9 +979,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능"
-"을 끄면 DuckDuckGo Search의 AI Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 "
-"%1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 이용할 수 있습니다."
+"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능을 끄면 DuckDuckGo Search의 AI "
+"Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 %1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 "
+"이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1064,10 +1042,9 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문"
-"을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 제공하는 경우는 많습니다. Duck.ai"
-"는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI 기반 "
-"채팅 서비스입니다."
+"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 "
+"제공하는 경우는 많습니다. Duck.ai는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI "
+"기반 채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1251,9 +1228,7 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr ""
-"이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전"
-"환하세요."
+msgstr "이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1288,18 +1263,14 @@ msgstr "광고"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사"
-"용되지 않습니다."
+msgstr "광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr ""
-"광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 "
-"데 사용되지 않습니다."
+msgstr "광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1349,9 +1320,7 @@ msgstr "DuckDuckGo 확장 프로그램 추가"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세"
-"요."
+msgstr "다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세요."
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1481,7 +1450,7 @@ msgstr "홈 화면에 추가"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "내 채팅에 추가"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1584,9 +1553,7 @@ msgctxt ""
 "model picker dropdown"
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
-msgstr ""
-"고급 모델은 다른 모델보다 사용 한도에 2~5배 더 빠르게 도달할 수 있습니다. "
-"%1$s"
+msgstr "고급 모델은 다른 모델보다 사용 한도에 2~5배 더 빠르게 도달할 수 있습니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1594,8 +1561,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"고급 모델은 다른 모델보다 한도를 2~5배 더 빠르게 소진할 수 있습니다. %1$s"
+msgstr "고급 모델은 다른 모델보다 한도를 2~5배 더 빠르게 소진할 수 있습니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1637,8 +1603,7 @@ msgstr "다운로드가 완료되고 파일이 열리면 %1$s설치%2$s를 클�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
+msgstr "다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1774,8 +1739,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 "
-"대화 내용을 채팅 모델 훈련에 사용하지 않습니다."
+"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 대화 내용을 채팅 모델 훈련에 사용하지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1807,8 +1772,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
+msgstr "모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1822,9 +1786,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니"
-"다."
+msgstr "AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니다."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1849,7 +1811,7 @@ msgstr "모든 종류"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "모든 기기의 동기화가 해제되었습니다."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1862,8 +1824,7 @@ msgstr "허용"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
+msgstr "음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1895,17 +1856,15 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이"
-"터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 보냅니다. %2$s 모델의 프롬"
-"프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
+"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 "
+"보냅니다. %2$s 모델의 프롬프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr ""
-"Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
+msgstr "Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2042,8 +2001,7 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2051,8 +2009,7 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2065,9 +2022,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택"
-"하거나 완전히 비활성화할 수 있습니다."
+msgstr "웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택하거나 완전히 비활성화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2113,9 +2068,7 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr ""
-"Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보"
-"를 들려줘)?"
+msgstr "Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보를 들려줘)?"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2280,8 +2233,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거"
-"나 공유하지 않습니다. 모든 개인정보 보호는 사용자의 기기에서 이루어집니다."
+"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거나 공유하지 않습니다. 모든 개인정보 보호는 "
+"사용자의 기기에서 이루어집니다."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2365,7 +2318,7 @@ msgstr "무엇이든 비공개로 물어보세요"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "무엇이든 비공개로 물어보세요"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2423,11 +2376,10 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 "
-"생성할 수 있습니다. Assist 표시 빈도 선택 가능: 안 함(검색 결과에서 Assist UI"
-"를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), 가끔(관"
-"련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표"
-"시). 현재 AI 지원 답변은 미국(영어) 지역에서만 이용 가능합니다."
+"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 생성할 수 있습니다. Assist 표시 빈도 선택 "
+"가능: 안 함(검색 결과에서 Assist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), "
+"가끔(관련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표시). 현재 AI 지원 답변은 미국(영어) "
+"지역에서만 이용 가능합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2439,10 +2391,9 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이"
-"며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관"
-"련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤"
-"링%2$s을 기반으로 자동 생성합니다."
+"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 "
+"자연어 기술을 사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 "
+"자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2467,9 +2418,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr ""
-"카페, 공항, 호텔에서 DuckDuckGo VPN을 사용하면 연결을 암호화하고 와이파이에"
-"서 IP 주소를 감출 수 있습니다."
+msgstr "카페, 공항, 호텔에서 DuckDuckGo VPN을 사용하면 연결을 암호화하고 와이파이에서 IP 주소를 감출 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2584,17 +2533,13 @@ msgstr "자동 응답"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습"
-"니다."
+msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 "
-"있습니다."
+msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2619,9 +2564,8 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 "
-"익명으로 정보를 조회하고 요약할 수 있습니다. 현재 Assist 서비스는 영어 사용 "
-"지역에서만 제공됩니다."
+"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
+"현재 Assist 서비스는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2630,16 +2574,14 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색"
-"에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. 현재 DuckAssist 서비스"
-"는 영어 사용 지역에서만 제공됩니다."
+"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 "
+"수 있습니다. 현재 DuckAssist 서비스는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
+msgstr "영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2839,8 +2781,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데"
-"이터와 같은 개인정보(PII)를 제거하여 대화 내용을 익명화합니다."
+"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데이터와 같은 개인정보(PII)를 제거하여 대화 "
+"내용을 익명화합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2969,9 +2911,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr ""
-"구독을 통해 유해 사이트 차단, IP 주소 숨기기, 더 많은 프리미엄 보호 기능을 이"
-"용하세요."
+msgstr "구독을 통해 유해 사이트 차단, IP 주소 숨기기, 더 많은 프리미엄 보호 기능을 이용하세요."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3231,18 +3171,16 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 "
-"%1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 "
-"이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
+"암호화 보호 강화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확"
-"장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 이용할 수 "
-"있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
+"암호화 보호 강화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3250,9 +3188,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으"
-"로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 차단, 사이트 암호화 기능을 이"
-"용할 수 있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 "
+"차단, 사이트 암호화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3359,10 +3296,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 "
-"Cloud Save를 사용하여 설정을 보다 영구적으로 저장할 수 있습니다(클라우드의 원"
-"격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암"
-"호 또한 서버에 저장되지 않습니다."
+"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 Cloud Save를 사용하여 설정을 보다 영구적으로 "
+"저장할 수 있습니다(클라우드의 원격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호 또한 서버에 저장되지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3370,8 +3306,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
-"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
+"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s "
+"페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3380,8 +3316,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
-"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
+"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 "
+"%1$s 페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3416,8 +3352,7 @@ msgstr "카메룬"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
+msgstr "닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3737,9 +3672,7 @@ msgstr "전체 사이트에 적용되는 배경 색상을 변경합니다."
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경"
-"합니다."
+msgstr "검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경합니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3868,9 +3801,8 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 "
-"타사 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 DuckDuckGo "
-"Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 타사 AI 채팅 모델과 익명으로 대화할 "
+"수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
 "%1$shttps://duck.ai%2$s에 바로 접속해서 채팅을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
@@ -3926,18 +3858,14 @@ msgstr "비공개로 채팅하기"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅"
-"하세요."
+msgstr "DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공"
-"개로 채팅하세요."
+msgstr "DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4005,9 +3933,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채"
-"팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
+msgstr "채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4019,10 +3945,9 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅"
-"을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버"
-"에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로"
-"운 프롬프트와 응답의 임시 저장이 중단됩니다."
+"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
+"암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 "
+"저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4045,17 +3970,15 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일"
-"은 %2$s의 콘텐츠 조정 공급자에 의한 익명 검토를 거칩니다."
+"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일은 %2$s의 콘텐츠 조정 공급자에 의한 익명 "
+"검토를 거칩니다."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr ""
-"첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화"
-"를 재개할 수 있습니다."
+msgstr "첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화를 재개할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4108,8 +4031,7 @@ msgstr "철자 검사"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
+msgstr "DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4211,9 +4133,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
-msgstr ""
-"전 세계 40개 이상의 서버 위치를 사용하며 유해 사이트와 온라인 사기를 차단하세"
-"요."
+msgstr "전 세계 40개 이상의 서버 위치를 사용하며 유해 사이트와 온라인 사기를 차단하세요."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4411,9 +4331,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무"
-"기한으로 보관하거나, AI Chat을 7일 이상 사용하지 않으면 자동으로 삭제할 수 있"
-"습니다."
+"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무기한으로 보관하거나, AI Chat을 7일 이상 사용하지 "
+"않으면 자동으로 삭제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4423,9 +4342,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅"
-"이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 사용하지 않으면 자동으로 "
-"삭제될 수도 있습니다."
+"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 "
+"사용하지 않으면 자동으로 삭제될 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4433,9 +4351,7 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr ""
-"브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 "
-"DuckDuckGo 무료 브라우저에"
+msgstr "브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 DuckDuckGo 무료 브라우저에"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4444,9 +4360,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모"
-"델을 지원하는 DuckDuckGo의 비공개 AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 "
-"후속 질문을 하세요."
+"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 "
+"AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 후속 질문을 하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4487,9 +4402,7 @@ msgstr "드롭다운 메뉴에서 %1$s검색 설정 변경%2$s을 클릭하세�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환"
-"경설정%4$s을 클릭하세요."
+msgstr "Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환경설정%4$s을 클릭하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4505,9 +4418,7 @@ msgstr "DuckDuckGo 확장 프로그램을 다운로드하려면 %1$s여기%2$s�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세"
-"요."
+msgstr "%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세요."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4521,9 +4432,7 @@ msgstr "왼쪽 사이드바에서 %1$s개인정보 및 서비스%2$s를 클릭�
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s"
-"기어 모양 아이콘%4$s을 클릭하세요)."
+msgstr "상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s기어 모양 아이콘%4$s을 클릭하세요)."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4552,8 +4461,7 @@ msgstr "%1$s예%2$s를 클릭하세요."
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
+msgstr "Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4615,9 +4523,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지"
-"만 브라우저에는 남아있습니다. 남아있는 데이터를 제거하려면 %3$s모든 검색 설"
-"정 초기화%4$s를 클릭하거나 누르세요."
+"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지만 브라우저에는 남아있습니다. 남아있는 데이터를 "
+"제거하려면 %3$s모든 검색 설정 초기화%4$s를 클릭하거나 누르세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4628,9 +4535,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서"
-"는 데이터가 삭제되지만, %3$s모든 설정 초기화%4$s를 클릭하거나 누를 때까지 브"
-"라우저에는 데이터가 남아 있게 됩니다."
+"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서는 데이터가 삭제되지만, %3$s모든 설정 "
+"초기화%4$s를 클릭하거나 누를 때까지 브라우저에는 데이터가 남아 있게 됩니다."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4698,18 +4604,14 @@ msgstr "검색 창에서 드롭다운을 클릭하세요."
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 "
-"%3$sDuckDuckGo%4$s를 선택하세요."
+msgstr "주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 %3$sDuckDuckGo%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr ""
-"광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리"
-"에 있습니다."
+msgstr "광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리에 있습니다."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4909,9 +4811,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 "
-"수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
+msgstr "Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5182,8 +5082,7 @@ msgstr "광고 차단 계속하기"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"최근 채팅을 여기서 계속 이어가거나, Fire Button을 눌러 삭제할 수 있습니다."
+msgstr "최근 채팅을 여기서 계속 이어가거나, Fire Button을 눌러 삭제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5290,7 +5189,7 @@ msgstr "복사"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "복사"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5301,8 +5200,7 @@ msgstr "복사"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
+msgstr "주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5340,13 +5238,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "공유 링크 복사"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "다른 기기에서 코드를 복사해 주세요"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5355,6 +5253,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"다른 기기에서 코드를 복사하세요. %1$sDuck.ai Settings › Chats › Sync & Backup › Sync With "
+"Another Device%2$s로 들어가서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5506,8 +5406,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr ""
-"링크를 생성하면 링크를 연 모든 사람이 볼 수 있는 채팅 사본이 생성됩니다."
+msgstr "링크를 생성하면 링크를 연 모든 사람이 볼 수 있는 채팅 사본이 생성됩니다."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5739,17 +5638,14 @@ msgstr "일일 한도에 도달했습니다."
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr "일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있"
-"습니다."
+msgstr "일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6039,7 +5935,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "공유 링크 삭제"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6060,6 +5956,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"링크를 삭제하면 더 이상 링크를 사용할 수 없습니다. 이미 링크를 열어서 해당 대화를 자신의 채팅에 추가한 사람은 자신이 추가한 사본을 "
+"계속 보유할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6155,8 +6053,7 @@ msgstr "Duck.ai 받아쓰기"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr "당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6173,9 +6070,7 @@ msgstr "받아쓰기를 일시적으로 사용할 수 없습니다"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력"
-"하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
+msgstr "받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6320,7 +6215,7 @@ msgstr "닫기"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "닫기"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6456,9 +6351,7 @@ msgstr "목록에 DuckDuckGo가 보이지 않으시나요?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요."
-"%4$s"
+msgstr "파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6496,8 +6389,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 "
-"AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 AI 이미지를 걸러냅니다. "
+"%3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6506,8 +6399,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하"
-"지 않고 AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하지 않고 AI 이미지를 걸러냅니다. "
+"%3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6622,9 +6515,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr ""
-"실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하"
-"세요."
+msgstr "실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6632,9 +6523,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr ""
-"가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 "
-"작성하세요."
+msgstr "가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6654,9 +6543,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성"
-"하세요."
+msgstr "다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6664,9 +6551,7 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr ""
-"팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써"
-"보세요."
+msgstr "팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써보세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6798,9 +6683,8 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있"
-"습니다. 페이지 내용은 사용자가 첨부할 때만 포함됩니다. 또는 설정에서 페이지 "
-"자동 첨부를 선택하세요."
+"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있습니다. 페이지 내용은 사용자가 첨부할 때만 "
+"포함됩니다. 또는 설정에서 페이지 자동 첨부를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6810,8 +6694,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 "
-"설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 시도하세요."
+"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 "
+"시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6819,16 +6703,13 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr ""
-"Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
+msgstr "Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합"
-"니다!"
+msgstr "Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6837,9 +6718,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사"
-"람들을 위한 독립된 온라인 보호 기업입니다."
+msgstr "Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사람들을 위한 독립된 온라인 보호 기업입니다."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6853,9 +6732,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기"
-"억하기 쉽게 바뀌었습니다."
+msgstr "Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기억하기 쉽게 바뀌었습니다."
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6869,18 +6746,14 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)"
-"를 %2$s 이메일로 보내주세요"
+msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세"
-"요."
+msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6894,9 +6767,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄"
-"면 Duck.ai 버튼과 링크가 숨겨지지만 %1$sduck.ai%2$s에 들어가서 직접 기능을 이"
-"용할 수 있습니다."
+"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄면 Duck.ai 버튼과 링크가 숨겨지지만 "
+"%1$sduck.ai%2$s에 들어가서 직접 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6907,10 +6779,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화"
-"할 수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보"
-"이지 않습니다. 하지만 이 설정이 꺼져 있어도 %1$shttps://duck.ai%2$s에 바로 접"
-"속해서 Duck.ai를 이용할 수 있습니다."
+"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 "
+"DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"%1$shttps://duck.ai%2$s에 바로 접속해서 Duck.ai를 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6924,9 +6795,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr ""
-"Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하"
-"실 수 있습니다."
+msgstr "Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하실 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6963,8 +6832,7 @@ msgstr "Duck.ai가 업그레이드되었습니다!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
+msgstr "Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6974,9 +6842,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필"
-"요 없는 AI 채팅, OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이"
-"버시 중심 AI, 계정 필요 없는 AI 채팅"
+"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필요 없는 AI 채팅, "
+"OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이버시 중심 AI, 계정 필요 없는 AI 채팅"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7004,11 +6871,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
-"DuckAssist 표시 빈도 선택 가능: 안 함(검색 결과에서 DuckAssist UI를 완전히 제"
-"거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 표"
-"시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영"
-"어) 지역에서만 제공됩니다."
+"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. DuckAssist 표시 빈도 선택 가능: 안 "
+"함(검색 결과에서 DuckAssist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 "
+"표시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영어) 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7017,9 +6882,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
-"지원하는 비공개 AI 기반 채팅 서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니"
-"다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7028,9 +6892,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
-"지원하는 비공개 AI 기반 채팅 서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니"
-"다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7042,10 +6905,9 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 "
-"관련 사이트에서 의미있는 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여 "
-"해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용"
-"을 기반으로 답변을 제공하며 정확성 검사는 하지 않습니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 관련 사이트에서 의미있는 콘텐츠를 검색한 "
+"다음 AI 기반 자연어 기술을 사용하여 해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용을 기반으로 "
+"답변을 제공하며 정확성 검사는 하지 않습니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7059,21 +6921,17 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관"
-"련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관련 정보를 바"
-"탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 "
-"바로 링크하고 답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정"
-"보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 자"
-"동 생성합니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 "
+"사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 바로 링크하고 "
+"답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 "
+"기반으로 자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr ""
-"DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습"
-"니다."
+msgstr "DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7081,9 +6939,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채"
-"팅은 내일 계속하세요."
+msgstr "하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7092,8 +6948,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
-"개 AI 기반 채팅 서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스입니다."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7102,8 +6958,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
-"개 AI 기반 채팅 서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스입니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7111,9 +6967,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr ""
-"DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있"
-"습니다."
+msgstr "DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7121,9 +6975,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 "
-"코드(%1$s)를 %2$s 이메일로 보내주세요"
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7131,16 +6983,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다"
-"시 시도하세요."
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7173,7 +7022,7 @@ msgstr "DuckDuckGo 브라우저 %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo 도움말 페이지"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7290,17 +7139,15 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정"
-"보(PII)를 자동으로 제거해 이러한 보고서를 익명화합니다."
+"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정보(PII)를 자동으로 제거해 이러한 보고서를 "
+"익명화합니다."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동"
-"의합니다."
+msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동의합니다."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7308,9 +7155,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s"
-"에 동의합니다."
+msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s에 동의합니다."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7319,8 +7164,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에"
-"서 사용자 추적을 시도하는 Google과 Facebook 등의 추적기도 차단합니다."
+"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에서 사용자 추적을 시도하는 Google과 "
+"Facebook 등의 추적기도 차단합니다."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7332,11 +7177,10 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위"
-"치 정보는 로컬 기기에만 저장됩니다. 사용자가 검색을 하면 사용자의 기기는 해"
-"당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 "
-"데 사용한 후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보"
-"를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 알아보세요%2$s."
+"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위치 정보는 로컬 기기에만 저장됩니다. 사용자가 "
+"검색을 하면 사용자의 기기는 해당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 데 사용한 "
+"후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 "
+"알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7356,8 +7200,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋"
-"은 결과를 제공할 수 있습니다. %1$s자세히 알아보세요%2$s."
+"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋은 결과를 제공할 수 있습니다. %1$s자세히 "
+"알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7449,9 +7293,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 "
-"목록을 받습니다. 그러 다음 브라우저에서 목록에 포함된 4~5개의 무작위 단어를 "
-"선택하여 최소 18~20자 이상의 암호를 만듭니다."
+"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 목록을 받습니다. 그러 다음 브라우저에서 목록에 "
+"포함된 4~5개의 무작위 단어를 선택하여 최소 18~20자 이상의 암호를 만듭니다."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7658,9 +7501,7 @@ msgstr "웹 검색 활성화"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변"
-"경할 수 있습니다."
+msgstr "보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변경할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7702,9 +7543,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위"
-"치는 DuckDuckGo에 공개하지 않을 수 있습니다."
+msgstr "익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위치는 DuckDuckGo에 공개하지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7865,9 +7704,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이"
-"터가 새 암호로 저장됩니다."
+msgstr "새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이터가 새 암호로 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7892,9 +7729,7 @@ msgstr "번역할 내용 입력하기"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네"
-"임%6$s: d%7$s"
+msgstr "다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네임%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7994,16 +7829,14 @@ msgstr "지도 확장하기"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습"
-"니다."
+msgstr "개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습니다."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "만료됨"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8017,7 +7850,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "%1$s 만료"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8279,8 +8112,7 @@ msgstr "피드백이 성공적으로 전송되었습니다."
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
+msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8288,9 +8120,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사"
-"용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
+msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8380,16 +8210,13 @@ msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니�
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
+msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
-"이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세"
-"요%2$s"
+msgstr "이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세요%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8430,8 +8257,7 @@ msgstr "다운로드 폴더에서 <b>%1$s</b> 파일을 찾으세요"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
+msgstr "표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8468,8 +8294,7 @@ msgstr "여러분과 보다 관련있는 결과를 찾아보세요."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
+msgstr "내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8532,9 +8357,7 @@ msgstr "안개"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 "
-"클릭해야 할 수도 있습니다."
+msgstr "안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 클릭해야 할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8651,8 +8474,7 @@ msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
+msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8763,8 +8585,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 확"
-"인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
+"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 "
+"확인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9057,8 +8879,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"DuckDuckGo VPN, 고급 Duck.ai, Identity Theft Restoration을 이용해 보세요."
+msgstr "DuckDuckGo VPN, 고급 Duck.ai, Identity Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9138,8 +8959,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Personal Info Removal, "
-"Identity Theft Restoration을 이용해 보세요."
+"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Personal Info Removal, Identity Theft "
+"Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9147,9 +8968,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr ""
-"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Identity Theft Restoration"
-"을 이용해 보세요."
+msgstr "빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Identity Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9157,9 +8976,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 "
-"Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9169,9 +8986,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 "
-"Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9214,9 +9029,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr ""
-"빠른 노로그 VPN, 옵션으로 이용 가능한 고급 AI 모델(채팅 한도 더 높음), 그 외 "
-"다양한 프리미엄 보호 기능을 이용해 보세요."
+msgstr "빠른 노로그 VPN, 옵션으로 이용 가능한 고급 AI 모델(채팅 한도 더 높음), 그 외 다양한 프리미엄 보호 기능을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9225,24 +9038,20 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"안전한 노로그 VPN, 고급 Duck.ai를 사용해 보세요. Personal Information "
-"Removal 및 Identity Theft Restoration을 이용해 보세요."
+"안전한 노로그 VPN, 고급 Duck.ai를 사용해 보세요. Personal Information Removal 및 Identity "
+"Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"안전한 노로그 VPN, 고급 Duck.ai, Identity Theft Restoration 서비스를 이용해 "
-"보세요."
+msgstr "안전한 노로그 VPN, 고급 Duck.ai, Identity Theft Restoration 서비스를 이용해 보세요."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 "
-"수 있습니다."
+msgstr "다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9278,8 +9087,7 @@ msgstr "앱 받기"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"무료 DuckDuckGo 브라우저를 다운로드하여 %1$sYouTube 광고를 차단하세요.%2$s"
+msgstr "무료 DuckDuckGo 브라우저를 다운로드하여 %1$sYouTube 광고를 차단하세요.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9338,8 +9146,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9348,8 +9156,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9359,8 +9167,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device%4$s로 들어가서 코드 스캔:"
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device%4$s로 들어가서 코드 스캔:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9370,9 +9178,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR"
-"을 스캔하세요."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9381,6 +9188,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"%1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With Another "
+"Device%4$s로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9394,9 +9203,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr ""
-"%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비"
-"스'가 켜져 있는지 확인합니다."
+msgstr "%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비스'가 켜져 있는지 확인합니다."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9404,9 +9211,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 "
-"%3$sDuckDuckGo%4$s를 찾습니다."
+msgstr "%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 %3$sDuckDuckGo%4$s를 찾습니다."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9496,7 +9301,7 @@ msgstr "이해했습니다."
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "이해했습니다."
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10094,9 +9899,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 "
-"강조 표시합니다."
+msgstr "중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 강조 표시합니다."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10123,8 +9926,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그"
-"런 다음 %5$s기본값으로 설정%6$s을 클릭하세요"
+"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그런 다음 %5$s기본값으로 "
+"설정%6$s을 클릭하세요"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10137,9 +9940,7 @@ msgstr "몽족어"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 "
-"보호 기능을 사용할 수 없게 됩니다."
+msgstr "잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 보호 기능을 사용할 수 없게 됩니다."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10188,9 +9989,7 @@ msgstr "더움"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr ""
-"호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수"
-"집하는 데 사용되지 않습니다."
+msgstr "호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10452,9 +10251,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으"
-"며, 그 이유는 무엇인가요?"
+msgstr "바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으며, 그 이유는 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10488,9 +10285,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 "
-"및 개인정보 보호 재설정%2$s으로 이동하세요."
+msgstr "여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 및 개인정보 보호 재설정%2$s으로 이동하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10500,8 +10295,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사"
-"이트 설정 > 위치%2$s로 이동하여 DuckDuckGo의 위치 접근을 허용하세요."
+"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사이트 설정 > 위치%2$s로 이동하여 "
+"DuckDuckGo의 위치 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10515,9 +10310,7 @@ msgstr "이 오류가 계속되면 %1$s에 문의하세요."
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가"
-"해야 합니다."
+msgstr "만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10525,9 +10318,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이"
-"지에 직접 문의하실 수도 있습니다."
+msgstr "채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이지에 직접 문의하실 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10535,17 +10326,13 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니"
-"다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
+msgstr "기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주"
-"세요%2$s"
+msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주세요%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10554,8 +10341,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
+msgstr "JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10703,8 +10489,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 "
-"서버를 통해 처리되도록 경로 변경이 필요합니다. %1$s자세히 알아보세요%2$s."
+"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 서버를 통해 처리되도록 경로 변경이 필요합니다. "
+"%1$s자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10714,9 +10500,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동"
-"기화”로 이동하세요."
+msgstr "DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동기화”로 이동하세요."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10730,9 +10514,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개"
-"됩니다."
+msgstr "투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개됩니다."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11137,9 +10919,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 "
-"통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 연결되며, 광고와는 달리 "
-"DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
+"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 "
+"연결되며, 광고와는 달리 DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11147,8 +10928,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
+msgstr "임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11220,8 +11000,7 @@ msgstr "두 기기 모두에서 Sync & Backup을 열어둘 수 있습니다."
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr ""
-"한번에 최대 5대의 기기에서 모든 앱과 온라인 활동을 비공개로 유지하세요."
+msgstr "한번에 최대 5대의 기기에서 모든 앱과 온라인 활동을 비공개로 유지하세요."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11458,7 +11237,7 @@ msgstr "%1$s더%2$s 알아보기"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "자세히 알아보기"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -12094,7 +11873,7 @@ msgstr "관리"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "관리"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12351,7 +12130,7 @@ msgstr "메뉴"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "이 지점 이후의 메시지는 나에게만 보입니다."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12381,8 +12160,7 @@ msgstr "미크로네시아"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
+msgstr "마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12724,7 +12502,7 @@ msgstr "Duck.ai 더 알아보기"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "작업 더 보기"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12924,7 +12702,7 @@ msgstr "톤 다운된 빨간색"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "내 기기"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13166,10 +12944,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트"
-"와 응답을 암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성"
-"화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니"
-"다."
+"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버에 임시로 "
+"저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13484,8 +13260,7 @@ msgstr "검색 결과가 없습니다."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
+msgstr "음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13991,9 +13766,7 @@ msgstr "요청 시"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이"
-"콘 > 설정을 클릭하세요.%5$s"
+msgstr "Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이콘 > 설정을 클릭하세요.%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14002,6 +13775,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
+"Another Device%4$s로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14010,6 +13785,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
+"Another Device%4$s로 들어가서 코드 스캔:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14018,6 +13795,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
+"Another Device%4$s로 들어가거나 복구 PDF에 있는 QR 코드를 스캔하세요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14044,9 +13823,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 "
-"파일을 업로드하세요."
+msgstr "첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 파일을 업로드하세요."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14072,9 +13849,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지"
-"를 참고하세요."
+msgstr "사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지를 참고하세요."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14088,8 +13863,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
+msgstr "이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14411,9 +14185,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 "
-"추적하지 않습니다."
+msgstr "다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 추적하지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14426,18 +14198,14 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr ""
-"빠른 노로그 VPN과 함께 더 높은 한도의 스마트한 AI 채팅, 그 외 다양한 프리미"
-"엄 보호 기능을 올인원 구독으로 이용해 보세요."
+msgstr "빠른 노로그 VPN과 함께 더 높은 한도의 스마트한 AI 채팅, 그 외 다양한 프리미엄 보호 기능을 올인원 구독으로 이용해 보세요."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr ""
-"DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공"
-"유하지 않습니다."
+msgstr "DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공유하지 않습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14445,8 +14213,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강"
-"화 등의 기능이 탑재되어 있습니다. %1$siOS 및 Android%2$s에서 다운로드하세요."
+"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강화 등의 기능이 탑재되어 있습니다. %1$siOS "
+"및 Android%2$s에서 다운로드하세요."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14698,9 +14466,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 "
-"않기 때문에 암호를 복구할 수 없습니다."
+msgstr "해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 않기 때문에 암호를 복구할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14770,7 +14536,7 @@ msgstr "최근 일 년"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "붙여넣기"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14788,7 +14554,7 @@ msgstr "동기화 코드 붙여넣기"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "아래에 붙여넣어 주세요"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14847,7 +14613,7 @@ msgstr "페르시아어"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14856,6 +14622,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal은 정보를 판매하는 데이터 브로커 사이트에서 사용자의 정보를 찾아내서 정보 삭제를 "
+"도와드립니다."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14926,9 +14694,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 "
-"답변 수준이 높아질 수 있습니다. 이 기능을 끄고 Assist 버튼을 숨기려면 %1$s검"
-"색 설정%2$s으로 들어가세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 답변 수준이 높아질 수 있습니다. 이 기능을 끄고 "
+"Assist 버튼을 숨기려면 %1$s검색 설정%2$s으로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14937,9 +14704,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어"
-"난 답을 얻을 가능성이 높아집니다. %1$sDuckAssist 설정%2$s에서 이 기능을 끄거"
-"나 작동 방식을 조정할 수 있습니다."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어난 답을 얻을 가능성이 높아집니다. "
+"%1$sDuckAssist 설정%2$s에서 이 기능을 끄거나 작동 방식을 조정할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14949,9 +14715,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 "
-"더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 끄고 Assist 버튼을 감추려면 "
-"%1$sDuckAssist 설정%2$s을 방문하세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 "
+"끄고 Assist 버튼을 감추려면 %1$sDuckAssist 설정%2$s을 방문하세요."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14983,9 +14748,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
-"보세요."
+msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14993,9 +14756,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
-"보세요."
+msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15003,9 +14764,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보"
-"호 기능이 제공되지 않습니다."
+msgstr "목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보호 기능이 제공되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15153,9 +14912,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해"
-"하거나 불법적인 이유를 설명해 주세요."
+msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해하거나 불법적인 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15163,9 +14920,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법"
-"이거나 해로운 이유를 설명해 주세요."
+msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법이거나 해로운 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15317,9 +15072,7 @@ msgstr "DuckDuckGo를 구독하면 더 많은 프리미엄 기능들도 따라�
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니"
-"다."
+msgstr "또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15381,9 +15134,7 @@ msgstr "형식이 조악함"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
-"인기 있는 AI 모델을 사용할 수 있습니다. 계정이 없어도 괜찮습니다. DuckDuckGo"
-"가 익명화하는 채팅입니다."
+msgstr "인기 있는 AI 모델을 사용할 수 있습니다. 계정이 없어도 괜찮습니다. DuckDuckGo가 익명화하는 채팅입니다."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15820,8 +15571,7 @@ msgstr "DuckDuckGo는 절대 저장하지 않는 비공개 채팅"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr ""
-"DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
+msgstr "DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -15893,9 +15643,7 @@ msgstr "재생하기 전에 물어보기"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니"
-"다."
+msgstr "내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니다."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15913,8 +15661,7 @@ msgstr "검색과 인터넷 이용 과정에서 데이터를 보호하세요."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
+msgstr "검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15938,9 +15685,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입"
-"력]"
+msgstr "다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입력]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16115,7 +15860,7 @@ msgstr "웹사이트 읽는 중…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "일식 보러 가실래요?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16157,8 +15902,7 @@ msgstr "추론을 통해 복잡한 질문에 대해 더 나은 답변을 얻을 
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"추론 기능이 더 뛰어나지만, 사용 한도에 2~5배 더 빠르게 도달합니다. %1$s"
+msgstr "추론 기능이 더 뛰어나지만, 사용 한도에 2~5배 더 빠르게 도달합니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16213,9 +15957,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
-"됩니다."
+msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16223,9 +15965,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
-"됩니다."
+msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16235,9 +15975,8 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 "
-"때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 "
-"DuckDuckGo 서버에 임시로 저장합니다."
+"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
+"암호화하여 DuckDuckGo 서버에 임시로 저장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16311,7 +16050,7 @@ msgstr "복구 코드"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "복구 코드"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16518,9 +16257,7 @@ msgstr "Duck.ai를 다시 불러오기"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 "
-"DuckDuckGo를 새로고침하세요."
+msgstr "안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 DuckDuckGo를 새로고침하세요."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16566,7 +16303,7 @@ msgstr "%1$s 삭제"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "기기 제거"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16614,31 +16351,27 @@ msgstr "불필요한 문장 부호를 제거해 보세요"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "인터넷에서 개인정보를 삭제하세요"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "온라인에서 개인정보를 삭제하세요"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 "
-"항상 자동으로 표시됩니다."
+msgstr "'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변"
-"이 항상 자동으로 표시됩니다."
+msgstr "'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16696,18 +16429,15 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. "
-"사용자님이 익명으로 보내주신 의견은 %1$s 사에도 서비스 개선을 위해 제공됩니"
-"다."
+"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. 사용자님이 익명으로 보내주신 의견은 %1$s "
+"사에도 서비스 개선을 위해 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 "
-"기재하지 마세요."
+msgstr "DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16716,9 +16446,8 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 "
-"요청하는 모든 텍스트가 들어있으며, 이 텍스트는 익명 상태입니다. 피드백에 개"
-"인 정보나 식별 정보를 기재하지 마세요."
+"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 요청하는 모든 텍스트가 들어있으며, 이 텍스트는 "
+"익명 상태입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16810,9 +16539,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. AI 지원 답변에는 %1$s서비스 약관%2$s"
-"이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. AI 지원 "
+"답변에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16821,9 +16549,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. DuckAssist에는 %1$s서비스 약관%2$s이 "
-"적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. "
+"DuckAssist에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16833,10 +16560,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 바탕으로 자동 생성된 응답"
-"이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약"
-"관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 "
+"바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17260,9 +16985,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많"
-"이 저장할 수도 있습니다."
+msgstr "최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많이 저장할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17311,7 +17034,7 @@ msgstr "안녕하세요, Duck.ai입니다!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "DuckDuckGo가 선보이는 비공개 무료 AI 채팅 서비스, Duck.ai를 만나보세요."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17428,9 +17151,7 @@ msgstr "아래로 스크롤하여 %1$s고급 설정 보기%2$s를 클릭하세�
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변"
-"경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
+msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17438,9 +17159,7 @@ msgstr ""
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr ""
-"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 "
-"%5$s새로 추가%6$s)을 클릭하세요."
+msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17464,9 +17183,7 @@ msgstr "%1$sDuckDuckGo%2$s로 스크롤하여 사용자의 위치를 사용하�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클"
-"릭하세요."
+msgstr "아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17520,12 +17237,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 "
-"콘텐츠를 검색한 다음 AI를 사용하여 간단한 답변을 생성합니다. 답변 표시 빈도"
-"는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클"
-"릭했을 때만), 가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 "
-"때 표시) 중 선택하세요. 현재 Search Assist는 영어를 사용하는 일부 지역에만 제"
-"공됩니다."
+"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 콘텐츠를 검색한 다음 AI를 사용하여 간단한 "
+"답변을 생성합니다. 답변 표시 빈도는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클릭했을 때만), "
+"가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 때 표시) 중 선택하세요. 현재 Search Assist는 영어를 "
+"사용하는 일부 지역에만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17533,8 +17248,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 "
-"충분히 찾지 못했습니다. 다른 검색을 시도해 보세요."
+"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 충분히 찾지 못했습니다. 다른 검색을 시도해 "
+"보세요."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17543,9 +17258,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이"
-"를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s 한 다음 AI를 사용하여 찾은 정보를 "
-"기반으로 간단한 답변을 생성합니다."
+"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s "
+"한 다음 AI를 사용하여 찾은 정보를 기반으로 간단한 답변을 생성합니다."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17666,8 +17380,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 "
-"위키피디아에서 바로 'ducks'를 바로 검색합니다."
+"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 위키피디아에서 바로 'ducks'를 바로 "
+"검색합니다."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17686,18 +17400,15 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하"
-"는 브라우저에 비공개 웹 검색 기능을 설치하거나, %1$sduckduckgo.com%2$s에서 바"
-"로 검색하세요."
+"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하는 브라우저에 비공개 웹 검색 기능을 설치하거나, "
+"%1$sduckduckgo.com%2$s에서 바로 검색하세요."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
 msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
-msgstr ""
-"검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용"
-"합니다)."
+msgstr "검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용합니다)."
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17709,10 +17420,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저"
-"장됩니다. 하지만 Cloud Save를 사용하여 클라우드 원격 서버에 설정을 익명으로 "
-"저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으"
-"며, 암호가 브라우저 밖으로 유출되지 않습니다."
+"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저장됩니다. 하지만 Cloud Save를 사용하여 클라우드 "
+"원격 서버에 설정을 익명으로 저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호가 브라우저 밖으로 "
+"유출되지 않습니다."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17814,9 +17524,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17824,9 +17532,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17834,9 +17540,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 동기화된 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 동기화된 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17844,9 +17548,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 "
-"기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17860,9 +17562,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데"
-"이터는 본인 외에 누구도 볼 수 없습니다."
+msgstr "DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데이터는 본인 외에 누구도 볼 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18012,9 +17712,7 @@ msgstr "Safari 메뉴에서 %1$s'이 웹사이트의 설정'%2$s을 선택하세
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입"
-"력하세요."
+msgstr "%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입력하세요."
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18078,18 +17776,14 @@ msgstr "드롭다운 메뉴에서 %1$s추가 기능 관리%2$s를 선택하세�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설"
-"정%4$s을 선택하세요."
+msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설정%4$s을 선택하세요."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵"
-"션%4$s을 선택하세요."
+msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵션%4$s을 선택하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18153,8 +17847,7 @@ msgstr "%1$s설정%2$s을 선택한 다음 %3$s검색 엔진%4$s을 선택하세
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
+msgstr "%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18275,9 +17968,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞"
-"으로 나와 나누는 모든 대화에 적용됩니다."
+msgstr "AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞으로 나와 나누는 모든 대화에 적용됩니다."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18304,7 +17995,7 @@ msgstr "세르비아어(라틴)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "서버 데이터가 삭제되었습니다"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18399,9 +18090,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지"
-"하세요."
+msgstr "채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지하세요."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18464,7 +18153,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "공유"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18481,9 +18170,7 @@ msgstr "공유"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세"
-"요!"
+msgstr "DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세요!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18510,8 +18197,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용"
-"자의 정확한 위치를 우리에게나 AI 모델에게나 절대 공개하지 않습니다."
+"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용자의 정확한 위치를 우리에게나 AI 모델에게나 "
+"절대 공개하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18606,8 +18293,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
+msgstr "DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18619,13 +18305,13 @@ msgstr "검색창에 당신의 생각을 적어주세요."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "공유 채팅 링크"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "공유 채팅 링크"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18633,9 +18319,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr ""
-"로그를 남기지 않는 빠른 VPN으로 온라인 활동을 보호하세요. 설정이 간편하고 언"
-"제든 쉽게 켜고 끌 수 있어요."
+msgstr "로그를 남기지 않는 빠른 VPN으로 온라인 활동을 보호하세요. 설정이 간편하고 언제든 쉽게 켜고 끌 수 있어요."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18993,17 +18677,15 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알"
-"림을 숨기며 검색 개인정보에는 영향을 주지 않습니다."
+"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알림을 숨기며 검색 개인정보에는 영향을 주지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림"
-"만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
+msgstr "DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19148,8 +18830,7 @@ msgstr "사이트 이름"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
+msgstr "사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19301,7 +18982,7 @@ msgstr "문제가 발생했습니다"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "이 공유 대화를 불러오는 중 문제가 발생했어요."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19381,8 +19062,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
+msgstr "업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19390,9 +19070,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는"
-"지 확인하세요."
+msgstr "죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는지 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19406,9 +19084,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여"
-"기를 클릭%2$s하세요."
+msgstr "죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여기를 클릭%2$s하세요."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -19468,8 +19144,7 @@ msgstr "원문 지움"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
+msgstr "원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19818,9 +19493,7 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr ""
-"DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많"
-"이 만들어 보세요."
+msgstr "DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20145,7 +19818,7 @@ msgstr "모델 전환"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "모델 전환"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20327,13 +20000,11 @@ msgid ""
 msgstr ""
 "동기화 복구 코드\n"
 "\n"
-"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅"
-"을 동기화할 수 있으며, 장치에 액세스할 수 없는 경우 동기화된 데이터를 복구할 "
-"수 있습니다.\n"
+"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅을 동기화할 수 있으며, 장치에 액세스할 수 없는 "
+"경우 동기화된 데이터를 복구할 수 있습니다.\n"
 "\n"
 "이 정보를 안전하게 보관하세요.\n"
-"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니"
-"다.\n"
+"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니다.\n"
 "\n"
 "%1$s\n"
 "\n"
@@ -20342,8 +20013,8 @@ msgstr ""
 "2. \"Sync & Backup\"를 선택한 다음, \"동기화된 데이터 복구\"를 선택합니다.\n"
 "3. 위 복구 코드를 복사하여 \"여기에 코드 붙여넣기\"에 붙여넣습니다.\n"
 "\n"
-"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 "
-"않으면 서버에서 데이터가 삭제되어 복원할 수 없습니다."
+"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 않으면 서버에서 데이터가 삭제되어 "
+"복원할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20404,7 +20075,7 @@ msgstr "동기화된 기기"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "동기화 날짜: %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20442,7 +20113,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "표"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20475,9 +20146,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
-"어디서나 Duck.ai를 이용해 보세요. 어디서든 더 빠르게 이용할 수 있도록 무료 앱"
-"에 내장하세요."
+msgstr "어디서나 Duck.ai를 이용해 보세요. 어디서든 더 빠르게 이용할 수 있도록 무료 앱에 내장하세요."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20485,9 +20154,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
-"어디서나 Duck.ai를 이용해 보세요. 어디서 웹서핑을 하든 더 빠르게 이용할 수 있"
-"도록 무료 브라우저에 내장하세요."
+msgstr "어디서나 Duck.ai를 이용해 보세요. 어디서 웹서핑을 하든 더 빠르게 이용할 수 있도록 무료 브라우저에 내장하세요."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20731,9 +20398,8 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 "
-"가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 비밀번호 또는 결제 세부 정"
-"보가 이에 포함됩니다."
+"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 "
+"비밀번호 또는 결제 세부 정보가 이에 포함됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20741,9 +20407,7 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr ""
-"Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으"
-"로 저장할 수 있습니다."
+msgstr "Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20772,8 +20436,7 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr ""
-"암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
+msgstr "암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -20852,9 +20515,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활"
-"성화되어 있는지 브라우저 설정에서 확인하세요."
+msgstr "이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활성화되어 있는지 브라우저 설정에서 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20868,8 +20529,7 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr ""
-"검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
+msgstr "검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20888,9 +20548,8 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, "
-"DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 웹사이트의 개인정보 보호를 "
-"강화하는 데 적용됩니다."
+"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 "
+"웹사이트의 개인정보 보호를 강화하는 데 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20927,9 +20586,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세"
-"요."
+msgstr "이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20937,9 +20594,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅"
-"을 시작해 보세요."
+msgstr "이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20978,8 +20633,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
-"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 "
+"수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20989,8 +20644,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
-"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %2$s 참조)."
+"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 "
+"있습니다(자세한 내용은 %2$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20999,8 +20654,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌"
-"한 정보를 제공할 수 있습니다(자세한 내용은 %2$s 참고)."
+"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌한 정보를 제공할 수 있습니다(자세한 내용은 "
+"%2$s 참고)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21010,15 +20665,14 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습"
-"니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용"
-"은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습니다. AI 채팅은 부정확하거나 "
+"공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "이 장치"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21028,7 +20682,7 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr ""
+msgstr "이 기기는 앞으로 다른 기기에서 동기화된 데이터에 접근할 수 없습니다. 마지막 채팅 %1$s개는 로컬 저장소에 남습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21099,16 +20753,14 @@ msgstr "이 이미지를 만들 수 없습니다."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
+msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
+msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21119,7 +20771,7 @@ msgstr "이 정보는 유용하지 않습니다."
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "공유된 채팅의 사본이에요."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21127,9 +20779,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
-"샘플 채팅입니다. 메뉴(점 3개)를 열고 '고정'을 선택하여 채팅 목록 맨 위에 계"
-"속 표시되도록 하세요."
+msgstr "샘플 채팅입니다. 메뉴(점 3개)를 열고 '고정'을 선택하여 채팅 목록 맨 위에 계속 표시되도록 하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21137,8 +20787,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
-"샘플 채팅입니다. 측면 메뉴에 있는 Fire Button을 사용하여 삭제해 보세요!"
+msgstr "샘플 채팅입니다. 측면 메뉴에 있는 Fire Button을 사용하여 삭제해 보세요!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21158,9 +20807,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 "
-"제공사는 데이터를 보유하지 않는 모델을 따릅니다."
+msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 제공사는 데이터를 보유하지 않는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21168,9 +20815,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공"
-"사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
+msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21206,9 +20851,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 "
-"모든 브라우저에서 접근할 수 있습니다."
+msgstr "이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 모든 브라우저에서 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21216,9 +20859,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
-"면 AI 지원 답변이 다시 표시될 수 있습니다."
+msgstr "이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21228,21 +20869,20 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
-"면 AI 지원 답변이 다시 표시될 수 있습니다. 하지만 AI 지원 답변이 절대 표시되"
-"지 않는 시작 페이지(%1$s)도 있습니다."
+"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다. "
+"하지만 AI 지원 답변이 절대 표시되지 않는 시작 페이지(%1$s)도 있습니다."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "이 공유된 채팅을 열 수 없어요. 링크가 불완전할 수 있어요."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "이 공유 채팅 링크는 더 이상 이용할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21265,17 +20905,13 @@ msgstr "이 번역은 잘못되었습니다."
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 "
-"수 있습니다."
+msgstr "아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 "
-"사용하지 않고 있습니다."
+msgstr "이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 사용하지 않고 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21285,9 +20921,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결"
-"이 끊깁니다. Sync & Backup에 연결된 다른 브라우저에서는 계속 채팅을 볼 수 있"
-"습니다."
+"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결이 끊깁니다. Sync & Backup에 "
+"연결된 다른 브라우저에서는 계속 채팅을 볼 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21295,9 +20930,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌"
-"릴 수 없습니다."
+msgstr "이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21389,9 +21022,7 @@ msgstr "팁"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니"
-"다.%2$s"
+msgstr "개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니다.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21436,9 +21067,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인"
-"쇄 아이콘을 클릭하세요.%4$s"
+msgstr "경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인쇄 아이콘을 클릭하세요.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21448,9 +21077,8 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합"
-"니다. 이 코드는 Sync를 설치할 때 원래 사용한 기기에 PDF로 저장되었을 수 있습"
-"니다."
+"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합니다. 이 코드는 Sync를 설치할 때 원래 사용한 "
+"기기에 PDF로 저장되었을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21458,18 +21086,14 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트"
-"하고 다시 시도하세요."
+msgstr "채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr ""
-"받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허"
-"용해 주세요."
+msgstr "받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허용해 주세요."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21491,9 +21115,7 @@ msgstr "오늘"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"전환하여 비공개 AI 채팅을 사용해 보거나 %1$s %2$s 메뉴에서 비활성화하세요."
-"%3$s"
+msgstr "전환하여 비공개 AI 채팅을 사용해 보거나 %1$s %2$s 메뉴에서 비활성화하세요.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21666,9 +21288,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되"
-"었는지 둘러보세요."
+msgstr "DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되었는지 둘러보세요."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21715,9 +21335,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
-"주세요."
+msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21725,9 +21343,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
-"주세요."
+msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21892,7 +21508,7 @@ msgstr "무료 체험"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "무료 체험!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22011,7 +21627,7 @@ msgstr "무료 체험"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "무료로 체험하세요!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22113,9 +21729,7 @@ msgstr "위치를 수동으로 설정하세요."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 "
-"보호."
+msgstr "%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 보호."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22207,8 +21821,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 "
-"설치하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 설치하면 설정을 기억시킬 수 "
+"있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22217,8 +21831,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 "
-"전환하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 전환하면 설정을 기억시킬 수 "
+"있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22260,7 +21874,7 @@ msgstr "투르크메니스탄"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "끄기"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22278,7 +21892,7 @@ msgstr "Sync & Backup 끄기"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Sync & Backup과 Delete Server Data를 끄시겠어요?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22418,9 +22032,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표"
-"시되기까지 시간이 조금 지연될 수 있습니다."
+msgstr "DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표시되기까지 시간이 조금 지연될 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22549,30 +22161,24 @@ msgstr "장점과 단점 파악"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이"
-"지 설정%6$s을 클릭하세요."
+msgstr "%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이지 설정%6$s을 클릭하세요."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com"
-"을 입력하세요."
+msgstr "%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
+msgstr "%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
+msgstr "%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22582,8 +22188,7 @@ msgstr "%1$s검색 설정%2$s에서 %3$sDuckDuckGo%4$s를 선택하세요."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
+msgstr "%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -22595,8 +22200,7 @@ msgstr "%1$s검색%2$s 섹션에서, %3$s검색 엔진 관리...%4$s를 클릭�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
+msgstr "시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22679,9 +22283,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사"
-"용 한도를 이용하세요."
+msgstr "Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사용 한도를 이용하세요."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22759,7 +22361,7 @@ msgstr "음소거 해제"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "제목 없는 채팅"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22800,7 +22402,7 @@ msgstr "브라우저 업데이트"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "이 공유된 채팅을 보려면 Duck.ai를 업데이트하세요."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22838,9 +22440,7 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr ""
-"DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 "
-"이용하세요."
+msgstr "DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22964,9 +22564,7 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr ""
-"Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 "
-"더 많이 만들어 보세요."
+msgstr "Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -23068,8 +22666,8 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채"
-"팅을 보호하세요. 정보를 기밀로 유지하세요. 무료로. 계정이 없어도 괜찮습니다."
+"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채팅을 보호하세요. 정보를 기밀로 유지하세요. "
+"무료로. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23123,17 +22721,14 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr ""
-"기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 "
-"보관하세요."
+msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 보관하세요."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr ""
-"기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
+msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23282,9 +22877,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소"
-"프트의 광고 네트워크에서 관리합니다."
+msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소프트의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23292,9 +22885,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 "
-"TripAdvisor의 광고 네트워크에서 관리합니다."
+msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 TripAdvisor의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23321,9 +22912,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명"
-"을 따르세요."
+msgstr "휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명을 따르세요."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23338,8 +22927,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
-"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
+"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & Backup%4$s > "
+"%5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23349,9 +22938,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아"
-"래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF"
-"에 있는 QR을 스캔하세요."
+"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 '켜기'를 선택하고 "
+"''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23361,9 +22949,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > "
-"%3$sSync & Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선"
-"택하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
+"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23373,9 +22960,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. "
-"Sync & Backup 아래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세"
-"요. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 "
+"'켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23427,8 +23013,7 @@ msgstr "음성 채팅이 끝났습니다"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr "당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23571,9 +23156,7 @@ msgstr "Duck Player에서 보기"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 "
-"YouTube 추천 영상이 달라지지 않습니다."
+msgstr "Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 YouTube 추천 영상이 달라지지 않습니다."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23593,9 +23176,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하"
-"는 웹사이트에서 사용자를 추적할 수 있습니다. DuckDuckGo는 동영상 대부분을 호"
-"스팅하는 YouTube와 무관한 독립적인 기업입니다."
+"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하는 웹사이트에서 사용자를 추적할 수 있습니다. "
+"DuckDuckGo는 동영상 대부분을 호스팅하는 YouTube와 무관한 독립적인 기업입니다."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23607,9 +23189,7 @@ msgstr "DuckDuckGo의 익명화"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니"
-"다."
+msgstr "더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23621,8 +23201,8 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저"
-"희가 문제를 조사하고 해결할 수 있도록 이대화를 DuckDuckGo와 공유해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저희가 문제를 조사하고 해결할 수 있도록 이대화를 "
+"DuckDuckGo와 공유해 주세요."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23634,9 +23214,8 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저"
-"희가 문제를 조사하고 해결할 수 있도록 사용하신 프롬프트와 응답 내용을 보내서 "
-"신고해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저희가 문제를 조사하고 해결할 수 있도록 사용하신 "
+"프롬프트와 응답 내용을 보내서 신고해 주세요."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23677,9 +23256,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따"
-"라다니며 광고를 게재하지 않습니다. DuckDuckGo는 사용자를 추적하지 않습니다. "
-"절대."
+"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따라다니며 광고를 게재하지 않습니다. "
+"DuckDuckGo는 사용자를 추적하지 않습니다. 절대."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23692,9 +23270,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 "
-"알려주시면 도움이 될 것 같습니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23702,9 +23278,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알"
-"려주시면 도움이 될 것 같습니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23715,9 +23289,7 @@ msgstr "DuckDuckGo는 절대로 사용자를 추적하지 않습니다."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
-"니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23746,24 +23318,19 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사"
-"용자를 추적하는 광고주에게 판매할 수 있는 어떠한 정보도 보유하고 있지 않습니"
-"다."
+"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사용자를 추적하는 광고주에게 판매할 수 있는 어떠한 "
+"정보도 보유하고 있지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하"
-"지 않습니다."
+msgstr "DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
-"니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23777,7 +23344,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr ""
+msgstr "데이터 브로커 사이트에서 개인정보를 찾아 삭제해 드립니다. VPN 등의 기능까지 함께 이용하세요."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23785,9 +23352,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않"
-"도록 보장합니다."
+msgstr "DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않도록 보장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23811,9 +23376,7 @@ msgstr "연결이 끊겼습니다. 메시지를 다시 보내 보세요."
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr ""
-"우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터"
-"를 악용하지 않습니다."
+msgstr "우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터를 악용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23821,9 +23384,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든"
-"지 설정을 변경할 수 있습니다."
+msgstr "익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든지 설정을 변경할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -23831,22 +23392,18 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr ""
+msgstr "데이터 브로커 사이트에 있는 사용자의 개인정보를 정기적으로 스캔해서, 사용하기 쉬운 대시보드를 통해 진행 상황을 알려드립니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 "
-"좋게 발전시킵니다."
+msgstr "여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 좋게 발전시킵니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 "
-"포함해서 말이죠."
+msgstr "여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 포함해서 말이죠."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23862,8 +23419,8 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s"
-"의 재량에 따라 적용됩니다. 정정 사항이 결과에 바로 나타나지 않을 수 있습니다."
+"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s의 재량에 따라 적용됩니다. 정정 사항이 결과에 "
+"바로 나타나지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23876,7 +23433,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr ""
+msgstr "데이터 브로커 사이트에서 사용자의 이메일, 이름, 주소 등을 스캔해서 발견된 정보가 삭제되도록 도와드립니다."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23884,9 +23441,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문"
-"의하세요."
+msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문의하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23894,9 +23449,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제"
-"가 해결되는 경우도 있습니다."
+msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제가 해결되는 경우도 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23910,9 +23463,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노"
-"력 중입니다."
+msgstr "불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노력 중입니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23920,9 +23471,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr ""
-"Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치"
-"세요."
+msgstr "Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치세요."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24030,8 +23579,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr ""
-"주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
+msgstr "주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24045,8 +23593,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되"
-"며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 "
+"사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24055,8 +23603,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공"
-"개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 "
+"저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24066,9 +23614,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 "
-"세션입니다. 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저"
-"장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 세션입니다. 여기서 이루어지는 모든 "
+"채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24141,9 +23688,7 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr ""
-"정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로"
-"고침해 보세요."
+msgstr "정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로고침해 보세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24177,9 +23722,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 "
-"개 알려 주세요."
+msgstr "“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 개 알려 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24191,7 +23734,7 @@ msgstr "연금의 장단점은 무엇인가요?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Duck.ai의 장점은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24204,10 +23747,9 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? "
-"DuckDuckGo 공식 출처만 참고하세요. 답변은 명료하게 섹션을 나누어 작성하고 제"
-"목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 "
-"유무에 관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
+"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? DuckDuckGo 공식 출처만 참고하세요. "
+"답변은 명료하게 섹션을 나누어 작성하고 제목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 유무에 "
+"관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24442,8 +23984,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
+msgstr "Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24518,8 +24059,7 @@ msgstr "무엇에 대해 피드백을 주고 싶으세요?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
+msgstr "DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24544,9 +24084,7 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr ""
-"초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나"
-"요?"
+msgstr "초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나요?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24747,8 +24285,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai를 사용하면 채팅 내용이 익명화되며, AI 학습에 절대 사용되지 않습니다. "
-"'%1$s' 메뉴에서 언제든지 켜거나 끌 수 있습니다."
+"Duck.ai를 사용하면 채팅 내용이 익명화되며, AI 학습에 절대 사용되지 않습니다. '%1$s' 메뉴에서 언제든지 켜거나 끌 수 "
+"있습니다."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24762,7 +24300,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
-msgstr ""
+msgstr "사용자의 기기에서 직접 작동하여 데이터 브로커 사이트에 있는 사용자의 이메일, 이름, 주소 등의 정보를 삭제해 드립니다."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25029,9 +24567,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있"
-"습니다."
+msgstr "%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25039,9 +24575,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 "
-"검색할 수 있습니다."
+msgstr "%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 검색할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25054,8 +24588,7 @@ msgstr "%1$s에서 DuckDuckGo AI Chat에 바로 접속할 수 있습니다."
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
+msgstr "%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25063,22 +24596,17 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr ""
-"%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니"
-"다."
+msgstr "%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
+msgstr "%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr ""
-"%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 "
-"있습니다."
+msgstr "%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25091,9 +24619,7 @@ msgstr "텍스트 선택은 %1$s개까지 첨부할 수 있습니다."
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 "
-"수 있습니다."
+msgstr "%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25113,9 +24639,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트"
-"를 삭제할 수도 있습니다."
+msgstr "다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트를 삭제할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25144,8 +24668,7 @@ msgstr "월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
+msgstr "이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25208,9 +24731,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이"
-"트 차단을 먼저 해제해야 합니다."
+msgstr "차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이트 차단을 먼저 해제해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25265,7 +24786,7 @@ msgstr "1번 다시 시도할 수 있습니다."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "공유 채팅 링크가 없습니다."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25273,9 +24794,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습"
-"니다."
+msgstr "이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25284,8 +24803,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 "
-"DuckDuckGo 구독 보호 기능을 이용할 수 있습니다."
+"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 DuckDuckGo 구독 보호 기능을 이용할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25307,9 +24826,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
-"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
-"다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
+"채팅이 삭제되지는 않습니다."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25319,9 +24837,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
-"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
-"다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
+"채팅이 삭제되지는 않습니다."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25349,8 +24866,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용"
-"해 보세요. 이미 설치되어 있으며 다음과 같은 기능이 제공됩니다."
+"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용해 보세요. 이미 설치되어 있으며 "
+"다음과 같은 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25362,9 +24879,7 @@ msgstr "이제 개인정보 보호를 받으며 검색할 수 있습니다!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 "
-"팁을 알아보세요."
+msgstr "현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 팁을 알아보세요."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25440,9 +24955,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화"
-"를 재개하려면 가장 오래된 채팅 %1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않"
-"습니다."
+"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화를 재개하려면 가장 오래된 채팅 "
+"%1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25452,9 +24966,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 "
-"첨부 파일이 있는 채팅을 오래된 순으로 %1$s개 삭제하세요. 고정된 채팅은 삭제되"
-"지 않습니다."
+"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 첨부 파일이 있는 채팅을 오래된 순으로 "
+"%1$s개 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25468,8 +24981,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기"
-"서 YouTube 동영상을 시청하면 YouTube나 Google의 추적을 받게 됩니다."
+"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기서 YouTube 동영상을 시청하면 "
+"YouTube나 Google의 추적을 받게 됩니다."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25490,14 +25003,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
+msgstr "최근 채팅 %1$s개를 로컬 저장소에서 볼 수 있는 브라우저:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Duck.ai 채팅을 종단간 암호화를 통해 동기화하고 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25528,7 +25041,7 @@ msgctxt "First body paragraph in the Delete Server Data confirmation modal"
 msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
-msgstr ""
+msgstr "백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25538,8 +25051,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
-"브라우저에서는 최근 채팅 %1$s개가 로컬 저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 %1$s개가 로컬 "
+"저장소에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25549,8 +25062,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
-"브라우저에서는 최근 채팅 100개가 로컬 저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 100개가 로컬 저장소에 "
+"저장됩니다."
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25574,18 +25087,14 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr ""
-"가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo"
-"는 절대 이 데이터에 접근할 수 없습니다."
+msgstr "가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo는 절대 이 데이터에 접근할 수 없습니다."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터"
-"에 절대 액세스할 수 없습니다."
+msgstr "브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터에 절대 액세스할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25593,9 +25102,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표"
-"시할 수 있습니다."
+msgstr "%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25620,36 +25127,28 @@ msgstr "사용자의 채팅은 비공개로 처리되며 AI 모델 훈련에 사
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
-"습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
-"습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
-"지 않습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
-"지 않습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25664,8 +25163,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련"
-"에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 다음과 같습니다."
+"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 "
+"다음과 같습니다."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25704,9 +25203,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. "
-"[%2$s메시지 예시%3$s]"
+msgstr "사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. [%2$s메시지 예시%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25749,10 +25246,9 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 "
-"키를 생성합니다. 키와 연관된 설정 파일만 브라우저 외부로 전송됩니다. "
-"DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 "
-"암호를 절대 알 수 없습니다."
+"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 키를 생성합니다. 키와 연관된 설정 파일만 "
+"브라우저 외부로 전송됩니다. DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 암호를 절대 알 수 "
+"없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25767,9 +25263,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데"
-"이터는 제거됩니다. 따라서 모델 제공사는 대화를 특정 사용자에 연결할 수 없습니"
-"다."
+"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데이터는 제거됩니다. 따라서 모델 제공사는 대화를 "
+"특정 사용자에 연결할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25814,8 +25309,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 "
-"%1$sDuckDuckGo No AI%2$s 확장 프로그램을 사용 설정하세요."
+"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 %1$sDuckDuckGo No AI%2$s 확장 프로그램을 "
+"사용 설정하세요."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25824,8 +25319,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 "
-"%1$sDuckDuckGo No AI%2$s 확장 프로그램을 설치하세요. %3$s자세히 알아보기%4$s"
+"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 %1$sDuckDuckGo No AI%2$s 확장 프로그램을 "
+"설치하세요. %3$s자세히 알아보기%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25845,9 +25340,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 "
-"DuckDuckGo 브라우저를 이용해서 더 철저하게 보호받으세요. 이미 설치되어 있으"
-"며 다음 기능이 제공됩니다."
+"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 DuckDuckGo 브라우저를 이용해서 더 철저하게 "
+"보호받으세요. 이미 설치되어 있으며 다음 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25863,9 +25357,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌"
-"러 이 대화를 지우세요."
+msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌러 이 대화를 지우세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25873,8 +25365,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
+msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25888,9 +25379,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세"
-"요."
+msgstr "하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26192,9 +25681,7 @@ msgstr "공식 웹사이트"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s "
-"문자입니다)"
+msgstr "또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s 문자입니다)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ku/LC_MESSAGES/duckduckgo.po
+++ b/locales/ku/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% Deqandî"
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -397,6 +404,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%sFêr bibe ka çawa em cihê te taybet diparêzin%s."
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -632,6 +645,11 @@ msgstr ""
 msgctxt "Sports module"
 msgid "2nd in Group %s"
 msgstr "2yemîn di Koma %s de"
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
@@ -1186,6 +1204,11 @@ msgstr "Tevlî %s bike"
 msgid "Add to Home Screen"
 msgstr "Tevlî Dîmendera Sereke bike"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Pêvek"
@@ -1478,6 +1501,12 @@ msgstr "Hemû mezinahî"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Hemû cure"
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
@@ -1891,6 +1920,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4237,6 +4271,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4271,6 +4310,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4831,6 +4889,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4839,6 +4904,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5045,6 +5117,12 @@ msgstr "Paşguh bike"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5692,6 +5770,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6371,9 +6455,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7468,6 +7565,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7552,6 +7656,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9166,6 +9275,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Bêtir %sFêr bibe%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9685,6 +9799,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9890,6 +10010,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10192,6 +10317,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Bêtir li ser"
@@ -10349,6 +10479,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Sor çilmisî"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11228,6 +11363,27 @@ msgstr ""
 "Li ser Mac, %sMaxthon > Hilbijartin%s bitikîne, Li ser Windows, %sSembola > "
 "Sazkarî%s %sbitikîne"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11845,6 +12001,11 @@ msgstr "Hefteya borî"
 msgid "Past year"
 msgstr "Sala borî"
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11853,6 +12014,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11898,6 +12064,18 @@ msgstr ""
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Farsî"
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
 msgctxt "Assistant role option label for Personal trainer"
@@ -12915,6 +13093,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13064,6 +13247,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13271,6 +13459,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13304,6 +13497,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13857,6 +14060,11 @@ msgstr "Sazkariyên xwe bi awayekî nenas tomar bike bo ewrê"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14638,6 +14846,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Sirbî (Latînî)"
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14762,6 +14976,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14882,6 +15103,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15431,6 +15662,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16122,6 +16358,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16319,6 +16560,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16343,6 +16590,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16805,6 +17057,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16874,6 +17140,11 @@ msgstr ""
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Ev zanyarî ne alîkar e"
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
@@ -16956,6 +17227,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17475,6 +17756,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17567,6 +17853,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17766,6 +18057,11 @@ msgstr "Tirkî"
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17774,6 +18070,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18159,6 +18460,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18186,6 +18492,11 @@ msgstr "Rojane bike"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18972,6 +19283,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -19008,6 +19326,13 @@ msgstr ""
 "Em tenê cihê te ya nenas bi kar tînin da ku encamên çêtir, nêzîktir peyda "
 "bikin bo Te. Tu dikarî her dem paşê ramana xwe biguherînî."
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -19039,6 +19364,13 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Dema ku tu digerî em ê şopgerên ku hewl didin daneyên te berhev bikin asteng "
 "bikin."
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
 msgctxt "noresults"
@@ -19282,6 +19614,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19746,6 +20083,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20149,6 +20493,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "1 hewldanê te maye."
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20320,6 +20670,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube Standard"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Dîroka lêgerînê te ya DuckDuckGo taybet e"
@@ -20337,6 +20702,13 @@ msgstr "Cihê te ya rast taybet dimîne"
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/kw_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/kw_GB/LC_MESSAGES/duckduckgo.po
@@ -43,6 +43,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -393,6 +400,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -627,6 +640,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1180,6 +1198,11 @@ msgstr "Keworra dhe %s"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Keworransow"
@@ -1470,6 +1493,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1880,6 +1909,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4194,6 +4228,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4226,6 +4265,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4786,6 +4844,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4794,6 +4859,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5000,6 +5072,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5647,6 +5725,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6309,9 +6393,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7402,6 +7499,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7486,6 +7590,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9072,6 +9181,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Dyski %sMoy%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9589,6 +9703,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9794,6 +9914,11 @@ msgstr "Rol"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10096,6 +10221,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10253,6 +10383,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Rudh disliw"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11130,6 +11265,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11734,6 +11890,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11742,6 +11903,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11786,6 +11952,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12800,6 +12978,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12949,6 +13132,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13156,6 +13344,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13189,6 +13382,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13737,6 +13940,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14501,6 +14709,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14625,6 +14839,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14744,6 +14965,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15291,6 +15522,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15980,6 +16216,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16177,6 +16418,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16202,6 +16449,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Pellwolok"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16654,6 +16906,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16722,6 +16988,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16805,6 +17076,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17319,6 +17600,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17411,6 +17697,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17610,6 +17901,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17618,6 +17914,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -17995,6 +18296,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18022,6 +18328,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18788,6 +19099,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18822,6 +19140,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18846,6 +19171,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19090,6 +19422,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19552,6 +19889,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19952,6 +20296,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20116,6 +20466,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20133,6 +20498,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/ky_KG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ky_KG/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr ""
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Кошумчалар"
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4193,6 +4227,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4225,6 +4264,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4785,6 +4843,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4793,6 +4858,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -4999,6 +5071,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5646,6 +5724,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6308,9 +6392,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7401,6 +7498,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7485,6 +7589,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9069,6 +9178,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9586,6 +9700,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9791,6 +9911,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10093,6 +10218,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10250,6 +10380,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Кычкыл кызыл"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11127,6 +11262,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11731,6 +11887,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11739,6 +11900,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11783,6 +11949,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12797,6 +12975,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12946,6 +13129,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13153,6 +13341,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13186,6 +13379,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13734,6 +13937,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14498,6 +14706,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14622,6 +14836,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14741,6 +14962,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15288,6 +15519,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15977,6 +16213,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16174,6 +16415,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16198,6 +16445,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16651,6 +16903,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16719,6 +16985,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16802,6 +17073,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17316,6 +17597,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17408,6 +17694,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17607,6 +17898,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17615,6 +17911,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -17992,6 +18293,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18019,6 +18325,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18785,6 +19096,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18819,6 +19137,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18843,6 +19168,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19087,6 +19419,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19549,6 +19886,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19949,6 +20293,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20113,6 +20463,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20130,6 +20495,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/ln_CD/LC_MESSAGES/duckduckgo.po
+++ b/locales/ln_CD/LC_MESSAGES/duckduckgo.po
@@ -43,6 +43,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -393,6 +400,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -627,6 +640,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1180,6 +1198,11 @@ msgstr "Kobakisa na %s"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Ebakisi"
@@ -1470,6 +1493,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1880,6 +1909,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4194,6 +4228,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4226,6 +4265,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4786,6 +4844,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4794,6 +4859,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5000,6 +5072,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5647,6 +5725,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6309,9 +6393,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7402,6 +7499,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7486,6 +7590,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9070,6 +9179,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9587,6 +9701,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9792,6 +9912,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10094,6 +10219,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10250,6 +10380,11 @@ msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
+msgstr ""
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
 msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -11128,6 +11263,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11732,6 +11888,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11740,6 +11901,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11784,6 +11950,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12798,6 +12976,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12947,6 +13130,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13154,6 +13342,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13187,6 +13380,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13735,6 +13938,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14499,6 +14707,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14623,6 +14837,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14742,6 +14963,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15289,6 +15520,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15978,6 +16214,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16175,6 +16416,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16199,6 +16446,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16652,6 +16904,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16720,6 +16986,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16803,6 +17074,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17317,6 +17598,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17409,6 +17695,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17608,6 +17899,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17616,6 +17912,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -17993,6 +18294,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18020,6 +18326,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18786,6 +19097,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18820,6 +19138,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18844,6 +19169,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19088,6 +19420,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19550,6 +19887,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19950,6 +20294,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20114,6 +20464,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20131,6 +20496,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: lt_LT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -41,6 +42,14 @@ msgstr "% Visiškai Pasiskiepijusių"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% Pasiskiepijusių"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -372,7 +381,8 @@ msgstr "%1$s išnaudota"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s išnaudoja limitus iki 2–5 kartų greičiau nei baziniai modeliai %2$s"
+msgstr ""
+"%1$s išnaudoja limitus iki 2–5 kartų greičiau nei baziniai modeliai %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -489,6 +499,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sSužinok, kaip išsaugome tavo buvimo vietos privatumą%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -501,7 +518,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
+msgstr ""
+"%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -779,6 +797,12 @@ msgid "2nd in Group %s"
 msgstr "2 vieta %1$s Grupėje"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -931,14 +955,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
+msgstr ""
+"Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
+msgstr ""
+"Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1461,6 +1487,12 @@ msgid "Add to Home Screen"
 msgstr "Pridėti prie Pradžios Ekrano"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Priedai"
@@ -1615,7 +1647,8 @@ msgstr "Kai atsisiųsi ir atidarysi, spustelėk %1$sĮdiegti%2$s"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
+msgstr ""
+"Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1823,6 +1856,13 @@ msgid "All types"
 msgstr "Visi tipai"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1857,7 +1897,8 @@ msgstr "Leisti anonimiškai peržiūrėti šio pokalbio failus?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
+msgstr ""
+"Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1909,7 +1950,8 @@ msgstr "Jau sinchronizuota."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
+msgstr ""
+"Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2342,6 +2384,12 @@ msgid "Ask anything privately"
 msgstr "Klausk bet ko privačiai"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2563,7 +2611,8 @@ msgstr "Automatinis atsakymas"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
+msgstr ""
+"Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3717,7 +3766,8 @@ msgstr "Pakeičia fono spalvą visoje svetainėje"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
+msgstr ""
+"Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4026,9 +4076,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į "
-"Duck.ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų "
-"teikėjas, ieškantis tokio turinio: %2$s."
+"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į Duck."
+"ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų teikėjas, "
+"ieškantis tokio turinio: %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4498,7 +4548,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
+msgstr ""
+"Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4525,7 +4576,8 @@ msgstr "Išskleidžiamajame meniu spustelėk %1$sNustatymai%2$s."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
+msgstr ""
+"Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4592,7 +4644,8 @@ msgstr "Paieškos juostoje spustelėk %1$sdidinamąjį stiklą%2$s"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr "Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
+msgstr ""
+"Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -5274,6 +5327,12 @@ msgid "Copy"
 msgstr "Kopijuoti"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5282,7 +5341,8 @@ msgstr "Kopijuoti"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
+msgstr ""
+"Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5313,6 +5373,28 @@ msgstr "Kopijuoti arba išsaugoti šį kodą"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Kopijuoti atkūrimo kodą"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5992,6 +6074,14 @@ msgid "Delete recent chats?"
 msgstr "Ištrinti naujausius pokalbius?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6002,6 +6092,14 @@ msgstr "Ištrinti šį pokalbį?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Ištrinti pokalbiai"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6097,7 +6195,8 @@ msgstr "Diktavimas „Duck.ai“"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
+msgstr ""
+"Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6255,6 +6354,13 @@ msgstr "Atmesti"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Atmesti"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -7042,8 +7148,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
-"„%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
+"„%3$s“ „%4$s“."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7053,8 +7159,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
-"„%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
+"„%3$s“ „%4$s“."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7090,7 +7196,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
+msgstr ""
+"„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7117,6 +7224,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "„DuckDuckGo“ naršyklė %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7243,8 +7357,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su "
-"„Duck.ai“ %2$s."
+"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su „Duck."
+"ai“ %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7395,9 +7509,9 @@ msgid ""
 "characters long."
 msgstr ""
 "Kiekvieną kartą, kai paprašai pasiūlyti slaptafrazę, naudojame didelį "
-"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame "
-"4–5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent "
-"18–20 simbolių ilgio."
+"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame 4–"
+"5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent 18–"
+"20 simbolių ilgio."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7730,13 +7844,15 @@ msgstr "Ar tau patinka „Duck.ai“?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
+msgstr ""
+"Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
+msgstr ""
+"Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7884,7 +8000,8 @@ msgstr "Pusiaujo Gvinėja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
+msgstr ""
+"Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7947,10 +8064,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "Meistriškai sukurti produktai žmonėms, kuriems rūpi privatumas."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Baigė galioti"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7975,7 +8107,8 @@ msgstr "Paprastais žodžiais paaiškink priimtą atsakymą."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
+msgstr ""
+"Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8053,7 +8186,8 @@ msgstr "Naršyti „Duck.ai“"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
+msgstr ""
+"Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8232,7 +8366,8 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
+msgstr ""
+"Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8354,7 +8489,8 @@ msgstr "Finansų konsultantas"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
+msgstr ""
+"Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8478,7 +8614,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
+msgstr ""
+"Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8589,7 +8726,8 @@ msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
+msgstr ""
+"Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8997,7 +9135,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "Gauk „DuckDuckGo VPN“, pažangųjį „Duck.ai“ ir „Identity Theft Restoration“."
+msgstr ""
+"Gauk „DuckDuckGo VPN“, pažangųjį „Duck.ai“ ir „Identity Theft Restoration“."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9056,7 +9195,8 @@ msgstr "Pradėti"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
+msgstr ""
+"Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9148,7 +9288,8 @@ msgstr "Gauk didesnius naudojimo limitus su „DuckDuckGo“ prenumerata."
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
-msgstr "Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
+msgstr ""
+"Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market. 'No-log' means the VPN keeps no activity logs; 'advanced AI models' with 'higher chat limits' refer to Duck.ai; the VPN and other premium protections are bundled subscription features.
@@ -9183,7 +9324,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
+msgstr ""
+"Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9220,8 +9362,8 @@ msgstr "Gauti programą"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Gauk nemokamą „DuckDuckGo“ naršyklę, %1$skad blokuotum reklamas "
-"„YouTube“.%2$s"
+"Gauk nemokamą „DuckDuckGo“ naršyklę, %1$skad blokuotum reklamas „YouTube“."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9318,6 +9460,14 @@ msgstr ""
 "Kitoje naršyklėje arba „DuckDuckGo“ programėlėje atverk %1$s„Duck.ai“ "
 "nuostatas%2$s ir eik į %3$sPokalbiai › „Sync & Backup“ › Sinchronizuoti su "
 "kitu įrenginiu%4$s. Arba nuskaityk QR kodą atkūrimo PDF faile."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9429,6 +9579,12 @@ msgstr "Supratau"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Supratau"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10396,7 +10552,8 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
+msgstr ""
+"Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10629,7 +10786,8 @@ msgstr "Pagerink argumentus"
 msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
-msgstr "Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
+msgstr ""
+"Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11061,7 +11219,8 @@ msgstr "Ji greita, nemokama ir užtikrina dar daugiau apsaugos internete."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
+msgstr ""
+"Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11401,6 +11560,12 @@ msgid "Learn %sMore%s"
 msgstr "Sužinoti %1$sDaugiau%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11573,7 +11738,8 @@ msgstr "Leidžia ieškoti anonimiškai su „DuckDuckGo“"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Leidžia perjungti tarp paieškos užklausų ir DI užklausų pateikimo „Duck.ai“"
+msgstr ""
+"Leidžia perjungti tarp paieškos užklausų ir DI užklausų pateikimo „Duck.ai“"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11665,7 +11831,8 @@ msgstr "Nuorodos:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
+msgstr ""
+"Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11776,7 +11943,8 @@ msgstr "Įkeliama daugiau vaizdų slenkant"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
+msgstr ""
+"Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12030,6 +12198,13 @@ msgid "Manage"
 msgstr "Tvarkyti"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12279,6 +12454,12 @@ msgstr "Meniu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Meniu"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12649,6 +12830,12 @@ msgid "More about Duck.ai"
 msgstr "Daugiau apie „Duck.ai“"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Daugiau"
@@ -12841,6 +13028,12 @@ msgstr "Nutildyta"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Blankiai raudona"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13869,7 +14062,8 @@ msgstr "Omanas"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
+msgstr ""
+"Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13909,6 +14103,30 @@ msgid ""
 msgstr ""
 "Jei naudoji „Mac“, %1$sspustelėk „Maxthon“ > Nuostatos%2$s, jei naudoji "
 "„Windows“, %3$sspustelėk %4$s piktogramą > Nustatymai%5$s"
+
+# smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14032,7 +14250,8 @@ msgstr "Atidaryti %1$s svetainę"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
+msgstr ""
+"Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14201,7 +14420,8 @@ msgstr "Atidaryti skydelį „Kaip veikia Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
+msgstr ""
+"Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14659,6 +14879,12 @@ msgid "Past year"
 msgstr "Praėję metai"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14669,6 +14895,12 @@ msgstr "Įklijuoti"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Įklijuok sinchronizavimo kodą"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14722,6 +14954,20 @@ msgstr "Visam laikui uždaryta"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persų"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15000,7 +15246,8 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
+msgstr ""
+"Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15188,7 +15435,8 @@ msgstr "Luktelk..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr "„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
+msgstr ""
+"„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
@@ -15770,7 +16018,8 @@ msgstr "Paraginti mane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
+msgstr ""
+"Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15986,6 +16235,12 @@ msgid "Reading website…"
 msgstr "Skaitoma svetainė…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16179,6 +16434,12 @@ msgstr "Atkūrimas"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Atkūrimo kodas"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16434,6 +16695,12 @@ msgid "Remove %s"
 msgstr "Pašalink %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16474,6 +16741,18 @@ msgstr "Pašalinti pažymėtą tekstą"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Pašalink nereikalingus skyrybos ženklus"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17165,6 +17444,12 @@ msgid "Say hello to Duck.ai"
 msgstr "Pasisveikink su „Duck.ai“!"
 
 # smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai!"
@@ -17309,7 +17594,8 @@ msgstr "Slink žemyn ir sąraše rask %1$ssavo naršyklę%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
+msgstr ""
+"Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17700,8 +17986,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. "
-"<em>end-to-end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
+"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. <em>end-to-"
+"end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17868,24 +18154,27 @@ msgstr "„Safari“ meniu pasirink %1$s„Šios svetainės nustatymas...“%2$s
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk "
-"%3$shttps://duckduckgo.com%4$s"
+"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk %3$shttps://"
+"duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17899,7 +18188,8 @@ msgstr ""
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
+msgstr ""
+"Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17911,7 +18201,8 @@ msgstr "Paieškos teikėjų sąraše pasirink %1$s„DuckDuckGo“%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17922,7 +18213,8 @@ msgstr "Pasirink %1$s„DuckDuckGo“%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
+msgstr ""
+"Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17996,7 +18288,8 @@ msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sIšplėstiniai nustatymai%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
+msgstr ""
+"Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18018,7 +18311,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
+msgstr ""
+"Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18090,7 +18384,8 @@ msgstr "Pažymėtas tekstas iš %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
+msgstr ""
+"Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18156,6 +18451,13 @@ msgstr "Serbų (Kirilica)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Serbų (Lotynų)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18312,6 +18614,14 @@ msgid "Share"
 msgstr "Bendrinti"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18461,6 +18771,18 @@ msgid "Share your thoughts on the search box."
 msgstr "Pasidalink savo nuomone apie paieškos laukelį."
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
@@ -18588,7 +18910,8 @@ msgstr "Rodyti „DuckAssist“ <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
+msgstr ""
+"Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18771,7 +19094,8 @@ msgstr "Rodyk šoninę juostą"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Rodyti nuoseklius patarimus, kaip geriausiai išnaudoti „ Duck.ai“ galimybes."
+msgstr ""
+"Rodyti nuoseklius patarimus, kaip geriausiai išnaudoti „ Duck.ai“ galimybes."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18847,7 +19171,8 @@ msgstr "Rodomos horizontalios linijos ties rezultatų puslapio lūžiais"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
+msgstr ""
+"Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18914,7 +19239,8 @@ msgstr "Rodomas sveikinamasis pranešimas paieškos rezultatų viršuje"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
+msgstr ""
+"Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19137,6 +19463,12 @@ msgid "Something went wrong"
 msgstr "Įvyko klaida"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19250,7 +19582,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
+msgstr ""
+"Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19519,13 +19852,15 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr ""
+"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr ""
+"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19563,12 +19898,14 @@ msgstr "Sustabdyti generavimą"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
+msgstr ""
+"Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
+msgstr ""
+"Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19741,7 +20078,8 @@ msgstr "Pasiūlyk tinklaraščio įrašo pavadinimą"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
+msgstr ""
+"Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19981,6 +20319,12 @@ msgstr "Pakeisti modelį"
 msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr "Perjungti modelį"
+
+# smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20240,6 +20584,13 @@ msgid "Synced Devices"
 msgstr "Sinchronizuoti įrenginiai"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Sirija"
 
@@ -20270,6 +20621,12 @@ msgstr "TBD"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20856,6 +21213,22 @@ msgstr ""
 "informacija (daugiau informacijos rasite %4$s)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20937,6 +21310,12 @@ msgstr "Šis vaizdo tipas nepalaikomas. Pridėk JPG, PNG, WebP arba GIF."
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Ši informacija nėra naudinga"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21051,6 +21430,18 @@ msgstr ""
 "naršyklės duomenis, vėl matysi su DI pagalba sukurtus atsakymus. Tačiau mes "
 "taip pat turime pradinį puslapį, kuriame niekada nerodomi su DI kuriami "
 "atsakymai adresu %1$s."
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21650,7 +22041,8 @@ msgstr "Pabandyk %1$s, kad daugiau nematytum tokių pranešimų."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
+msgstr ""
+"Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21696,6 +22088,12 @@ msgstr "Išbandyk nemokamai"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Išbandyk nemokamai"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21815,6 +22213,12 @@ msgid "Try for Free"
 msgstr "Išbandyk nemokamai"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
 msgctxt ""
 "Link text shown to unauthenticated users in the subscription promo card to "
@@ -21840,7 +22244,8 @@ msgstr "Išbandyti nemokamai"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
+msgstr ""
+"Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -21879,7 +22284,8 @@ msgstr "Išbandyk mūsų naršyklę,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
+msgstr ""
+"Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22058,6 +22464,12 @@ msgid "Turkmenistan"
 msgstr "Turkmėnistanas"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22068,6 +22480,12 @@ msgstr "Išjungti „Sync & Backup“"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Išjungti „Sync & Backup“"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22138,7 +22556,8 @@ msgstr "Norėdami gauti tikslesnius rezultatus, įjunkite %1$sTiksli vieta%2$s"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
+msgstr ""
+"Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22156,7 +22575,8 @@ msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Tiksli vietovė
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
+msgstr ""
+"Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22361,7 +22781,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
+msgstr ""
+"Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22371,13 +22792,15 @@ msgstr "Laukelyje %1$sPaieškos nustatymai%2$s pasirink %3$s„DuckDuckGo“%4$s
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
+msgstr ""
+"Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
+msgstr ""
+"Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22534,7 +22957,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
+msgstr ""
+"Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -22547,6 +22971,12 @@ msgstr "Atrask „Premium“ apsaugos funkcijas"
 msgctxt "voice chat"
 msgid "Unmute"
 msgstr "Įjungti mikrofoną"
+
+# smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22582,6 +23012,12 @@ msgstr "Naujinti"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Atnaujinti naršyklę"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23221,7 +23657,8 @@ msgstr "Balso pokalbis baigtas"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
+msgstr ""
+"Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23447,7 +23884,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
+msgstr ""
+"Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23549,7 +23987,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
+msgstr ""
+"Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -23562,6 +24001,14 @@ msgstr "Mes tavęs nesekame. Štai mūsų privatumo politikos apibendrinimas…"
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Pokalbį baigėme dėl neaktyvumo. Nori pabandyti dar kartą?"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23610,6 +24057,14 @@ msgstr ""
 "esančius arčiau tavęs. Vėliau visada gali tai pakeisti."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23645,6 +24100,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Užblokuosime stebėjimo priemones, bandančias rinkti tavo duomenis naršymo "
 "metu."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23835,9 +24298,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia „%1$s“ "
-"„%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų niekada "
-"nesaugo ir nenaudoja DI modeliams mokyti."
+"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia "
+"„%1$s“ „%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų "
+"niekada nesaugo ir nenaudoja DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23851,7 +24314,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
+msgstr ""
+"Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -23942,7 +24406,8 @@ msgstr "Į kokius veiksnius reikia atsižvelgti perkant kompiuterio monitorių?"
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
+msgstr ""
+"Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23959,6 +24424,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Kokie yra kasmetinės rentos privalumai ir trūkumai?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24203,7 +24674,8 @@ msgstr "Kokia informacija yra išsaugoma?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr "Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
+msgstr ""
+"Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -24288,7 +24760,8 @@ msgstr "Apie ką norėtum pateikti atsiliepimą?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
+msgstr ""
+"Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24527,6 +25000,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Matoma paslaugų teikėjui"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24774,7 +25255,8 @@ msgstr "Taip, naujas naudotojas!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
+msgstr ""
+"Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25026,6 +25508,13 @@ msgid "You have 1 attempt left."
 msgstr "Tau liko 1 bandymas."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25174,7 +25663,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
+msgstr ""
+"Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25244,6 +25734,23 @@ msgid "YouTube Standard"
 msgstr "„YouTube“ Standartas"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Tavo „DuckDuckGo“ paieškos istorija yra privati"
@@ -25265,6 +25772,14 @@ msgstr "Tavo faktinė vieta išlieka konfidenciali"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Faktinė vieta išlieka konfidenciali."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25362,14 +25877,16 @@ msgstr ""
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr ""
+"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr ""
+"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25723,7 +26240,8 @@ msgstr "sukurta %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
+msgstr ""
+"kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: lt_LT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"(n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -49,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (šis įrenginys)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -381,8 +380,7 @@ msgstr "%1$s išnaudota"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s išnaudoja limitus iki 2–5 kartų greičiau nei baziniai modeliai %2$s"
+msgstr "%1$s išnaudoja limitus iki 2–5 kartų greičiau nei baziniai modeliai %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -503,7 +501,7 @@ msgstr "%1$sSužinok, kaip išsaugome tavo buvimo vietos privatumą%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sSužinok daugiau%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -518,8 +516,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
+msgstr "%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -800,7 +797,7 @@ msgstr "2 vieta %1$s Grupėje"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "Antroji nuomonė"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -955,16 +952,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
+msgstr "Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
+msgstr "Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1490,7 +1485,7 @@ msgstr "Pridėti prie Pradžios Ekrano"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Pridėti prie mano pokalbių"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1647,8 +1642,7 @@ msgstr "Kai atsisiųsi ir atidarysi, spustelėk %1$sĮdiegti%2$s"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
+msgstr "Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1860,7 +1854,7 @@ msgstr "Visi tipai"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Visi tavo įrenginiai atjungti nuo sinchronizavimo."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1897,8 +1891,7 @@ msgstr "Leisti anonimiškai peržiūrėti šio pokalbio failus?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
+msgstr "Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1950,8 +1943,7 @@ msgstr "Jau sinchronizuota."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
+msgstr "Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2387,7 +2379,7 @@ msgstr "Klausk bet ko privačiai"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Klausk bet ko privačiai"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2611,8 +2603,7 @@ msgstr "Automatinis atsakymas"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
+msgstr "Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3766,8 +3757,7 @@ msgstr "Pakeičia fono spalvą visoje svetainėje"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
+msgstr "Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4076,9 +4066,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į Duck."
-"ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų teikėjas, "
-"ieškantis tokio turinio: %2$s."
+"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į "
+"Duck.ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų "
+"teikėjas, ieškantis tokio turinio: %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4548,8 +4538,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
+msgstr "Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4576,8 +4565,7 @@ msgstr "Išskleidžiamajame meniu spustelėk %1$sNustatymai%2$s."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
+msgstr "Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4644,8 +4632,7 @@ msgstr "Paieškos juostoje spustelėk %1$sdidinamąjį stiklą%2$s"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr ""
-"Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
+msgstr "Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -5330,7 +5317,7 @@ msgstr "Kopijuoti"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopijuoti"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5341,8 +5328,7 @@ msgstr "Kopijuoti"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
+msgstr "Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5380,13 +5366,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Kopijuoti bendrinamą nuorodą"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Kopijuoti kodą iš kito įrenginio"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5395,6 +5381,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Nukopijuok kodą iš kito įrenginio. Eik į %1$s„Duck.ai“ nuostatas › Pokalbiai "
+"› „Sync & Backup“ › Sinchronizuoti su kitu įrenginiu%2$s ir bandyk dar kartą."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6079,7 +6067,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Ištrinti bendrinamą nuorodą"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6100,6 +6088,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Ištrynus nuorodą, ji nustos veikti. Ją atidarę ir pokalbį prie savo pokalbių "
+"pridėję asmenys išsaugos savo kopiją."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6195,8 +6185,7 @@ msgstr "Diktavimas „Duck.ai“"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
+msgstr "Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6360,7 +6349,7 @@ msgstr "Atmesti"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Atmesti"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -7148,8 +7137,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
-"„%3$s“ „%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
+"„%4$s“."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7159,8 +7148,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
-"„%3$s“ „%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
+"„%4$s“."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7196,8 +7185,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
+msgstr "„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7230,7 +7218,7 @@ msgstr "„DuckDuckGo“ naršyklė %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "„DuckDuckGo“ žinyno puslapiai"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7357,8 +7345,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su „Duck."
-"ai“ %2$s."
+"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su "
+"„Duck.ai“ %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7509,9 +7497,9 @@ msgid ""
 "characters long."
 msgstr ""
 "Kiekvieną kartą, kai paprašai pasiūlyti slaptafrazę, naudojame didelį "
-"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame 4–"
-"5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent 18–"
-"20 simbolių ilgio."
+"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame "
+"4–5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent "
+"18–20 simbolių ilgio."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7844,15 +7832,13 @@ msgstr "Ar tau patinka „Duck.ai“?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
+msgstr "Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
+msgstr "Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8000,8 +7986,7 @@ msgstr "Pusiaujo Gvinėja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
+msgstr "Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8068,7 +8053,7 @@ msgstr "Meistriškai sukurti produktai žmonėms, kuriems rūpi privatumas."
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Nebegalioja"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8082,7 +8067,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Galioja iki %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8107,8 +8092,7 @@ msgstr "Paprastais žodžiais paaiškink priimtą atsakymą."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
+msgstr "Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8186,8 +8170,7 @@ msgstr "Naršyti „Duck.ai“"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
+msgstr "Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8366,8 +8349,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
+msgstr "Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8489,8 +8471,7 @@ msgstr "Finansų konsultantas"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
+msgstr "Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8614,8 +8595,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
+msgstr "Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8726,8 +8706,7 @@ msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
+msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9135,8 +9114,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Gauk „DuckDuckGo VPN“, pažangųjį „Duck.ai“ ir „Identity Theft Restoration“."
+msgstr "Gauk „DuckDuckGo VPN“, pažangųjį „Duck.ai“ ir „Identity Theft Restoration“."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9195,8 +9173,7 @@ msgstr "Pradėti"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
+msgstr "Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9288,8 +9265,7 @@ msgstr "Gauk didesnius naudojimo limitus su „DuckDuckGo“ prenumerata."
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
-msgstr ""
-"Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
+msgstr "Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market. 'No-log' means the VPN keeps no activity logs; 'advanced AI models' with 'higher chat limits' refer to Duck.ai; the VPN and other premium protections are bundled subscription features.
@@ -9324,8 +9300,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
+msgstr "Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9362,8 +9337,8 @@ msgstr "Gauti programą"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Gauk nemokamą „DuckDuckGo“ naršyklę, %1$skad blokuotum reklamas „YouTube“."
-"%2$s"
+"Gauk nemokamą „DuckDuckGo“ naršyklę, %1$skad blokuotum reklamas "
+"„YouTube“.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9468,6 +9443,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Eik į %1$s„Duck.ai“ nuostatas%2$s › %3$sPokalbiai › „Sync & Backup“ › "
+"Sinchronizuoti su kitu įrenginiu%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9584,7 +9561,7 @@ msgstr "Supratau"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Supratau"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10552,8 +10529,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
+msgstr "Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10786,8 +10762,7 @@ msgstr "Pagerink argumentus"
 msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
-msgstr ""
-"Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
+msgstr "Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11219,8 +11194,7 @@ msgstr "Ji greita, nemokama ir užtikrina dar daugiau apsaugos internete."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
+msgstr "Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11563,7 +11537,7 @@ msgstr "Sužinoti %1$sDaugiau%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Sužinok daugiau"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11738,8 +11712,7 @@ msgstr "Leidžia ieškoti anonimiškai su „DuckDuckGo“"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Leidžia perjungti tarp paieškos užklausų ir DI užklausų pateikimo „Duck.ai“"
+msgstr "Leidžia perjungti tarp paieškos užklausų ir DI užklausų pateikimo „Duck.ai“"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11831,8 +11804,7 @@ msgstr "Nuorodos:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
+msgstr "Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11943,8 +11915,7 @@ msgstr "Įkeliama daugiau vaizdų slenkant"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
+msgstr "Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12202,7 +12173,7 @@ msgstr "Tvarkyti"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Tvarkyti"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12459,7 +12430,7 @@ msgstr "Meniu"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Žinutės po šios ribos matomos tik tau."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12833,7 +12804,7 @@ msgstr "Daugiau apie „Duck.ai“"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Daugiau veiksmų"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13033,7 +13004,7 @@ msgstr "Blankiai raudona"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Mano įrenginiai"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14062,8 +14033,7 @@ msgstr "Omanas"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
+msgstr "Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14111,6 +14081,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Kitame įrenginyje eik į %1$s„Duck.ai“ nuostatas%2$s › %3$sPokalbiai › „Sync "
+"& Backup“ › Sinchronizuoti su kitu įrenginiu%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14119,6 +14091,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Kitame įrenginyje eik į %1$s„Duck.ai“ nuostatas%2$s › %3$sPokalbiai › „Sync "
+"& Backup“ › Sinchronizuoti su kitu įrenginiu%4$s ir nuskaityk šį kodą:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14127,6 +14101,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Kitame įrenginyje eik į %1$s„Duck.ai“ nuostatas%2$s › %3$sPokalbiai › „Sync "
+"& Backup“ › Sinchronizuoti su kitu įrenginiu%4$s. Arba nuskaityk atkūrimo "
+"PDF faile esantį QR kodą."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14250,8 +14227,7 @@ msgstr "Atidaryti %1$s svetainę"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
+msgstr "Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14420,8 +14396,7 @@ msgstr "Atidaryti skydelį „Kaip veikia Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
+msgstr "Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14882,7 +14857,7 @@ msgstr "Praėję metai"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Įklijuoti"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14900,7 +14875,7 @@ msgstr "Įklijuok sinchronizavimo kodą"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Įklijuok žemiau"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14959,7 +14934,7 @@ msgstr "Persų"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14968,6 +14943,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"„Personal Information Removal“ randa tavo informaciją duomenų brokerių "
+"svetainėse, kurios ją parduoda. Tada pasirūpiname, kad ji būtų pašalinta."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15246,8 +15223,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
+msgstr "Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15435,8 +15411,7 @@ msgstr "Luktelk..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr ""
-"„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
+msgstr "„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
@@ -16018,8 +15993,7 @@ msgstr "Paraginti mane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
+msgstr "Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16238,7 +16212,7 @@ msgstr "Skaitoma svetainė…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Ar jau pasiruošei saulės užtemimui?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16439,7 +16413,7 @@ msgstr "Atkūrimo kodas"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Atkūrimo kodas"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16698,7 +16672,7 @@ msgstr "Pašalink %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Pašalinti įrenginį"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16746,13 +16720,13 @@ msgstr "Pašalink nereikalingus skyrybos ženklus"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Pašalink savo informaciją iš interneto"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Pašalink savo informaciją internete"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17447,7 +17421,7 @@ msgstr "Pasisveikink su „Duck.ai“!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Susipažink su „Duck.ai“ – nemokamu, privačiu „DuckDuckGo“ DI pokalbiu."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17594,8 +17568,7 @@ msgstr "Slink žemyn ir sąraše rask %1$ssavo naršyklę%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
+msgstr "Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17986,8 +17959,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. <em>end-to-"
-"end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
+"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. "
+"<em>end-to-end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18154,27 +18127,24 @@ msgstr "„Safari“ meniu pasirink %1$s„Šios svetainės nustatymas...“%2$s
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk %3$shttps://"
-"duckduckgo.com%4$s"
+"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18188,8 +18158,7 @@ msgstr ""
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
+msgstr "Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18201,8 +18170,7 @@ msgstr "Paieškos teikėjų sąraše pasirink %1$s„DuckDuckGo“%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18213,8 +18181,7 @@ msgstr "Pasirink %1$s„DuckDuckGo“%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
+msgstr "Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18288,8 +18255,7 @@ msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sIšplėstiniai nustatymai%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
+msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18311,8 +18277,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
+msgstr "Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18384,8 +18349,7 @@ msgstr "Pažymėtas tekstas iš %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
+msgstr "Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18457,7 +18421,7 @@ msgstr "Serbų (Lotynų)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Serverio duomenys ištrinti"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18619,7 +18583,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Bendrinti"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18774,13 +18738,13 @@ msgstr "Pasidalink savo nuomone apie paieškos laukelį."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Bendrinamų pokalbių nuorodos"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Bendrinamų pokalbių nuorodos"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18910,8 +18874,7 @@ msgstr "Rodyti „DuckAssist“ <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
+msgstr "Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19094,8 +19057,7 @@ msgstr "Rodyk šoninę juostą"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Rodyti nuoseklius patarimus, kaip geriausiai išnaudoti „ Duck.ai“ galimybes."
+msgstr "Rodyti nuoseklius patarimus, kaip geriausiai išnaudoti „ Duck.ai“ galimybes."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19171,8 +19133,7 @@ msgstr "Rodomos horizontalios linijos ties rezultatų puslapio lūžiais"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
+msgstr "Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19239,8 +19200,7 @@ msgstr "Rodomas sveikinamasis pranešimas paieškos rezultatų viršuje"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
+msgstr "Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19466,7 +19426,7 @@ msgstr "Įvyko klaida"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Įkeliant šį bendrinamą pokalbį įvyko klaida."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19582,8 +19542,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
+msgstr "Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19852,15 +19811,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19898,14 +19855,12 @@ msgstr "Sustabdyti generavimą"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
+msgstr "Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
+msgstr "Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20078,8 +20033,7 @@ msgstr "Pasiūlyk tinklaraščio įrašo pavadinimą"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
+msgstr "Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20324,7 +20278,7 @@ msgstr "Perjungti modelį"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Keisti modelį"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20588,7 +20542,7 @@ msgstr "Sinchronizuoti įrenginiai"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Sinchronizuota %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20626,7 +20580,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Lentelė"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -21216,7 +21170,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Šis įrenginys"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21227,6 +21181,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Šis įrenginys nebeturės prieigos prie sinchronizuotų duomenų kituose "
+"įrenginiuose. Paskutiniai %1$s tavo pokalbiai (-ių) vis tiek liks pasiekiami "
+"vietinėje saugykloje."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21315,7 +21272,7 @@ msgstr "Ši informacija nėra naudinga"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Tai – bendrinamo pokalbio kopija."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21435,13 +21392,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Šio bendrinamo pokalbio atidaryti nepavyko. Nuoroda gali būti nepilna."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Ši bendrinamo pokalbio nuoroda nebepasiekiama."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -22041,8 +21998,7 @@ msgstr "Pabandyk %1$s, kad daugiau nematytum tokių pranešimų."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
+msgstr "Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22093,7 +22049,7 @@ msgstr "Išbandyk nemokamai"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Išbandyk nemokamai!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22216,7 +22172,7 @@ msgstr "Išbandyk nemokamai"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Išbandyk nemokamai!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22244,8 +22200,7 @@ msgstr "Išbandyti nemokamai"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
+msgstr "Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22284,8 +22239,7 @@ msgstr "Išbandyk mūsų naršyklę,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
+msgstr "Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22467,7 +22421,7 @@ msgstr "Turkmėnistanas"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Išjungti"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22485,7 +22439,7 @@ msgstr "Išjungti „Sync & Backup“"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Išjungti „Sync & Backup“ ir ištrinti serverio duomenis?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22556,8 +22510,7 @@ msgstr "Norėdami gauti tikslesnius rezultatus, įjunkite %1$sTiksli vieta%2$s"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
+msgstr "Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22575,8 +22528,7 @@ msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Tiksli vietovė
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
+msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22781,8 +22733,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
+msgstr "Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22792,15 +22743,13 @@ msgstr "Laukelyje %1$sPaieškos nustatymai%2$s pasirink %3$s„DuckDuckGo“%4$s
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
+msgstr "Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
+msgstr "Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22957,8 +22906,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
+msgstr "Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -22976,7 +22924,7 @@ msgstr "Įjungti mikrofoną"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Pokalbis be pavadinimo"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23017,7 +22965,7 @@ msgstr "Atnaujinti naršyklę"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Atnaujink „Duck.ai“, kad matytum šį bendrinamą pokalbį."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23657,8 +23605,7 @@ msgstr "Balso pokalbis baigtas"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
+msgstr "Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23884,8 +23831,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
+msgstr "Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23987,8 +23933,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
+msgstr "Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24009,6 +23954,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Surandame ir pašaliname tavo asmeninę informaciją iš duomenų brokerių "
+"svetainių. Be to, gausi VPN ir dar daugiau."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24063,6 +24010,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Nuolat tikriname duomenų brokerių svetaines ieškodami tavo asmeninės "
+"informacijos ir dalijamės darbo eiga patogioje suvestinėje."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24108,6 +24057,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Patikrinsime duomenų brokerių svetaines ieškodami tavo el. pašto adreso, "
+"vardo, adreso ir kitų duomenų bei pasirūpinsime, kad visa rasta informacija "
+"apie tave būtų pašalinta."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24298,9 +24250,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia "
-"„%1$s“ „%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų "
-"niekada nesaugo ir nenaudoja DI modeliams mokyti."
+"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia „%1$s“ "
+"„%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų niekada "
+"nesaugo ir nenaudoja DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24314,8 +24266,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
+msgstr "Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24406,8 +24357,7 @@ msgstr "Į kokius veiksnius reikia atsižvelgti perkant kompiuterio monitorių?"
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
+msgstr "Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24429,7 +24379,7 @@ msgstr "Kokie yra kasmetinės rentos privalumai ir trūkumai?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Kokie „Duck.ai“ privalumai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24674,8 +24624,7 @@ msgstr "Kokia informacija yra išsaugoma?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
-"Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
+msgstr "Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -24760,8 +24709,7 @@ msgstr "Apie ką norėtum pateikti atsiliepimą?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
+msgstr "Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25008,6 +24956,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Veikia tiesiai tavo įrenginyje ir pašalina tavo el. pašto adresą, vardą, "
+"adresą ir kitus duomenis iš duomenų brokerių svetainių."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25255,8 +25205,7 @@ msgstr "Taip, naujas naudotojas!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
+msgstr "Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25512,7 +25461,7 @@ msgstr "Tau liko 1 bandymas."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Neturi jokių bendrinamų pokalbių nuorodų."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25663,8 +25612,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
+msgstr "Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25742,13 +25690,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"%1$s naujausi (-ų) tavo pokalbiai (-ių) bus pasiekiami šių naršyklių "
+"vietinėje saugykloje:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Tavo „Duck.ai“ pokalbiai sinchronizuojami naudojant ištisinį šifravimą."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25780,6 +25730,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Tavo atsarginė kopija bus ištrinta iš „DuckDuckGo“ serverio. Visi įrenginiai "
+"bus atjungti nuo sinchronizavimo."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25877,16 +25829,14 @@ msgstr ""
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26240,8 +26190,7 @@ msgstr "sukurta %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
+msgstr "kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: lv_LV\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (šī ierīce)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -380,8 +380,7 @@ msgstr "%1$s izmantots"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s patērē lietojuma limitu līdz pat 2–5 reizes ātrāk nekā pamatmodeļi %2$s"
+msgstr "%1$s patērē lietojuma limitu līdz pat 2–5 reizes ātrāk nekā pamatmodeļi %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -502,7 +501,7 @@ msgstr "%1$sUzzini, kā mēs nodrošinām tavas atrašanās vietas privātumu%2$
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sUzzināt vairāk%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -800,7 +799,7 @@ msgstr "2. vieta %1$s grupā"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "Otrs viedoklis"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -957,16 +956,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
+msgstr "Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
+msgstr "Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1492,7 +1489,7 @@ msgstr "Pievienot sākuma ekrānam"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Pievienot manām tērzēšanām"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1596,8 +1593,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"Izmantojot jaudīgākus modeļus, lietošanas ierobežojumu var sasniegt 2–"
-"5 reizes ātrāk nekā ar citiem modeļiem. %1$s"
+"Izmantojot jaudīgākus modeļus, lietošanas ierobežojumu var sasniegt "
+"2–5 reizes ātrāk nekā ar citiem modeļiem. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1772,8 +1769,7 @@ msgstr "Visas tērzēšanas sarunas ir %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr ""
-"Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
+msgstr "Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -1864,7 +1860,7 @@ msgstr "Visi formāti"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Visas tavas ierīces ir atvienotas no sinhronizācijas."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2234,8 +2230,7 @@ msgstr "Vai tu joprojām esi tur?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
+msgstr "Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2247,8 +2242,7 @@ msgstr "Vai tiešām vēlies notīrīt šo sarunu un sākt jaunu?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
+msgstr "Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2392,7 +2386,7 @@ msgstr "Jautā jebko privāti"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Jautā jebko privāti"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -3451,8 +3445,7 @@ msgstr "Kamerūna"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
+msgstr "Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3772,8 +3765,7 @@ msgstr "Maina fona krāsu visā vietnē"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
+msgstr "Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3906,8 +3898,8 @@ msgstr ""
 "ar trešo pušu mākslīgā intelekta tērzēšanas modeļiem, kas atbalsta OpenAI, "
 "Anthropic un citus rīkus. Izslēdzot šo iestatījumu tiks paslēptas tērzēšanas "
 "pogas un saites DuckDuckGo Search platformā. Taču tu joprojām vari piekļūt "
-"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot %1$shttps://duck."
-"ai%2$s tieši."
+"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot "
+"%1$shttps://duck.ai%2$s tieši."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4521,8 +4513,7 @@ msgstr "Nospied %1$sAtļaut%2$s, pēc tam %3$sPievienot%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr ""
-"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4623,8 +4614,7 @@ msgstr "Sānjoslā noklikšķini uz %1$sPārlūks%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4644,8 +4634,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
+msgstr "Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4774,8 +4763,7 @@ msgstr "Noklikšķini uz palielināmā stikla ikonas meklēšanas lodziņā"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
+msgstr "Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5235,8 +5223,7 @@ msgstr "Turpināt bloķēt reklāmas"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Turpini nesenās tērzēšanas sarunas šeit. Vai arī dzēs tās ar Fire Button."
+msgstr "Turpini nesenās tērzēšanas sarunas šeit. Vai arī dzēs tās ar Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5343,7 +5330,7 @@ msgstr "Kopēt"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopēt"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5392,13 +5379,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Kopēt kopīgoto saiti"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Nokopē kodu no citas ierīces"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5407,6 +5394,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Nokopē kodu no citas ierīces. Dodies uz %1$sDuck.ai Iestatījumi › Tērzēšanas "
+"› Sync & Backup › Sinhronizēt ar citu ierīci%2$s un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5458,8 +5447,7 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
+msgstr "Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6096,7 +6084,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Dzēst kopīgoto saiti"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6117,6 +6105,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Izdzēšot saiti, tā vairs nedarbosies. Cilvēki, kuri to ir atvēruši un "
+"pievienojuši sarunu savām tērzēšanas sarunām, paturēs savu kopiju."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6313,8 +6303,7 @@ msgstr "Atspējot un atvienot"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
+msgstr "Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6379,7 +6368,7 @@ msgstr "Nerādīt"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Nerādīt"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6515,8 +6504,7 @@ msgstr "Neredzi DuckDuckGo sarakstā?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
+msgstr "Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6940,8 +6928,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
+msgstr "Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6956,8 +6943,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai ļauj tev privāti tērzēt ar populāriem MI modeļiem. Atspējošana "
-"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt %1$sduck."
-"ai%2$s tieši."
+"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt "
+"%1$sduck.ai%2$s tieši."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7027,8 +7014,7 @@ msgstr "Duck.ai atjaunināts!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
+msgstr "Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7247,7 +7233,7 @@ msgstr "DuckDuckGo pārlūks %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo palīdzības lapas"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7599,8 +7585,7 @@ msgstr "Rediģē attēlu..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
+msgstr "Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7922,15 +7907,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
+msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
+msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8024,8 +8007,7 @@ msgstr "Ekvatoriālā Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
+msgstr "Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8092,7 +8074,7 @@ msgstr "Meistarīgi radīti produkti cilvēkiem, kuriem rūp privātums."
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Termiņš beidzies"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8106,7 +8088,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Derīgs līdz %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8131,8 +8113,7 @@ msgstr "Izskaidro pieņemto atbildi vienkāršā valodā."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
+msgstr "Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8369,8 +8350,7 @@ msgstr "Atsauksme sekmīgi iesniegta"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
+msgstr "Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8511,8 +8491,7 @@ msgstr "Finanšu konsultants"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
+msgstr "Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8863,9 +8842,9 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac datorā lietotnes izvēlnes joslā izvēlies <strong>DuckDuckGo</strong> "
-"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt atjauninājumus..."
-"&quot;) un tad <strong>Install Update</strong> (&quot;Instalēt "
-"atjauninājumu&quot;)."
+"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt "
+"atjauninājumus...&quot;) un tad <strong>Install Update</strong> "
+"(&quot;Instalēt atjauninājumu&quot;)."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9158,8 +9137,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Iegūsti DuckDuckGo VPN, padziļināto Duck.ai un Identity Theft Restoration."
+msgstr "Iegūsti DuckDuckGo VPN, padziļināto Duck.ai un Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9382,8 +9360,7 @@ msgstr "Iegūt lietotni"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"Iegūsti bezmaksas pārlūku DuckDuckGo, %1$slai bloķētu reklāmas YouTube.%2$s"
+msgstr "Iegūsti bezmaksas pārlūku DuckDuckGo, %1$slai bloķētu reklāmas YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9488,13 +9465,14 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Dodies uz %1$sDuck.ai Iestatījumi%2$s › %3$sTērzēšanas › Sync & Backup › "
+"Sinhronizēt ar citu ierīci%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
+msgstr "Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9605,7 +9583,7 @@ msgstr "Sapratu"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Sapratu"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10167,8 +10145,8 @@ msgstr "Slēp savu e-pasta adresi"
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
 msgstr ""
-"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas cilnē/"
-"vēsturē"
+"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas "
+"cilnē/vēsturē"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10416,8 +10394,7 @@ msgstr "Cik daudz tu vēlies, lai parādītos MI atbalstītas atbildes?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
+msgstr "Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10574,8 +10551,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
+msgstr "Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10662,8 +10638,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
+msgstr "Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10681,8 +10656,7 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
+msgstr "Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -11240,8 +11214,7 @@ msgstr "Tas varētu aizņemt dažas minūtes"
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
+msgstr "Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -11590,7 +11563,7 @@ msgstr "Uzzināt %1$sVairāk%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Uzzināt vairāk"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -12230,7 +12203,7 @@ msgstr "Pārvaldīt"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Pārvaldīt"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12487,7 +12460,7 @@ msgstr "Izvēlne"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Ziņojumi pēc šī punkta ir redzami tikai tev."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12750,8 +12723,7 @@ msgstr "Tu esi sasniedzis mēneša limitu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
+msgstr "Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12862,7 +12834,7 @@ msgstr "Vairāk par Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Vairāk darbību"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13062,7 +13034,7 @@ msgstr "Blāvi sarkans"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Manas ierīces"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13653,8 +13625,7 @@ msgstr "Tikai meklēšana – bez izsekošanas un mērķētas reklāmas!"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
+msgstr "Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -14141,6 +14112,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Citā ierīcē dodies uz %1$sDuck.ai Iestatījumi%2$s › %3$sTērzēšanas › Sync & "
+"Backup › Sinhronizēt ar citu ierīci%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14149,6 +14122,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Citā ierīcē dodies uz %1$sDuck.ai Iestatījumi%2$s › %3$sTērzēšanas › Sync & "
+"Backup › Sinhronizēt ar citu ierīci%4$s un noskenē šo kodu:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14157,6 +14132,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Citā ierīcē dodies uz %1$sDuck.ai Iestatījumi%2$s › %3$sTērzēšanas › Sync & "
+"Backup › Sinhronizēt ar citu ierīci%4$s. Vai arī noskenē kvadrātkodu savā "
+"atkopšanas PDF failā."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14304,8 +14282,7 @@ msgstr "Atver %1$sIestatījumi%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
+msgstr "Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14915,7 +14892,7 @@ msgstr "Pēdējais gads"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Ielīmēt"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14933,7 +14910,7 @@ msgstr "Ielīmēt sinhronizācijas kodu"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Ielīmē to zemāk"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14992,7 +14969,7 @@ msgstr "Persiešu"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -15001,6 +14978,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Pakalpojums Personal Information Removal atrod tavu informāciju datu "
+"tirgotāju vietnēs, kas to pārdod. Pēc tam mēs strādājam, lai to izņemtu tavā "
+"vietā."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15254,8 +15234,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
+msgstr "Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15263,8 +15242,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
+msgstr "Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15475,8 +15453,7 @@ msgstr "Plus vēl citas premium funkcijas ar DuckDuckGo abonementu."
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
+msgstr "Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -16069,8 +16046,7 @@ msgstr "Aizsargā savus datus meklēšanas un pārlūkošanas laikā."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
+msgstr "Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16271,7 +16247,7 @@ msgstr "Lapas ielāde…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Esi gatavs saules aptumsumam?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16471,7 +16447,7 @@ msgstr "Atkopšanas kods"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Atkopšanas kods"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16692,8 +16668,7 @@ msgstr "Atcerēties manu izvēli"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
+msgstr "Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16729,7 +16704,7 @@ msgstr "Noņemt %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Noņemt ierīci"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16777,13 +16752,13 @@ msgstr "Noņem nevajadzīgās pieturzīmes"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Izņem savus datus no Interneta"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Izņem savus datus tiešsaistē"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17483,6 +17458,8 @@ msgstr "Iepazīsties ar Duck.ai!"
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
+"Iepazīsties ar Duck.ai — privātu bezmaksas MI tērzēšanu, ko piedāvā "
+"DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17629,8 +17606,7 @@ msgstr "Ritini uz leju un sarakstā atrodi %1$ssavu pārlūkprogrammu%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
+msgstr "Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18154,8 +18130,7 @@ msgstr "Apskati dažus no mūsu pēdējiem atjauninājumiem"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
+msgstr "Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18189,20 +18164,18 @@ msgstr "Safari izvēlnē atlasi %1$s“Šīs vietnes iestatījumi...”%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Atlasi %1$sPielāgots%2$s un ievades laukā raksti %3$shttps://duckduckgo."
-"com%4$s"
+"Atlasi %1$sPielāgots%2$s un ievades laukā raksti "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
+msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
+msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18214,8 +18187,7 @@ msgstr "Atlasi %1$sDuckDuckGo%2$s un nospied %3$sIestatīt kā noklusējumu%4$s.
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
+msgstr "Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18235,8 +18207,7 @@ msgstr "Meklēšanas pakalpojumu sniedzēju sarakstā atlasi %1$sDuckDuckGo%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
+msgstr "Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18269,8 +18240,7 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
+msgstr "Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18490,7 +18460,7 @@ msgstr "Serbu (latīņu)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Servera dati izdzēsti"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18652,7 +18622,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Kopīgot"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18807,13 +18777,13 @@ msgstr "Dalies ar savām domām meklēšanas lodziņā."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Kopīgotās tērzēšanas saites"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Kopīgotās tērzēšanas saites"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19201,8 +19171,7 @@ msgstr "Parāda horizontālas līnijas rezultātu lapu pārtraukumos"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
+msgstr "Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19223,8 +19192,7 @@ msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu pārlūk
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
+msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19494,21 +19462,19 @@ msgstr "Kaut kas notika nepareizi"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Ielādējot šo kopīgoto tērzēšanu, radās kļūda."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
+msgstr "Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
+msgstr "Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19595,8 +19561,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt Duck."
-"ai."
+"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19612,8 +19578,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
+msgstr "Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19874,22 +19839,19 @@ msgstr "Paliec DuckDuckGo platformā"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20091,8 +20053,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
+msgstr "Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20349,7 +20310,7 @@ msgstr "Pārslēgt modeli"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Pārslēgt modeli"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20612,7 +20573,7 @@ msgstr "Sinhronizētās ierīces"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Sinhronizēts %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20650,7 +20611,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabula"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20718,8 +20679,7 @@ msgstr "Esi noteicējs pār saviem personīgajiem datiem!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
+msgstr "Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21238,7 +21198,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Šī ierīce"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21249,6 +21209,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Šī ierīce vairs nevarēs piekļūt taviem sinhronizētajiem datiem citās "
+"ierīcēs. Pēdējās %1$s tērzēšanas joprojām būs pieejamas vietējā krātuvē."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21341,7 +21303,7 @@ msgstr "Šī informācija nav noderīga"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Šī ir kopīgotas tērzēšanas kopija."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21461,13 +21423,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Šo kopīgoto tērzēšanu neizdevās atvērt. Iespējams, saite ir nepilnīga."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Šī kopīgotās tērzēšanas saite vairs nav pieejama."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21765,8 +21727,7 @@ msgstr "Pārāk daudz reklāmu"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr ""
-"Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
+msgstr "Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22117,7 +22078,7 @@ msgstr "Izmēģini bez maksas"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Izmēģini par brīvu!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22207,8 +22168,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
+msgstr "Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22239,7 +22199,7 @@ msgstr "Izmēģināt bez maksas"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Izmēģini bez maksas!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22490,7 +22450,7 @@ msgstr "Turkmenistāna"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Izslēgt"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22508,7 +22468,7 @@ msgstr "Izslēgt Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Vai izslēgt Sync & Backup un dzēst servera datus?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22599,8 +22559,7 @@ msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Precīza atrašanās v
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
+msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22751,8 +22710,7 @@ msgstr "Nevar iesniegt atsauksmi"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
+msgstr "Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -22793,8 +22751,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: https://"
-"duckduckgo.com"
+"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22820,15 +22778,13 @@ msgstr "Zem %1$sMeklēt adreses joslā ar%2$s nospied %3$sPievienot jaunu%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
+msgstr "Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
+msgstr "Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22936,8 +22892,7 @@ msgstr "Atbloķē ar DuckDuckGo abonementu"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
+msgstr "Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22996,7 +22951,7 @@ msgstr "Izslēgt klusumu"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Tērzēšana bez nosaukuma"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23037,7 +22992,7 @@ msgstr "Atjaunināt pārlūku"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Atjaunini Duck.ai, lai skatītu šo kopīgoto tērzēšanu."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23380,8 +23335,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
+msgstr "Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23620,8 +23574,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver Duck."
-"ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
+"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver "
+"Duck.ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
 "“Sinhronizēt ar citu ierīci”. Vai arī noskenē kvadrātkodu savā atkopšanas "
 "PDF failā."
 
@@ -23903,8 +23857,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
+msgstr "Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23920,8 +23873,7 @@ msgstr "Mēs neglabājam lietotājvārdus un personu identificējošu informāci
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
+msgstr "Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24026,6 +23978,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Mēs atrodam un izņemam tavu personisko informāciju no datu tirgotāju "
+"vietnēm. Turklāt iegūsti VPN un vēl citus aizsardzības līdzekļus."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24052,8 +24006,7 @@ msgstr "Mēs zaudējām savienojumu, lūdzu, vēlāk mēģini vēlreiz."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
+msgstr "Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24081,6 +24034,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Mēs regulāri skenējam datu tirgotāju vietnes, meklējot tavu personisko "
+"informāciju, un parādām tev rezultātus ērtā informācijas panelī."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24093,8 +24048,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
+msgstr "Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24127,6 +24081,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Mēs skenēsim datu brokeru vietnes, meklējot tavu e-pastu, vārdu, adresi un "
+"citu informāciju, un strādāsim, lai izņemtu visu, ko par tevi atradīsim."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24327,8 +24283,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
+msgstr "Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24449,7 +24404,7 @@ msgstr "Kādi ir daži anuitāšu plusi un mīnusi?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Kādas ir Duck.ai priekšrocības?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24779,8 +24734,7 @@ msgstr "Par ko tu vēlētos sniegt atsauksmes?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
+msgstr "Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24870,8 +24824,7 @@ msgstr "Kas mēs esam"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
-"Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
+msgstr "Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25025,6 +24978,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Darbojas tieši no tavas ierīces, lai izņemtu tavu e-pastu, vārdu, adresi un "
+"citu informāciju no datu tirgotāju vietnēm."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25272,8 +25227,7 @@ msgstr "Jā, jauns lietotājs!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
+msgstr "Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25370,8 +25324,7 @@ msgstr "Tu vari mainīt to jebkurā laikā sadaļā %1$sMeklēšanas iestatījum
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
+msgstr "Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25410,8 +25363,7 @@ msgstr "Tu vari turpināt tērzēt, izmantojot savu mēneša limitu."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
+msgstr "Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25531,7 +25483,7 @@ msgstr "Tev ir atlicis 1 mēģinājums."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Tev nav kopīgotu tērzēšanas saišu."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25592,8 +25544,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
+msgstr "Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25702,8 +25653,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
+msgstr "Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25762,14 +25712,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
+msgstr "Tavas %1$s jaunākās tērzēšanas būs pieejamas lokālajā krātuvē šajos pārlūkos:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Tavas Duck.ai tērzēšanas tiek sinhronizētas, izmantojot pilnīgu šifrēšanu."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25801,6 +25751,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Tavs dublējums tiks dzēsts no DuckDuckGo servera. Visas ierīces tiks "
+"atvienotas no sinhronizācijas."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25889,8 +25841,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
+msgstr "Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26182,8 +26133,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
+msgstr "Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26481,8 +26431,7 @@ msgstr "oficiālā vietne"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
+msgstr "vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: lv_LV\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% pilnībā vakcinēti"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% vakcinēti"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -372,7 +380,8 @@ msgstr "%1$s izmantots"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s patērē lietojuma limitu līdz pat 2–5 reizes ātrāk nekā pamatmodeļi %2$s"
+msgstr ""
+"%1$s patērē lietojuma limitu līdz pat 2–5 reizes ātrāk nekā pamatmodeļi %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -487,6 +496,13 @@ msgstr "%1$sUzzināt vairāk%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sUzzini, kā mēs nodrošinām tavas atrašanās vietas privātumu%2$s."
+
+# smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -781,6 +797,12 @@ msgid "2nd in Group %s"
 msgstr "2. vieta %1$s grupā"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -935,14 +957,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
+msgstr ""
+"Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
+msgstr ""
+"Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1465,6 +1489,12 @@ msgid "Add to Home Screen"
 msgstr "Pievienot sākuma ekrānam"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Paplašinājumi"
@@ -1566,8 +1596,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"Izmantojot jaudīgākus modeļus, lietošanas ierobežojumu var sasniegt "
-"2–5 reizes ātrāk nekā ar citiem modeļiem. %1$s"
+"Izmantojot jaudīgākus modeļus, lietošanas ierobežojumu var sasniegt 2–"
+"5 reizes ātrāk nekā ar citiem modeļiem. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1742,7 +1772,8 @@ msgstr "Visas tērzēšanas sarunas ir %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr "Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
+msgstr ""
+"Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -1827,6 +1858,13 @@ msgstr "Visi izmēri"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Visi formāti"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2196,7 +2234,8 @@ msgstr "Vai tu joprojām esi tur?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
+msgstr ""
+"Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2208,7 +2247,8 @@ msgstr "Vai tiešām vēlies notīrīt šo sarunu un sākt jaunu?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
+msgstr ""
+"Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2347,6 +2387,12 @@ msgstr "Jautā par šo lapu"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask anything privately"
 msgstr "Jautā jebko privāti"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -3405,7 +3451,8 @@ msgstr "Kamerūna"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
+msgstr ""
+"Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3725,7 +3772,8 @@ msgstr "Maina fona krāsu visā vietnē"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
+msgstr ""
+"Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3858,8 +3906,8 @@ msgstr ""
 "ar trešo pušu mākslīgā intelekta tērzēšanas modeļiem, kas atbalsta OpenAI, "
 "Anthropic un citus rīkus. Izslēdzot šo iestatījumu tiks paslēptas tērzēšanas "
 "pogas un saites DuckDuckGo Search platformā. Taču tu joprojām vari piekļūt "
-"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot "
-"%1$shttps://duck.ai%2$s tieši."
+"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot %1$shttps://duck."
+"ai%2$s tieši."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4473,7 +4521,8 @@ msgstr "Nospied %1$sAtļaut%2$s, pēc tam %3$sPievienot%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr ""
+"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4574,7 +4623,8 @@ msgstr "Sānjoslā noklikšķini uz %1$sPārlūks%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr ""
+"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4594,7 +4644,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
+msgstr ""
+"Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4723,7 +4774,8 @@ msgstr "Noklikšķini uz palielināmā stikla ikonas meklēšanas lodziņā"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr "Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
+msgstr ""
+"Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5183,7 +5235,8 @@ msgstr "Turpināt bloķēt reklāmas"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "Turpini nesenās tērzēšanas sarunas šeit. Vai arī dzēs tās ar Fire Button."
+msgstr ""
+"Turpini nesenās tērzēšanas sarunas šeit. Vai arī dzēs tās ar Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5287,6 +5340,12 @@ msgid "Copy"
 msgstr "Kopēt"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5326,6 +5385,28 @@ msgstr "Kopēt vai saglabāt šo kodu"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Kopēt atkopšanas kodu"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5377,7 +5458,8 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
+msgstr ""
+"Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6009,6 +6091,14 @@ msgid "Delete recent chats?"
 msgstr "Vai dzēst pēdējās tērzēšanas sarunas?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6019,6 +6109,14 @@ msgstr "Dzēst šo tērzēšanas sarunu?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Dzēstās tērzēšanas sarunas"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6215,7 +6313,8 @@ msgstr "Atspējot un atvienot"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
+msgstr ""
+"Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6274,6 +6373,13 @@ msgstr "Nerādīt"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Nerādīt"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6409,7 +6515,8 @@ msgstr "Neredzi DuckDuckGo sarakstā?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
+msgstr ""
+"Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6833,7 +6940,8 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
+msgstr ""
+"Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6848,8 +6956,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai ļauj tev privāti tērzēt ar populāriem MI modeļiem. Atspējošana "
-"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt "
-"%1$sduck.ai%2$s tieši."
+"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt %1$sduck."
+"ai%2$s tieši."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6919,7 +7027,8 @@ msgstr "Duck.ai atjaunināts!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
+msgstr ""
+"Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7132,6 +7241,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo pārlūks %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7483,7 +7599,8 @@ msgstr "Rediģē attēlu..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
+msgstr ""
+"Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7805,13 +7922,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
+msgstr ""
+"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
+msgstr ""
+"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7905,7 +8024,8 @@ msgstr "Ekvatoriālā Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
+msgstr ""
+"Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7968,10 +8088,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "Meistarīgi radīti produkti cilvēkiem, kuriem rūp privātums."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Beidzies"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7996,7 +8131,8 @@ msgstr "Izskaidro pieņemto atbildi vienkāršā valodā."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
+msgstr ""
+"Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8233,7 +8369,8 @@ msgstr "Atsauksme sekmīgi iesniegta"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
+msgstr ""
+"Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8374,7 +8511,8 @@ msgstr "Finanšu konsultants"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
+msgstr ""
+"Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8725,9 +8863,9 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac datorā lietotnes izvēlnes joslā izvēlies <strong>DuckDuckGo</strong> "
-"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt "
-"atjauninājumus...&quot;) un tad <strong>Install Update</strong> "
-"(&quot;Instalēt atjauninājumu&quot;)."
+"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt atjauninājumus..."
+"&quot;) un tad <strong>Install Update</strong> (&quot;Instalēt "
+"atjauninājumu&quot;)."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9020,7 +9158,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "Iegūsti DuckDuckGo VPN, padziļināto Duck.ai un Identity Theft Restoration."
+msgstr ""
+"Iegūsti DuckDuckGo VPN, padziļināto Duck.ai un Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9243,7 +9382,8 @@ msgstr "Iegūt lietotni"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "Iegūsti bezmaksas pārlūku DuckDuckGo, %1$slai bloķētu reklāmas YouTube.%2$s"
+msgstr ""
+"Iegūsti bezmaksas pārlūku DuckDuckGo, %1$slai bloķētu reklāmas YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9342,10 +9482,19 @@ msgstr ""
 "ierīci%4$s. Vai arī noskenē kvadrātkodu savā atkopšanas PDF failā."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
+msgstr ""
+"Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9451,6 +9600,12 @@ msgstr "Sapratu"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Sapratu"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10012,8 +10167,8 @@ msgstr "Slēp savu e-pasta adresi"
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
 msgstr ""
-"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas "
-"cilnē/vēsturē"
+"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas cilnē/"
+"vēsturē"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10261,7 +10416,8 @@ msgstr "Cik daudz tu vēlies, lai parādītos MI atbalstītas atbildes?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
+msgstr ""
+"Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10418,7 +10574,8 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
+msgstr ""
+"Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10505,7 +10662,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
+msgstr ""
+"Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10523,7 +10681,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
+msgstr ""
+"Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -11081,7 +11240,8 @@ msgstr "Tas varētu aizņemt dažas minūtes"
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr "Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
+msgstr ""
+"Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -11425,6 +11585,12 @@ msgstr "Uzzināt %1$sVairāk%2$s"
 msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Uzzināt %1$sVairāk%2$s"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -12060,6 +12226,13 @@ msgid "Manage"
 msgstr "Pārvaldīt"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12309,6 +12482,12 @@ msgstr "Izvēlne"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Izvēlne"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12571,7 +12750,8 @@ msgstr "Tu esi sasniedzis mēneša limitu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
+msgstr ""
+"Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12677,6 +12857,12 @@ msgstr "Vairāk par !bangs"
 msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr "Vairāk par Duck.ai"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12871,6 +13057,12 @@ msgstr "Izslēgts"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Blāvi sarkans"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13461,7 +13653,8 @@ msgstr "Tikai meklēšana – bez izsekošanas un mērķētas reklāmas!"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr "Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
+msgstr ""
+"Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -13942,6 +14135,30 @@ msgstr ""
 "%3$snoklikšķini %4$s ikonu > Iestatījumi%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14087,7 +14304,8 @@ msgstr "Atver %1$sIestatījumi%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
+msgstr ""
+"Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14694,6 +14912,12 @@ msgid "Past year"
 msgstr "Pēdējais gads"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14704,6 +14928,12 @@ msgstr "Ielīmēt"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Ielīmēt sinhronizācijas kodu"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14757,6 +14987,20 @@ msgstr "Pastāvīgi slēgts"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persiešu"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15010,7 +15254,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
+msgstr ""
+"Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15018,7 +15263,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
+msgstr ""
+"Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15229,7 +15475,8 @@ msgstr "Plus vēl citas premium funkcijas ar DuckDuckGo abonementu."
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr "Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
+msgstr ""
+"Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15822,7 +16069,8 @@ msgstr "Aizsargā savus datus meklēšanas un pārlūkošanas laikā."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
+msgstr ""
+"Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16020,6 +16268,12 @@ msgid "Reading website…"
 msgstr "Lapas ielāde…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16212,6 +16466,12 @@ msgstr "Atgūšana"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Atkopšanas kods"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16432,7 +16692,8 @@ msgstr "Atcerēties manu izvēli"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
+msgstr ""
+"Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16463,6 +16724,12 @@ msgstr "Noņemt %1$s"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "Noņemt %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16505,6 +16772,18 @@ msgstr "Noņemt atlasīto tekstu"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Noņem nevajadzīgās pieturzīmes"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17200,6 +17479,12 @@ msgid "Say hello to Duck.ai"
 msgstr "Iepazīsties ar Duck.ai!"
 
 # smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai!"
@@ -17344,7 +17629,8 @@ msgstr "Ritini uz leju un sarakstā atrodi %1$ssavu pārlūkprogrammu%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
+msgstr ""
+"Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17868,7 +18154,8 @@ msgstr "Apskati dažus no mūsu pēdējiem atjauninājumiem"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
+msgstr ""
+"Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17902,18 +18189,20 @@ msgstr "Safari izvēlnē atlasi %1$s“Šīs vietnes iestatījumi...”%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Atlasi %1$sPielāgots%2$s un ievades laukā raksti "
-"%3$shttps://duckduckgo.com%4$s"
+"Atlasi %1$sPielāgots%2$s un ievades laukā raksti %3$shttps://duckduckgo."
+"com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
+msgstr ""
+"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
+msgstr ""
+"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17925,7 +18214,8 @@ msgstr "Atlasi %1$sDuckDuckGo%2$s un nospied %3$sIestatīt kā noklusējumu%4$s.
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
+msgstr ""
+"Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17945,7 +18235,8 @@ msgstr "Meklēšanas pakalpojumu sniedzēju sarakstā atlasi %1$sDuckDuckGo%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
+msgstr ""
+"Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17978,7 +18269,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr "Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
+msgstr ""
+"Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18194,6 +18486,13 @@ msgid "Serbian (Latin)"
 msgstr "Serbu (latīņu)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18348,6 +18647,14 @@ msgid "Share"
 msgstr "Kopīgot"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18495,6 +18802,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Dalies ar savām domām meklēšanas lodziņā."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18882,7 +19201,8 @@ msgstr "Parāda horizontālas līnijas rezultātu lapu pārtraukumos"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
+msgstr ""
+"Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18903,7 +19223,8 @@ msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu pārlūk
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
+msgstr ""
+"Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19170,16 +19491,24 @@ msgid "Something went wrong"
 msgstr "Kaut kas notika nepareizi"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
+msgstr ""
+"Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
+msgstr ""
+"Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19266,8 +19595,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt "
-"Duck.ai."
+"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19283,7 +19612,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
+msgstr ""
+"Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19544,19 +19874,22 @@ msgstr "Paliec DuckDuckGo platformā"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr ""
+"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr ""
+"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr ""
+"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19758,7 +20091,8 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
+msgstr ""
+"Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20010,6 +20344,12 @@ msgstr "Pārslēgt modeli"
 msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr "Pārslēgt modeli"
+
+# smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20268,6 +20608,13 @@ msgid "Synced Devices"
 msgstr "Sinhronizētās ierīces"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Sīrija"
 
@@ -20298,6 +20645,12 @@ msgstr "Gaida"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20365,7 +20718,8 @@ msgstr "Esi noteicējs pār saviem personīgajiem datiem!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
+msgstr ""
+"Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20881,6 +21235,22 @@ msgstr ""
 "aizskaroša informācija (plašāku informācijas skati %4$s)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20966,6 +21336,12 @@ msgstr ""
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Šī informācija nav noderīga"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21080,6 +21456,18 @@ msgstr ""
 "izdzēs duckduckgo.com pārlūkprogrammas datus, tu atkal vari redzēt MI "
 "atbalstītas atbildes. Tomēr mums ir arī sākumlapa, kurā nekad netiek rādītas "
 "ar MI palīdzību veidotas atbildes vietnē %1$s."
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21377,7 +21765,8 @@ msgstr "Pārāk daudz reklāmu"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr "Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
+msgstr ""
+"Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21725,6 +22114,12 @@ msgid "Try Free"
 msgstr "Izmēģini bez maksas"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21812,7 +22207,8 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
+msgstr ""
+"Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21838,6 +22234,12 @@ msgstr "Izmēģināt bez maksas"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Izmēģināt bez maksas"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22085,6 +22487,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistāna"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22095,6 +22503,12 @@ msgstr "Izslēgt Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Izslēgt Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22185,7 +22599,8 @@ msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Precīza atrašanās v
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
+msgstr ""
+"Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22336,7 +22751,8 @@ msgstr "Nevar iesniegt atsauksmi"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
+msgstr ""
+"Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -22377,8 +22793,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: "
-"https://duckduckgo.com"
+"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22404,13 +22820,15 @@ msgstr "Zem %1$sMeklēt adreses joslā ar%2$s nospied %3$sPievienot jaunu%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
+msgstr ""
+"Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
+msgstr ""
+"Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22518,7 +22936,8 @@ msgstr "Atbloķē ar DuckDuckGo abonementu"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
+msgstr ""
+"Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22574,6 +22993,12 @@ msgid "Unmute"
 msgstr "Izslēgt klusumu"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22607,6 +23032,12 @@ msgstr "Atjaunināt"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Atjaunināt pārlūku"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22949,7 +23380,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
+msgstr ""
+"Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23188,8 +23620,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver "
-"Duck.ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
+"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver Duck."
+"ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
 "“Sinhronizēt ar citu ierīci”. Vai arī noskenē kvadrātkodu savā atkopšanas "
 "PDF failā."
 
@@ -23471,7 +23903,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
+msgstr ""
+"Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23487,7 +23920,8 @@ msgstr "Mēs neglabājam lietotājvārdus un personu identificējošu informāci
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
+msgstr ""
+"Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23586,6 +24020,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Mēs pārtraucām tērzēšanu neaktivitātes dēļ. Vai gribi mēģināt vēlreiz?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23610,7 +24052,8 @@ msgstr "Mēs zaudējām savienojumu, lūdzu, vēlāk mēģini vēlreiz."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
+msgstr ""
+"Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -23632,6 +24075,14 @@ msgstr ""
 "rezultātus tavā tuvumā. Vēlāk vienmēr varēsi pārdomāt."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23642,7 +24093,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
+msgstr ""
+"Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23667,6 +24119,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Mēs bloķēsim izsekotājus, kas mēģina vākt tavus datus tīmekļa pārlūkošanas "
 "laikā."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23867,7 +24327,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
+msgstr ""
+"Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23983,6 +24444,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Kādi ir daži anuitāšu plusi un mīnusi?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24312,7 +24779,8 @@ msgstr "Par ko tu vēlētos sniegt atsauksmes?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
+msgstr ""
+"Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24402,7 +24870,8 @@ msgstr "Kas mēs esam"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr "Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
+msgstr ""
+"Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24548,6 +25017,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Bez pilnīgas neredzamības pakalpojumu sniedzējam"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24795,7 +25272,8 @@ msgstr "Jā, jauns lietotājs!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
+msgstr ""
+"Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24892,7 +25370,8 @@ msgstr "Tu vari mainīt to jebkurā laikā sadaļā %1$sMeklēšanas iestatījum
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
+msgstr ""
+"Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24931,7 +25410,8 @@ msgstr "Tu vari turpināt tērzēt, izmantojot savu mēneša limitu."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
+msgstr ""
+"Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25047,6 +25527,13 @@ msgid "You have 1 attempt left."
 msgstr "Tev ir atlicis 1 mēģinājums."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25105,7 +25592,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
+msgstr ""
+"Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25214,7 +25702,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
+msgstr ""
+"Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25266,6 +25755,23 @@ msgid "YouTube Standard"
 msgstr "Youtube Standarta"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Tava DuckDuckGo meklēšanas vēsture ir privāta"
@@ -25287,6 +25793,14 @@ msgstr "Tava precīzā atrašanās vieta paliek privāta"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Tava precīzā atrašanās vieta paliek privāta."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25375,7 +25889,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
+msgstr ""
+"Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25667,7 +26182,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
+msgstr ""
+"Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25965,7 +26481,8 @@ msgstr "oficiālā vietne"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
+msgstr ""
+"vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ml_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% സമ്പൂര്‍ണ വാക്സിനേഷൻ എടു�
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% വാക്സിനേഷന്‍ എടുത്തു"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -182,9 +190,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
-"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
-"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
+"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -194,9 +201,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
-"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
-"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
+"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -212,9 +218,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് "
-"തുടരാൻ, നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
-"മോഡലിലേക്ക് മാറുക."
+"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് തുടരാൻ, നിങ്ങളുടെ "
+"സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -223,8 +228,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ "
-"പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ പിന്നീട് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -301,8 +306,7 @@ msgstr "%1$s റാങ്കിംഗുകൾ ഇതുവരെ ലഭ്യ�
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
 msgstr ""
-"%1$s അടിസ്ഥാന മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധികളിൽ "
-"എത്തുന്നു. %2$s"
+"%1$s അടിസ്ഥാന മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധികളിൽ എത്തുന്നു. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -323,9 +327,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് "
-"പോലും നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് "
-"അവരുടെ സെർവറുകളിൽ സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
+"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് പോലും "
+"നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് അവരുടെ സെർവറുകളിൽ "
+"സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -411,8 +415,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ "
-"ചാറ്റ് തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ ചാറ്റ് "
+"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -423,8 +427,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് "
-"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് തുടരുന്നതിന് "
+"നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -437,8 +441,8 @@ msgstr "%1$s വാക്കുകൾ"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, "
-"തുടർന്ന് %6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, തുടർന്ന് "
+"%6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -446,8 +450,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് "
-"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s "
+"ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -457,9 +461,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s "
-"ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s "
-"ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s ക്ലിക്ക് "
+"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -468,8 +471,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ "
-"ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ കരുതുന്നുണ്ടെങ്കിൽ."
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ "
+"കരുതുന്നുണ്ടെങ്കിൽ."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -488,8 +491,14 @@ msgstr "%1$sകൂടുതലറിയുക%2$s ."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
-"മനസ്സിലാക്കുക%2$s."
+"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക%2$s."
+
+# smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -497,16 +506,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
-"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
+"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
+"%1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
-"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
+"%1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -519,8 +528,7 @@ msgstr "ഹോം സ്ക്രീനിൽ DuckDuckGo ആപ്പ് ഐക�
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s "
-"വീണ്ടും ശ്രമിക്കുക."
+"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -784,6 +792,12 @@ msgid "2nd in Group %s"
 msgstr "%1$s ഗ്രൂപ്പിൽ 2-ാമത്"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -872,9 +886,7 @@ msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
-"തുടരാം."
+msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -928,8 +940,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. "
-"നിങ്ങളുടെ കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. നിങ്ങളുടെ കണക്ഷൻ "
+"പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -987,10 +999,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ "
-"അനുവദിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത "
-"മറയ്ക്കും. %1$sduckduckgo.com/aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് "
-"ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ കഴിയും."
+"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
+"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത മറയ്ക്കും. %1$sduckduckgo.com/"
+"aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1051,11 +1063,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് "
-"പിന്തുണയ്ക്കുന്നില്ല. എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി "
-"%1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, "
-"ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
-"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് പിന്തുണയ്ക്കുന്നില്ല. "
+"എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി %1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും "
+"പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് "
+"മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1240,8 +1251,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു "
-"സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
+"മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1277,8 +1288,8 @@ msgstr "പരസ്യം"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ "
-"നിങ്ങളെ തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
+"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ നിങ്ങളെ "
+"തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1286,8 +1297,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
-"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ "
+"ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1338,8 +1349,8 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ചേർക്കുക"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy "
-"Essentials ചേർക്കുക:"
+"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy Essentials "
+"ചേർക്കുക:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1466,6 +1477,12 @@ msgid "Add to Home Screen"
 msgstr "ഹോംസ്ക്രീനിലേക്കു ചേർക്കുക"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "ആഡ്-ഓണുകള്‍"
@@ -1567,8 +1584,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ "
-"പരിധിയിൽ എത്തിച്ചേരാൻ കഴിഞ്ഞേക്കാം. %1$s"
+"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധിയിൽ "
+"എത്തിച്ചേരാൻ കഴിഞ്ഞേക്കാം. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1577,8 +1594,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
-"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2-5 മടങ്ങ് വേഗത്തിൽ പരിധികൾ ഉപയോഗിക്കാൻ "
-"കഴിഞ്ഞേക്കാം. %1$s"
+"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2-5 മടങ്ങ് വേഗത്തിൽ പരിധികൾ ഉപയോഗിക്കാൻ കഴിഞ്ഞേക്കാം. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1614,17 +1631,15 @@ msgstr "ആഫ്രികാൻസ്"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് "
-"ചെയ്യുക"
+msgstr "ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
 msgstr ""
-"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് "
-"ഡബിൾ ക്ലിക്ക് ചെയ്യുക"
+"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് ഡബിൾ ക്ലിക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1760,9 +1775,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ "
-"DuckDuckGo അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കുന്നില്ല"
+"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ DuckDuckGo "
+"അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1795,8 +1809,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ "
-"ദാതാക്കളെയും അനുവദിക്കില്ല."
+"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ ദാതാക്കളെയും "
+"അനുവദിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1811,8 +1825,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും "
-"(ഉദാഹരണത്തിന്, നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
+"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും (ഉദാഹരണത്തിന്, "
+"നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1833,6 +1847,13 @@ msgid "All types"
 msgstr "എല്ലാ തരവും"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1844,8 +1865,7 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ "
-"ആക്സസ് അനുവദിക്കുക."
+"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ ആക്സസ് അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1877,11 +1897,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ "
-"%1$s-നെ അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് "
-"എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള "
-"പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ ദൃശ്യപരത പൂജ്യം "
-"ആണ്%4$s."
+"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ %1$s-നെ "
+"അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച "
+"ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ "
+"ദൃശ്യപരത പൂജ്യം ആണ്%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2028,8 +2047,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
-"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
+"അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2038,8 +2057,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
-"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
+"അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2053,9 +2072,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
-"സൃഷ്ടിക്കുന്നു. ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, "
-"അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
+"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്നു. ഇത് "
+"എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2223,8 +2241,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത "
-"ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ ചാറ്റുകളും ഇല്ലാതാക്കും."
+"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ "
+"ചാറ്റുകളും ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2233,8 +2251,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് "
-"ചെയ്ത സമീപകാല ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
+"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് ചെയ്ത സമീപകാല "
+"ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2272,9 +2290,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും "
-"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും ശേഖരിക്കുകയോ "
+"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2355,6 +2372,12 @@ msgid "Ask anything privately"
 msgstr "എന്തും സ്വകാര്യമായി ചോദിക്കൂ"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2410,15 +2433,13 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ "
-"ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ "
-"പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും ഇല്ല (തിരയൽ "
-"ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
-"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
-"കാണിക്കൂ), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
-"കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി "
-"കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. (ഇംഗ്ലീഷ്) മേഖലയിൽ "
-"മാത്രമേ ലഭ്യമാകൂ."
+"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ ഉത്തരങ്ങൾ അജ്ഞാതമായി "
+"സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
+"ഒരിക്കലും ഇല്ല (തിരയൽ ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
+"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ചിലപ്പോൾ "
+"(വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ "
+"തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. "
+"(ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2430,14 +2451,13 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ "
-"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. "
-"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
-"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
-"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
-"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
-"%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
+"അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
+"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
+"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ %1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് "
+"പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2463,9 +2483,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"കഫേയിലോ വിമാനത്താവളത്തിലോ ഹോട്ടലിലോ ആയിരിക്കുമ്പോൾ, DuckDuckGo VPN നിങ്ങളുടെ "
-"കണക്ഷൻ എൻക്രിപ്റ്റ് ചെയ്യുകയും Wi-Fi-യിൽ നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുകയും "
-"ചെയ്യുന്നു."
+"കഫേയിലോ വിമാനത്താവളത്തിലോ ഹോട്ടലിലോ ആയിരിക്കുമ്പോൾ, DuckDuckGo VPN നിങ്ങളുടെ കണക്ഷൻ "
+"എൻക്രിപ്റ്റ് ചെയ്യുകയും Wi-Fi-യിൽ നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2581,16 +2600,15 @@ msgstr "സ്വയമേവയുള്ള-ഉത്തരം"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ "
-"അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. "
-"പ്രതികരണങ്ങളിൽ അപാകതകൾ അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. പ്രതികരണങ്ങളിൽ അപാകതകൾ "
+"അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2615,9 +2633,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി "
-"തിരയാനും ചില സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. "
-"ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ Assist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി തിരയാനും ചില "
+"സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ "
+"മാത്രമേ Assist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2626,17 +2644,16 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് "
-"അജ്ഞാതമായി തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
-"കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് അജ്ഞാതമായി "
+"തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് "
+"പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
 msgstr ""
-"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ "
-"സ്വയമേവ പ്ലേ ചെയ്യുക."
+"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ സ്വയമേവ പ്ലേ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2668,9 +2685,7 @@ msgstr "ശരാശരി വോളിയം"
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr ""
-"നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് "
-"ഒഴിവാക്കുക."
+msgstr "നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് ഒഴിവാക്കുക."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2838,9 +2853,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, "
-"തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo "
-"നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
+"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ "
+"എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2970,8 +2984,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"ഉപദ്രവകരമായ സൈറ്റുകൾ തടയുക, നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുക, കൂടാതെ ഞങ്ങളുടെ "
-"സബ്സ്ക്രിപ്ഷൻ വഴി കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ നേടുക."
+"ഉപദ്രവകരമായ സൈറ്റുകൾ തടയുക, നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുക, കൂടാതെ ഞങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വഴി "
+"കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3231,18 +3245,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ "
-"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
-"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
+"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
+"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
+"ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ "
-"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
-"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
+"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
+"ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3250,9 +3264,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. "
-"%1$sപ്രധാന ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, "
-"സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. %1$sപ്രധാന "
+"ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ "
+"മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3338,9 +3352,7 @@ msgstr "'%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നി�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം "
-"അംഗീകരിക്കുന്നു."
+msgstr "“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3361,11 +3373,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), "
-"ക്രമീകരണം സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു "
-"വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത "
-"Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
-"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
+"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), ക്രമീകരണം "
+"സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ "
+"ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി "
+"തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
 "നിങ്ങളുടെ ബ്രൗസറിൽ നിന്ന് പുറത്തുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -3374,9 +3385,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
-"നിങ്ങളുടെ ശബ്ദ ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
-"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
+"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ ശബ്ദ ഡാറ്റ "
+"OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3385,9 +3395,9 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
-"നിങ്ങളുടെ വോയ്സ് ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
-"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
+"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ വോയ്സ് "
+"ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s "
+"കാണൂ."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3423,8 +3433,8 @@ msgstr "കാമറൂൺ"
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
 msgstr ""
-"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ "
-"പാചകക്കുറിപ്പുകൾ സൃഷ്ടിക്കാൻ കഴിയുമോ?"
+"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ പാചകക്കുറിപ്പുകൾ "
+"സൃഷ്ടിക്കാൻ കഴിയുമോ?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3726,8 +3736,7 @@ msgstr "ഫലങ്ങളുടെ URL-കൾ എങ്ങനെ പ്രദ�
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
 msgstr ""
-"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ "
-"പെരുമാറ്റവും മാറുന്നു"
+"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ പെരുമാറ്റവും മാറുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3746,17 +3755,13 @@ msgstr "മുഴുവൻ സൈറ്റിലും പശ്ചാത്ത�
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം "
-"മാറ്റുന്നു"
+msgstr "ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം "
-"മാറ്റുന്നു"
+msgstr "ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3879,11 +3884,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ "
-"ചാറ്റ് (Duck.ai സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic "
-"തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo "
-"Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, "
-"%1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
+"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ ചാറ്റ് (Duck.ai "
+"സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. "
+"ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. "
+"എന്നിരുന്നാലും, %1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
 "നിങ്ങൾക്ക് ചാറ്റ് ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
@@ -3940,8 +3944,8 @@ msgstr "സ്വകാര്യമായി ചാറ്റ് ചെയ്യ�
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
-"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3949,8 +3953,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
-"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4019,9 +4023,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത ചാറ്റുകൾ നീക്കം ചെയ്യും."
+"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം നിങ്ങളുടെ "
+"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത "
+"ചാറ്റുകൾ നീക്കം ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4033,13 +4037,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ "
-"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
-"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
-"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
-"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
-"പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും "
+"അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് "
+"നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും "
+"പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4062,9 +4064,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ "
-"അപ്‌ലോഡ് ചെയ്യുന്ന എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് "
-"അജ്ഞാതമായി പരിശോധിക്കുന്നു."
+"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ അപ്‌ലോഡ് ചെയ്യുന്ന "
+"എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് അജ്ഞാതമായി പരിശോധിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4072,8 +4073,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. "
-"സമന്വയം പുനരാരംഭിക്കാൻ സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
+"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. സമന്വയം പുനരാരംഭിക്കാൻ "
+"സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4126,9 +4127,7 @@ msgstr "സ്പെല്ലിംഗ് പരിശോധിക്കുക"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് "
-"പരിശോധിക്കുക."
+msgstr "ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4199,9 +4198,7 @@ msgstr "%1$s , %2$s എന്നിവ ഉൾപ്പെടെ AI മോഡല�
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s "
-"തിരഞ്ഞെടുക്കുക."
+msgstr "നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4233,8 +4230,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"ഉപദ്രവകരമായ സൈറ്റുകളെയും തട്ടിപ്പുകളെയും തടയാൻ ലോകമെമ്പാടുമുള്ള 40-ലധികം "
-"സെർവർ ലൊക്കേഷനുകളിൽ നിന്ന് തിരഞ്ഞെടുക്കുക."
+"ഉപദ്രവകരമായ സൈറ്റുകളെയും തട്ടിപ്പുകളെയും തടയാൻ ലോകമെമ്പാടുമുള്ള 40-ലധികം സെർവർ "
+"ലൊക്കേഷനുകളിൽ നിന്ന് തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4252,8 +4249,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് "
-"ആപ്പ് ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
+"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് ആപ്പ് "
+"ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4434,9 +4431,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ "
-"നടന്ന ചാറ്റുകൾ അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 "
-"ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ നടന്ന ചാറ്റുകൾ "
+"അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി "
+"ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4446,10 +4443,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ "
-"Duck.ai ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ "
-"യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ "
-"ആശ്രയിച്ചിരിക്കുന്നു."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ Duck.ai "
+"ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ "
+"ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ ആശ്രയിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4458,8 +4454,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. "
-"നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് "
+"ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4468,10 +4464,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ "
-"%1$sDuck.ai%2$s വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic "
-"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI "
-"ചാറ്റ് സേവനം."
+"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ %1$sDuck.ai%2$s "
+"വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI ചാറ്റ് സേവനം."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4530,9 +4525,7 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ച�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് "
-"ചെയ്യുക"
+msgstr "DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് ചെയ്യുക"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4549,8 +4542,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ "
-"വലതുവശത്തുള്ള %3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
+"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ വലതുവശത്തുള്ള "
+"%3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4568,8 +4561,7 @@ msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sക്രമീകരണം%
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
 msgstr ""
-"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി "
-"ക്ലിക്ക് ചെയ്യുക%4$s."
+"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി ക്ലിക്ക് ചെയ്യുക%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4582,8 +4574,7 @@ msgstr "%1$sഉവ്വ്%2$s ക്ലിക്ക് ചെയ്യുക"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് "
-"ചെയ്യുക."
+"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4645,10 +4636,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
-"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ "
-"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
-"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
+"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s "
+"ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4659,10 +4649,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
-"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ "
-"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
-"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
+"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/"
+"ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4731,8 +4720,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ "
-"മെനുവിൽ ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
+"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ "
+"ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4740,8 +4729,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ "
-"ബ്രൗസറിന്റെ മുകളിൽ വലത് കോണിലായിരിക്കും."
+"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ ബ്രൗസറിന്റെ "
+"മുകളിൽ വലത് കോണിലായിരിക്കും."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4942,8 +4931,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി "
-"സംരക്ഷിക്കാൻ അനുവദിക്കും. ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
+"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി സംരക്ഷിക്കാൻ അനുവദിക്കും. "
+"ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5214,9 +5203,7 @@ msgstr "പരസ്യങ്ങൾ തടയുന്നത് തുടരു�
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"സമീപകാല ചാറ്റുകൾ ഇവിടെ തുടരുക. അല്ലെങ്കിൽ Fire Button ഉപയോഗിച്ച് അവ "
-"ഇല്ലാതാക്കുക."
+msgstr "സമീപകാല ചാറ്റുകൾ ഇവിടെ തുടരുക. അല്ലെങ്കിൽ Fire Button ഉപയോഗിച്ച് അവ ഇല്ലാതാക്കുക."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5320,6 +5307,12 @@ msgid "Copy"
 msgstr "പകർത്തുക"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5359,6 +5352,28 @@ msgstr "ഈ കോഡ് പകർത്തുക അല്ലെങ്കിൽ
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "റിക്കവറി കോഡ് പകർത്തുക"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5410,9 +5425,7 @@ msgstr "കോസ്റ്റാ റിക്ക"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും "
-"ശ്രമിക്കു."
+msgstr "നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും ശ്രമിക്കു."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5513,8 +5526,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
-"ഒരു ലിങ്ക് നിർമ്മിക്കുന്നത് ചാറ്റിന്റെ ഒരു പകർപ്പ് ഉണ്ടാക്കുന്നു, അത് "
-"തുറക്കുന്ന ആർക്കും അത് കാണാൻ കഴിയും."
+"ഒരു ലിങ്ക് നിർമ്മിക്കുന്നത് ചാറ്റിന്റെ ഒരു പകർപ്പ് ഉണ്ടാക്കുന്നു, അത് തുറക്കുന്ന ആർക്കും അത് കാണാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5753,9 +5766,7 @@ msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞ
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
-"തുടരാം."
+msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6031,15 +6042,21 @@ msgstr "സംഭരണ സ്ഥലം ശൂന്യമാക്കാൻ ഏ
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ "
-"ഇല്ലാതാക്കണോ?"
+msgstr "സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കണോ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
 msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr "സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കണോ?"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6052,6 +6069,14 @@ msgstr "ഈ ചാറ്റ് ഇല്ലാതാക്കണോ?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "ഇല്ലാതാക്കിയ ചാറ്റുകൾ"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6148,8 +6173,8 @@ msgstr "Duck.ai-യിലെ ഡിക്റ്റേഷൻ"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കാറില്ല."
+"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6167,9 +6192,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ "
-"ഉപയോഗിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് "
-"ചെയ്യാൻ സാധിക്കും."
+"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ ഉപയോഗിക്കുന്നു, "
+"അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് ചെയ്യാൻ സാധിക്കും."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6310,6 +6334,13 @@ msgid "Dismiss"
 msgstr "നിരസിക്കുക"
 
 # smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
 msgctxt "duckassist"
 msgid "Dismiss"
@@ -6443,9 +6474,7 @@ msgstr "പട്ടികയിൽ DuckDuckGo കാണുന്നില്ല
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് "
-"ചെയ്യുക%4$s"
+msgstr "അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് ചെയ്യുക%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6483,8 +6512,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI "
-"ചിത്രങ്ങൾ ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
+"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI ചിത്രങ്ങൾ "
+"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6610,8 +6639,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു "
-"വെണ്ടറിന് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടറിന് "
+"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6620,8 +6649,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ "
-"അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് "
+"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6642,8 +6671,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ "
-"പോസ്റ്റിന് കുറച്ച് ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
+"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ പോസ്റ്റിന് കുറച്ച് "
+"ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6652,8 +6681,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു "
-"പോസ്റ്റിന്റെ തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
+"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു പോസ്റ്റിന്റെ "
+"തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6723,9 +6752,7 @@ msgstr "നിങ്ങളുടെ ഫോട്ടോകളോ PDF ഫയലു
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ "
-"അനുവദിക്കുന്നു"
+msgstr "ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6787,10 +6814,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് "
-"ഉത്തരം നൽകാൻ സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ "
-"നിങ്ങൾ തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് "
-"ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
+"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് ഉത്തരം നൽകാൻ "
+"സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ നിങ്ങൾ "
+"തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6800,9 +6826,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് "
-"ചെയ്യാൻ കഴിയില്ല. നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും "
-"എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. "
+"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ "
+"ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6811,16 +6837,14 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. "
-"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. ദയവായി നാളെ ഈ "
+"ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും "
-"മികച്ചത്!"
+msgstr "ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും മികച്ചത്!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6830,9 +6854,8 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ "
-"നിയന്ത്രണം തിരികെ നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര "
-"ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
+"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ നിയന്ത്രണം തിരികെ "
+"നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6847,8 +6870,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ "
-"എളുപ്പമുള്ള ഒരു വിലാസം ലഭിക്കും: https://duck.ai"
+"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ എളുപ്പമുള്ള ഒരു "
+"വിലാസം ലഭിക്കും: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6863,8 +6886,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s "
-"അജ്ഞാത കോഡ് %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s അജ്ഞാത കോഡ് "
+"%2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6885,9 +6908,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ "
-"അനുവദിക്കുന്നു. ഇത് പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും "
-"മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും %1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
+"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും "
+"%1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6898,12 +6921,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം "
-"കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ "
-"അനുവദിക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai "
-"ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ ക്രമീകരണം ഓഫ് "
-"ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai ആക്സസ് "
-"ചെയ്യാൻ കഴിയും. നേരിട്ട്."
+"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം കക്ഷി AI ചാറ്റ് "
+"മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഈ ക്രമീകരണം "
+"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ "
+"ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai "
+"ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6918,16 +6940,15 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. "
-"നിങ്ങൾക്ക് ഇപ്പോഴും പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
+"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. നിങ്ങൾക്ക് ഇപ്പോഴും "
+"പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
 msgstr ""
-"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് "
-"പരീക്ഷിച്ചു നോക്കൂ!"
+"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് പരീക്ഷിച്ചു നോക്കൂ!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6935,16 +6956,14 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ "
-"കൃത്യതയ്ക്കായി പരിശോധിച്ചിട്ടുമില്ല."
+"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ കൃത്യതയ്ക്കായി "
+"പരിശോധിച്ചിട്ടുമില്ല."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
-"Anthropic, OpenAI, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകളെ Duck.ai "
-"പിന്തുണയ്ക്കുന്നു."
+msgstr "Anthropic, OpenAI, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകളെ Duck.ai പിന്തുണയ്ക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6963,8 +6982,8 @@ msgstr "Duck.ai അപ്ഗ്രേഡ് ചെയ്തു!"
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
 msgstr ""
-"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും "
-"സൗജന്യവുമായ DuckDuckGo ആപ്പിലാണ്!"
+"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ "
+"DuckDuckGo ആപ്പിലാണ്!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6974,10 +6993,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത "
-"AI ചാറ്റ്, സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, "
-"മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, "
-"അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
+"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത AI ചാറ്റ്, "
+"സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI "
+"മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7005,12 +7023,11 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ "
-"സംഗ്രഹിക്കാനും കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് "
-"നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist "
-"UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ "
-"ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ "
-"മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
+"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
+"കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
+"ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-"
+"ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ "
+"പ്രസക്തമാകുമ്പോൾ മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
 "കാണിക്കുന്നു). ഇപ്പോൾ, DuckAssist യുഎസ് (ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
@@ -7020,10 +7037,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
-"എന്നിരുന്നാലും, ഞങ്ങൾ %1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് "
-"OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന "
-"ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
+"%1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ "
+"നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7032,10 +7048,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
-"എന്നിരുന്നാലും, ഞങ്ങൾ DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം "
-"ചെയ്യുന്നു, ഇത് OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
-"പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
+"DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic "
+"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7047,13 +7062,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
-"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ പ്രതികരണങ്ങൾ നിലവിൽ "
-"വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും കൃത്യത "
-"പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
+"അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി "
+"വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം "
+"സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ "
+"പ്രതികരണങ്ങൾ നിലവിൽ വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും "
+"കൃത്യത പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7067,16 +7081,14 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് "
-"തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് "
-"ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
-"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
-"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ "
-"രണ്ടോ ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് "
-"വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ "
-"വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
-"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
+"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
+"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ രണ്ടോ "
+"ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ "
+"നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് "
+"പ്രതികരണങ്ങൾ സ്വയം സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
 "%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
@@ -7095,8 +7107,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. "
-"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
+"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. ദയവായി നാളെ ഈ "
+"ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7105,8 +7117,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
-"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
+"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7115,8 +7127,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
-"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
+"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7125,8 +7137,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7135,8 +7147,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി "
-"ഈ അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ "
+"അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7177,6 +7189,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo ബ്രൗസർ %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7293,9 +7312,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ "
-"പോലുള്ള PII സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ "
-"അജ്ഞാതമാക്കുന്നു."
+"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII "
+"സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ അജ്ഞാതമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7303,8 +7321,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
-"നിങ്ങൾ Duck.ai-യുടെ %2$s സമ്മതിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ Duck.ai-"
+"യുടെ %2$s സമ്മതിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7313,8 +7331,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
-"നിങ്ങൾ ഞങ്ങളുടെ %2$s-നെ അംഗീകരിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ ഞങ്ങളുടെ "
+"%2$s-നെ അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7323,9 +7341,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന "
-"Google, Facebook പോലുള്ള കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ "
-"സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ DuckDuckGo തടയുന്നു."
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന Google, Facebook പോലുള്ള "
+"കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ "
+"DuckDuckGo തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7337,13 +7355,12 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ "
-"പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് "
-"സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് ഞങ്ങൾക്ക് "
-"അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് "
-"ഉപയോഗിക്കുന്നു, തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി "
-"ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ "
-"സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ അറിയുക%2$s."
+"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ "
+"ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് "
+"ഞങ്ങൾക്ക് അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് ഉപയോഗിക്കുന്നു, "
+"തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ "
+"സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ "
+"അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7363,9 +7380,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് "
-"കൂടുതൽ ബന്ധമുള്ള, മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് കൂടുതൽ ബന്ധമുള്ള, "
+"മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7457,11 +7473,10 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo "
-"സെർവറുകളിൽ നിന്ന് ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. "
-"പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ "
-"തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 അക്ഷരങ്ങളെങ്കിലും "
-"ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
+"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo സെർവറുകളിൽ നിന്ന് "
+"ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ "
+"നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 "
+"അക്ഷരങ്ങളെങ്കിലും ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7532,8 +7547,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും "
-"പുതിയത് സൃഷ്ടിക്കുകയും ചെയ്യും."
+"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും പുതിയത് സൃഷ്ടിക്കുകയും "
+"ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7594,9 +7609,7 @@ msgstr "AI സവിശേഷതകൾ പ്രവർത്തനക്ഷമ�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save "
-"പ്രവർത്തനക്ഷമമാക്കുക."
+msgstr "നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7673,8 +7686,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് "
-"എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് എപ്പോൾ "
+"വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7719,9 +7732,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, "
-"പക്ഷേ അപ്പോഴും നിങ്ങളുടെ തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് "
-"സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
+"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, പക്ഷേ അപ്പോഴും നിങ്ങളുടെ "
+"തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7798,8 +7810,7 @@ msgstr "Duck.ai ആസ്വദിക്കുകയാണോ?"
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
 msgstr ""
-"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് "
-"ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7885,8 +7896,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് "
-"ചെയ്യുക. ഇത് നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
+"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക. ഇത് "
+"നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7912,8 +7923,8 @@ msgstr "ടെക്‌സ്റ്റ് നൽകുക"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: "
-"%5$sഅപരനാമം %6$s: ഡി%7$s"
+"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: %5$sഅപരനാമം "
+"%6$s: ഡി%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7954,8 +7965,7 @@ msgstr "ഇക്വറ്റോറിയൽ ഗിനിയ"
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
 msgstr ""
-"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ "
-"മായ്ക്കുക %1$s%2$s"
+"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ മായ്ക്കുക %1$s%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8015,15 +8025,28 @@ msgstr "മാപ്പ് വികസിപ്പിക്കുക"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
+msgstr "സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത ഉൽപ്പന്നങ്ങൾ."
+
+# smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
 msgstr ""
-"സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത "
-"ഉൽപ്പന്നങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "കാലഹരണപ്പെട്ടു"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8090,9 +8113,7 @@ msgstr "ഇത് ലളിതമായി വിശദീകരിക്കു�
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
-"ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും "
-"വിശദീകരിക്കുക."
+msgstr "ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും വിശദീകരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -8288,8 +8309,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
-"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു."
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
+"സ്വാധീനിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8298,9 +8319,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
-"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും "
-"പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
+"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
+"സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8308,8 +8328,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ "
-"സൈറ്റിലേക്കു പകർത്തി ഒട്ടിക്കുക"
+"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ സൈറ്റിലേക്കു പകർത്തി "
+"ഒട്ടിക്കുക"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8393,16 +8413,15 @@ msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
-"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് "
-"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് ഫിൽട്ടർ ചെയ്ത് "
+"ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. "
-"%1$sകൂടുതലറിയുക%2$s"
+"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8444,8 +8463,7 @@ msgstr "<b>%1$s</b> നിങ്ങളുടെ ഡൗൺലോഡുകൾ ഫ�
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
 msgstr ""
-"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s "
-"എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8483,8 +8501,8 @@ msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
 msgstr ""
-"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും "
-"സുരക്ഷിതവും അജ്ഞാതവുമാണ്."
+"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും സുരക്ഷിതവും "
+"അജ്ഞാതവുമാണ്."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8548,9 +8566,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു "
-"മെനു ഓപ്ഷൻ തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി "
-"വന്നേക്കാം."
+"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു മെനു ഓപ്ഷൻ "
+"തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി വന്നേക്കാം."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8667,9 +8684,7 @@ msgstr "സൗജന്യവും സ്വകാര്യവുമായ ച�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് "
-"ആവശ്യമില്ല."
+msgstr "സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8699,9 +8714,7 @@ msgstr "പങ്കിടലും വാണിജ്യപരമായി ഉ�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ "
-"ഇല്ലാതാക്കില്ല."
+msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8782,9 +8795,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; "
-"<strong>അപ്ഡേറ്റുകൾ പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് "
-"ഇൻസ്റ്റാൾ ചെയ്യുക</strong> തിരഞ്ഞെടുക്കുക."
+"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; <strong>അപ്ഡേറ്റുകൾ "
+"പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് ഇൻസ്റ്റാൾ ചെയ്യുക</strong> "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9070,14 +9083,15 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN, നൂതന Duck.ai എന്നിവ നേടൂ, Personal Info Removal, Identity "
-"Theft Restoration എന്നിവയും."
+"DuckDuckGo VPN, നൂതന Duck.ai എന്നിവ നേടൂ, Personal Info Removal, Identity Theft "
+"Restoration എന്നിവയും."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "DuckDuckGo VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
+msgstr ""
+"DuckDuckGo VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9157,8 +9171,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണൽ അഡ്വാൻസ്ഡ് AI ചാറ്റ്, Personal Info Removal, "
-"കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
+"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണൽ അഡ്വാൻസ്ഡ് AI ചാറ്റ്, Personal Info Removal, കൂടാതെ "
+"Identity Theft Restoration എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9167,8 +9181,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണലായ നൂതന AI ചാറ്റ്, കൂടാതെ Identity Theft "
-"Restoration നേടൂ."
+"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണലായ നൂതന AI ചാറ്റ്, കൂടാതെ Identity Theft Restoration "
+"നേടൂ."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9177,9 +9191,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന "
-"DuckDuckGo-യിലേക്ക് സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI "
-"മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo-യിലേക്ക് "
+"സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9190,8 +9203,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo "
-"സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo സബ്സ്ക്രിപ്ഷൻ "
+"ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9235,9 +9248,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"ഞങ്ങളുടെ വേഗതയേറിയ നോ-ലോഗ് VPN, ഉയർന്ന ചാറ്റ് പരിധികളുള്ള നൂതന AI "
-"മോഡലുകളിലേക്കുള്ള ഓപ്ഷണൽ ആക്‌സസ്, കൂടാതെ കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ എന്നിവ "
-"നേടൂ."
+"ഞങ്ങളുടെ വേഗതയേറിയ നോ-ലോഗ് VPN, ഉയർന്ന ചാറ്റ് പരിധികളുള്ള നൂതന AI മോഡലുകളിലേക്കുള്ള ഓപ്ഷണൽ "
+"ആക്‌സസ്, കൂടാതെ കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9246,8 +9258,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai നേടൂ, Personal Information "
-"Removal, കൂടാതെ Identity Theft Restoration."
+"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai നേടൂ, Personal Information Removal, "
+"കൂടാതെ Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9255,15 +9267,14 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft "
-"Restoration എന്നിവ നേടൂ."
+"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration "
+"എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
 msgstr ""
-"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ "
-"സൗജന്യമായി നേടുക:"
+"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ സൗജന്യമായി നേടുക:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9359,8 +9370,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
-"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക › ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
+"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക › "
+"ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9395,8 +9406,16 @@ msgid ""
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
 "എന്നതിലേക്ക് പോയി %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
-"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ "
+"ചെയ്യുക."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9411,8 +9430,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് "
-"പോയി \"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് പോയി "
+"\"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9507,6 +9526,12 @@ msgstr "മനസ്സിലായി"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "മനസ്സിലായി"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9672,9 +9697,7 @@ msgstr "ഗ്വാട്ടിമാല"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ "
-"നയിക്കുക."
+msgstr "ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ നയിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9874,9 +9897,7 @@ msgstr "DuckDuckGo മെച്ചപ്പെടുത്താൻ ഞങ്ങ
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ "
-"സഹായിക്കൂ"
+msgstr "നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ സഹായിക്കൂ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9934,9 +9955,7 @@ msgstr "Duck ഭാഗത്ത് ചേരാൻ നിങ്ങളുടെ �
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ "
-"സഹായിക്കൂ!"
+msgstr "നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ സഹായിക്കൂ!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10111,8 +10130,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search "
-"Assist ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
+"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search Assist "
+"ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10139,9 +10158,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ "
-"%1$sമടങ്ങുക%2$s അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് "
-"ക്ലിക്ക് ചെയ്യുക"
+"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ %1$sമടങ്ങുക%2$s "
+"അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10155,8 +10173,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, "
-"നിങ്ങൾക്ക് ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
+"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, നിങ്ങൾക്ക് "
+"ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10206,8 +10224,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ "
-"ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
+"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10316,9 +10334,7 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് "
-"ആഗ്രഹിക്കുന്നത്?"
+msgstr "നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് ആഗ്രഹിക്കുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10351,8 +10367,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ "
-"തന്ത്രപൂർവ്വം സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
+"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ തന്ത്രപൂർവ്വം "
+"സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10459,9 +10475,7 @@ msgstr "കൂടുതൽ വിൽപ്പനക്കാരിൽ നിന�
 #. Header above text explaining that passwords can't be recovered.
 msgctxt "cloudsave"
 msgid "I forgot my passphrase. Can you recover it?"
-msgstr ""
-"എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ "
-"സാധിക്കുമോ?"
+msgstr "എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ സാധിക്കുമോ?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user hits a chat limit.
@@ -10476,16 +10490,14 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല "
-"പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
+"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് "
+"ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ "
-"എനിക്ക് ആവശ്യമാണ്"
+msgstr "ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ എനിക്ക് ആവശ്യമാണ്"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10514,9 +10526,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > "
-"പുനഃക്രമീകരിക്കുക > 'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s "
-"എന്നതിലേക്ക് പോകുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > പുനഃക്രമീകരിക്കുക > "
+"'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s എന്നതിലേക്ക് പോകുക."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10526,9 +10537,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക "
-"%1$s⋮ > മെനു > ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് "
-"DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക %1$s⋮ > മെനു > "
+"ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് "
+"അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10543,8 +10554,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ "
-"എഞ്ചിനുകളുടെ%4$s പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
+"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ എഞ്ചിനുകളുടെ%4$s "
+"പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10553,9 +10564,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് "
-"പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് "
-"%1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
+"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് "
+"ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് %1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10564,17 +10574,16 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച "
-"ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ "
-"ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ "
+"ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, "
-"%1$sDuckDuckGo പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
+"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, %1$sDuckDuckGo "
+"പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10584,8 +10593,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ "
-"%1$s അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
+"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ %1$s "
+"അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10593,8 +10602,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും "
-"അടുത്തുള്ള ഹോം പേജ് തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
+"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും അടുത്തുള്ള ഹോം പേജ് "
+"തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10723,8 +10732,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് "
-"ഫലത്തിന്റെ വ്യക്തത മെച്ചപ്പെടുത്തുന്നു"
+"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് ഫലത്തിന്റെ വ്യക്തത "
+"മെച്ചപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10737,8 +10746,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ "
-"ക്ലിക്കുകൾ റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ ക്ലിക്കുകൾ "
+"റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10749,8 +10758,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, "
-"തുടർന്ന് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
+"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, തുടർന്ന് \"മറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10765,9 +10774,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം "
-"വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി "
-"പരിശോധിക്കാവുന്നതാണ്."
+"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക "
+"എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി പരിശോധിക്കാവുന്നതാണ്."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11104,8 +11112,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ "
-"പ്രശസ്തി സംഗ്രഹിക്കുക."
+"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ പ്രശസ്തി "
+"സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11149,17 +11157,15 @@ msgstr "ഇതിന് ഏതാനും നിമിഷങ്ങൾ എടു
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും "
-"നൽകുന്നു."
+msgstr "ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും നൽകുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) "
-"ചോദിക്കുന്നതിൽ കുഴപ്പമില്ല"
+"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) ചോദിക്കുന്നതിൽ "
+"കുഴപ്പമില്ല"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11178,10 +11184,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, "
-"Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ "
-"നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് "
-"വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം ലഭിക്കുന്നില്ല."
+"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, Microsoft-ന്റെ "
+"പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് "
+"നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം "
+"ലഭിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11190,8 +11196,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 "
-"വാക്കുകൾ ഓർമിക്കുവാൻ, വളരെ അധികം സുരക്ഷിതവും."
+"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 വാക്കുകൾ ഓർമിക്കുവാൻ, "
+"വളരെ അധികം സുരക്ഷിതവും."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11264,8 +11270,8 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
 msgstr ""
-"ഒരേസമയം 5 ഉപകരണങ്ങളിൽ വരെ നിങ്ങളുടെ എല്ലാ ആപ്പുകളും ഓൺലൈൻ പ്രവർത്തനങ്ങളും "
-"സ്വകാര്യമായി സൂക്ഷിക്കുക."
+"ഒരേസമയം 5 ഉപകരണങ്ങളിൽ വരെ നിങ്ങളുടെ എല്ലാ ആപ്പുകളും ഓൺലൈൻ പ്രവർത്തനങ്ങളും സ്വകാര്യമായി "
+"സൂക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11499,6 +11505,12 @@ msgid "Learn %sMore%s"
 msgstr "%1$sകൂടുതൽ%2$s അറിയുക"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11567,9 +11579,7 @@ msgstr "DuckDuckGo ക്രമീകരണങ്ങൾ എങ്ങനെ ക�
 #. Description of a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "Learn how we keep your location private"
-msgstr ""
-"നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
-"മനസ്സിലാക്കുക"
+msgstr "നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക"
 
 # smartling.placeholder_format=C
 #. Link text in the Usage section of Duck.ai settings that opens a help page explaining Duck.ai usage limits.
@@ -11611,9 +11621,7 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് "
-"അറിയുക."
+msgstr "ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് അറിയുക."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11676,8 +11684,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Duck.ai-ലേക്ക് തിരയൽ ചോദ്യങ്ങളും പ്രോംപ്റ്റുകളും സമർപ്പിക്കുന്നത് തമ്മിൽ "
-"മാറാൻ നിങ്ങളെ അനുവദിക്കുന്നു"
+"Duck.ai-ലേക്ക് തിരയൽ ചോദ്യങ്ങളും പ്രോംപ്റ്റുകളും സമർപ്പിക്കുന്നത് തമ്മിൽ മാറാൻ നിങ്ങളെ "
+"അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11735,9 +11743,7 @@ msgstr "ഈ ചാറ്റിനായി പരിമിതമായ ഡാറ
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr ""
-"ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് "
-"പരിമിതപ്പെടുത്തുന്നു"
+msgstr "ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് പരിമിതപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -11772,8 +11778,7 @@ msgstr "ലിങ്കുകൾ:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
-"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ "
-"ലിസ്റ്റ് ചെയ്യുക."
+"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ ലിസ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11885,8 +11890,7 @@ msgstr "സ്ക്രോൾ ചെയ്യുമ്പോൾ കൂടുത�
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
 msgstr ""
-"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ "
-"ലോഡ് ചെയ്യുന്നു"
+"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ ലോഡ് ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12073,8 +12077,7 @@ msgstr "എല്ലാ വാക്കുകളും അക്ഷരത്ത�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് "
-"തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
+"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12140,6 +12143,13 @@ msgstr "ക്ഷുദ്രവെയർ"
 #. Text for generic link to send the user to a page to manage their settings.
 msgid "Manage"
 msgstr "മാനേജ് ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12393,6 +12403,12 @@ msgid "Menu"
 msgstr "മെനു"
 
 # smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
 msgstr "മെട്രിക് (കിലോഗ്രാം, മീറ്റർ, സെൽഷ്യസ്)"
@@ -12420,9 +12436,7 @@ msgstr "മൈക്രോനേഷ്യ"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും "
-"ശ്രമിക്കുക."
+msgstr "മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12761,6 +12775,12 @@ msgid "More about Duck.ai"
 msgstr "Duck.ai-യെക്കുറിച്ച് കൂടുതൽ"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "കൂടുതൽ ഇതിൽ"
@@ -12953,6 +12973,12 @@ msgstr "നിശബ്ദമാക്കി"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "ഇളം ചുവപ്പ്"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13194,11 +13220,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
-"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
-"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
-"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു "
+"DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് "
+"വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ "
+"ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
 "പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
@@ -14025,6 +14050,30 @@ msgstr ""
 "ക്രമീകരണം%5$s %3$sക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14050,9 +14099,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ "
-"കൂടുതൽ പേജുകളുണ്ട്. %1$s അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് "
-"ചെയ്യുക."
+"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ കൂടുതൽ പേജുകളുണ്ട്. %1$s "
+"അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14095,8 +14143,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത "
-"പിശകുണ്ടായി. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത പിശകുണ്ടായി. പിന്നീട് "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14150,8 +14198,8 @@ msgstr "%1$s വെബ്‌സൈറ്റ് തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
 msgstr ""
-"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
-"%3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s ഉറപ്പാക്കുക"
+"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s "
+"ഉറപ്പാക്കുക"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14172,8 +14220,7 @@ msgstr "%1$sക്രമീകരണം%2$s തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
 msgstr ""
-"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
-"%1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14322,9 +14369,7 @@ msgstr "How Duck.ai വർക്ക്സ് പാനൽ തുറക്കു�
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s "
-"തിരഞ്ഞെടുക്കുക..."
+msgstr "Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s തിരഞ്ഞെടുക്കുക..."
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14425,9 +14470,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ "
-"നിങ്ങളുടെ തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് "
-"ചെയ്യുന്നില്ല — കാലഘട്ടം"
+"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ നിങ്ങളുടെ "
+"തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല — കാലഘട്ടം"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14441,9 +14485,8 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"ഞങ്ങളുടെ വേഗതയേറിയ, നോ-ലോഗ് VPN-നൊപ്പം ഉയർന്ന പരിധികളുള്ള മികച്ച AI "
-"ചാറ്റുകളും കൂടുതൽ പ്രീമിയം പരിരക്ഷകളും ലഭിക്കുന്നു. എല്ലാം ഉൾപ്പെട്ട ഒരു "
-"സബ്‌സ്‌ക്രിപ്‌ഷൻ."
+"ഞങ്ങളുടെ വേഗതയേറിയ, നോ-ലോഗ് VPN-നൊപ്പം ഉയർന്ന പരിധികളുള്ള മികച്ച AI ചാറ്റുകളും കൂടുതൽ "
+"പ്രീമിയം പരിരക്ഷകളും ലഭിക്കുന്നു. എല്ലാം ഉൾപ്പെട്ട ഒരു സബ്‌സ്‌ക്രിപ്‌ഷൻ."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14451,8 +14494,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും "
-"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും ശേഖരിക്കുകയോ "
+"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14460,9 +14503,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ "
-"ഉൾപ്പെടുത്തി മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, "
-"Android%2$s എന്നിവയിൽ ലഭ്യമാണ്."
+"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ ഉൾപ്പെടുത്തി "
+"മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, Android%2$s എന്നിവയിൽ "
+"ലഭ്യമാണ്."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14715,9 +14758,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും "
-"വിവരങ്ങൾ ഞങ്ങൾ ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ "
-"കഴിയില്ല."
+"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും വിവരങ്ങൾ ഞങ്ങൾ "
+"ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14784,6 +14826,12 @@ msgid "Past year"
 msgstr "കഴിഞ്ഞ വർഷം"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14794,6 +14842,12 @@ msgstr "ഒട്ടിക്കുക"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "സമന്വയ കോഡ് പേസ്റ്റ് ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14847,6 +14901,20 @@ msgstr "ശാശ്വതമായി അടച്ചത്"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "പേർഷ്യൻ"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14917,10 +14985,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI "
-"സഹായമുള്ള ഉത്തരങ്ങൾ സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും "
-"പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. അവ ഓഫാക്കാനും Assist ബട്ടൺ "
-"മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI സഹായമുള്ള ഉത്തരങ്ങൾ "
+"സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. "
+"അവ ഓഫാക്കാനും Assist ബട്ടൺ മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14929,10 +14996,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
-"DuckAssist പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച "
-"ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് "
-"ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist "
+"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ "
+"സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist "
+"ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14942,10 +15009,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
-"DuckAssist സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും "
-"മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ "
-"മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist സ്വയമേവ "
+"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് "
+"ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14978,8 +15044,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
-"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14988,8 +15054,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
-"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14998,8 +15064,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ "
-"ആപ്പുകൾക്ക് DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
+"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ ആപ്പുകൾക്ക് "
+"DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15012,8 +15078,8 @@ msgstr "ഒരു നിർദിഷ്ട പ്രശ്നം തിരഞ്
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ "
-"നിർദ്ദേശങ്ങൾ പാലിക്കുക."
+"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ നിർദ്ദേശങ്ങൾ "
+"പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15102,8 +15168,7 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന "
-"ചലഞ്ച് പൂർത്തിയാക്കുക."
+"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന ചലഞ്ച് പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15112,24 +15177,23 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി "
-"പൂർത്തിയാക്കുക."
+"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
-"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
+"(ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
-"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
+"(ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15150,8 +15214,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് "
-"നിങ്ങളുടെ നിലവിലെ ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
+"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് നിങ്ങളുടെ നിലവിലെ "
+"ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15160,9 +15224,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
-"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ "
-"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
+"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15171,9 +15234,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
-"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ "
-"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
+"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15326,8 +15388,7 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
-"സ്വാധീനിക്കുകയില്ല."
+"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കുകയില്ല."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15390,8 +15451,7 @@ msgstr "മോശം ഫോർമാറ്റിംഗ്"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
-"ജനപ്രിയ AI മോഡലുകൾ ലഭ്യമാണ്. അക്കൗണ്ട് ആവശ്യമില്ല. ചാറ്റുകൾ ഞങ്ങൾ "
-"അജ്ഞാതമാക്കിയിരിക്കുന്നു."
+"ജനപ്രിയ AI മോഡലുകൾ ലഭ്യമാണ്. അക്കൗണ്ട് ആവശ്യമില്ല. ചാറ്റുകൾ ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15900,9 +15960,7 @@ msgstr "എന്നെ പ്രോംപ്റ്റ് ചെയ്യു�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് "
-"നിർദേശിക്കുക."
+msgstr "സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് നിർദേശിക്കുക."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15920,9 +15978,7 @@ msgstr "നിങ്ങൾ തിരയുകയും ബ്രൗസ് ചെ
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ "
-"സംരക്ഷിക്കുക."
+msgstr "തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15947,8 +16003,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. "
-"[നിങ്ങളുടെ സ്വന്തം വാചകം ഇവിടെ ചേർക്കുക.]"
+"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. [നിങ്ങളുടെ സ്വന്തം "
+"വാചകം ഇവിടെ ചേർക്കുക.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16120,6 +16176,12 @@ msgid "Reading website…"
 msgstr "വെബ്സൈറ്റ് വായിക്കുന്നു..."
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16160,16 +16222,14 @@ msgstr "സങ്കീർണ്ണമായ ചോദ്യങ്ങൾക്�
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ "
-"പരിധിയിലെത്തുന്നു. %1$s"
+"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധിയിലെത്തുന്നു. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ പരിധികൾ 2-5 മടങ്ങ് വേഗത്തിൽ "
-"ഉപയോഗിക്കുന്നു. %1$s"
+msgstr "റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ പരിധികൾ 2-5 മടങ്ങ് വേഗത്തിൽ ഉപയോഗിക്കുന്നു. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16219,8 +16279,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
+"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16229,8 +16289,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
+"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16240,10 +16300,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ "
-"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
-"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
-"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
+"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ പ്രോംപ്റ്റുകളും "
+"പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ "
+"സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16314,6 +16373,12 @@ msgid "Recovery Code"
 msgstr "റിക്കവറി കോഡ്"
 
 # smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Red"
 msgstr "ചുവപ്പ്"
@@ -16379,8 +16444,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ "
-"വലുപ്പം കുറയ്ക്കുകയും ചെയ്യുന്നു"
+"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ വലുപ്പം കുറയ്ക്കുകയും "
+"ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16521,9 +16586,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ "
-"ബ്രൗസറിലെ &quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് "
-"ചെയ്യുക."
+"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ ബ്രൗസറിലെ "
+"&quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16564,6 +16628,12 @@ msgstr "%1$s നീക്കം ചെയ്യുക"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "%1$s നീക്കം ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16608,14 +16678,25 @@ msgid "Remove unnecessary punctuation"
 msgstr "അനാവശ്യമായ ചിഹ്നങ്ങൾ നീക്കം ചെയ്യുക"
 
 # smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
-"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും "
-"സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
+"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16623,9 +16704,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
-"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും "
-"സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
+"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16683,10 +16763,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ "
-"സഹായിക്കുന്നതിന് അവ DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ "
-"മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് "
-"അയയ്ക്കാറുണ്ട്."
+"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് അവ "
+"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ "
+"അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് അയയ്ക്കാറുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16694,8 +16773,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ "
-"ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ "
+"തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16704,10 +16783,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് "
-"വിവർത്തനം ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ "
-"അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ "
-"വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് വിവർത്തനം "
+"ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ "
+"വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16799,10 +16877,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
-"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
-"ഉദ്ദേശിച്ചിട്ടില്ല. AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന "
-"നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
+"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. AI- "
+"സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16811,9 +16888,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
-"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
-"ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
+"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist "
+"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16823,11 +16900,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
-"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
-"ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി "
-"സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search Assist "
-"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
+"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് "
+"ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search "
+"Assist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16904,8 +16980,8 @@ msgstr "ബ്ലോക്ക് ചെയ്‌ത സൈറ്റുകളി�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ "
-"കൈകാര്യം ചെയ്യാൻ കഴിയും."
+"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ കൈകാര്യം ചെയ്യാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17254,17 +17330,16 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് "
-"നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ "
-"പ്രാദേശികമായി സംരക്ഷിക്കുക."
+"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ "
-"പ്രാദേശികമായി സംരക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ പ്രാദേശികമായി "
+"സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17272,8 +17347,7 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai "
-"ചാറ്റുകൾ സംരക്ഷിക്കുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai ചാറ്റുകൾ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17304,6 +17378,12 @@ msgstr "നിങ്ങളുടെ ക്രമീകരണം ക്ലൗഡ�
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Duck.ai-യോട് ഹലോ പറയൂ"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17407,17 +17487,13 @@ msgstr "സ്കോട്ട്ലൻഡ്"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് "
-"ചെയ്യുക."
+msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17425,8 +17501,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
-"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
+"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17435,8 +17511,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
-"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
+"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17455,16 +17531,15 @@ msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത്, �
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ "
-"ഉപയോഗിക്കാൻ അതിനെ അനുവദിക്കുക."
+"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ "
+"അതിനെ അനുവദിക്കുക."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s "
-"ക്ലിക്ക് ചെയ്യുക."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17518,14 +17593,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. "
-"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. "
-"നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
-"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ "
-"പ്രസക്തമാകുമ്പോൾ), അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, "
-"ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ ഒരു ഭാഗത്ത് മാത്രമേ Search Assist "
-"ലഭ്യമാകൂ."
+"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. ഇത് ചെയ്യുന്നതിന്, "
+"പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം "
+"സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
+"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ), "
+"അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ "
+"ഒരു ഭാഗത്ത് മാത്രമേ Search Assist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17533,8 +17606,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search "
-"Assist-ന് കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
+"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search Assist-ന് "
+"കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17543,10 +17616,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
-"സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും കണ്ടെത്തിയ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
+"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ "
+"സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും "
+"കണ്ടെത്തിയ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17667,8 +17739,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള "
-"തിരയൽ വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
+"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള തിരയൽ "
+"വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17687,9 +17759,9 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, "
-"നിങ്ങളുടെ പ്രിയപ്പെട്ട ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, "
-"അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് തിരയുക."
+"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, നിങ്ങളുടെ പ്രിയപ്പെട്ട "
+"ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് "
+"തിരയുക."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17697,8 +17769,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST "
-"അഭ്യർത്ഥനകൾ ഉപയോഗിക്കും)"
+"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST അഭ്യർത്ഥനകൾ "
+"ഉപയോഗിക്കും)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17710,11 +17782,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക "
-"സംഭരണത്തിലും നിങ്ങളുടെ ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു "
-"വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save "
-"ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ "
-"സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
+"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക സംഭരണത്തിലും നിങ്ങളുടെ "
+"ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
+"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
 "വിട്ടുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -17810,8 +17881,7 @@ msgstr "രണ്ടാമതൊരു അഭിപ്രായം"
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
 msgstr ""
-"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും "
-"സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
+"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17820,9 +17890,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
-"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
+"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17831,9 +17900,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
-"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
+"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17842,9 +17910,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
-"സുരക്ഷിതമായി സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
+"സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17853,17 +17920,15 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ "
-"സുരക്ഷിതമായി സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
-"സംഭരിച്ചിരിക്കുന്നു."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17872,9 +17937,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
-"സംഭരിച്ചിരിക്കുന്നു. നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, "
-"ഞങ്ങൾക്ക് പോലും."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു. "
+"നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, ഞങ്ങൾക്ക് പോലും."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18019,38 +18083,34 @@ msgstr "%1$s%2$s%3$s തിരഞ്ഞെടുക്കുക, തുടർന
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
 msgstr ""
-"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക."
+"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം "
-"%3$shttps://duckduckgo.com%4$s എന്ന് ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
+"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം %3$shttps://duckduckgo.com%4$s എന്ന് "
+"ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ "
-"ക്ലിക്ക് ചെയ്യുക!"
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ ക്ലിക്ക് "
+"ചെയ്യുക!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
-"ചെയ്യുക"
+msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
-"ചെയ്യുക."
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18062,9 +18122,7 @@ msgstr "ഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ ഡ്ര
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
-"%4$sഅനുവദിക്കുക%3$s"
+msgstr "ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %4$sഅനുവദിക്കുക%3$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18077,8 +18135,7 @@ msgstr "തിരയൽ ദാതാക്കളുടെ പട്ടികയ�
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
 msgstr ""
-"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s "
-"തിരഞ്ഞെടുക്കുക"
+"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18089,17 +18146,13 @@ msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sManage add-ons%s from the dropdown menu"
-msgstr ""
-"ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -18107,8 +18160,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s "
-"എന്നും തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s എന്നും "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18116,8 +18169,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s "
-"എന്നും തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s എന്നും "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18182,16 +18235,14 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
+"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ "
+"നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
-"%3$sഅനുവദിക്കുക%4$s"
+msgstr "ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %3$sഅനുവദിക്കുക%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18264,8 +18315,7 @@ msgstr "%1$s-ൽ നിന്ന് തിരഞ്ഞെടുത്ത ടെ�
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
 msgstr ""
-"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് "
-"വീണ്ടും ശ്രമിക്കൂ."
+"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18309,9 +18359,9 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ "
-"സന്ദേശങ്ങളുമായി AI മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ "
-"നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും ബാധകമാകും."
+"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ സന്ദേശങ്ങളുമായി AI "
+"മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും "
+"ബാധകമാകും."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18332,6 +18382,13 @@ msgstr "സെർബിയൻ (സിറിലിക്)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "സെർബിയൻ (ലാറ്റിൻ)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18427,8 +18484,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് "
-"ചരിത്രം ഓണാക്കിയ ശേഷം Sync & Backup സജ്ജമാക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് ചരിത്രം ഓണാക്കിയ "
+"ശേഷം Sync & Backup സജ്ജമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18488,6 +18545,14 @@ msgid "Share"
 msgstr "പങ്കിടുക"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18502,9 +18567,7 @@ msgstr "പങ്കിടുക"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ "
-"സഹായിക്കുക!"
+msgstr "DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ സഹായിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18531,9 +18594,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. "
-"Duck.ai ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ "
-"വെളിപ്പെടുത്തുകയില്ല."
+"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. Duck.ai "
+"ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ വെളിപ്പെടുത്തുകയില്ല."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18629,8 +18691,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക "
-"(നിയമവിരുദ്ധവും ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
+"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക (നിയമവിരുദ്ധവും "
+"ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18639,15 +18701,26 @@ msgid "Share your thoughts on the search box."
 msgstr "തിരയൽ ബോക്സ് സംബന്ധിച്ച നിങ്ങളുടെ ചിന്തകൾ പങ്കിടു."
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"ഞങ്ങളുടെ നോ-ലോഗ്, വേഗതയേറിയ VPN ഉപയോഗിച്ച് നിങ്ങളുടെ ഓൺലൈൻ പ്രവർത്തനം "
-"സംരക്ഷിക്കൂ. സജ്ജീകരിക്കാൻ ലളിതവും എപ്പോൾ വേണമെങ്കിലും എളുപ്പത്തിൽ ഓൺ "
-"ചെയ്യാനും ഓഫ് ചെയ്യാനും കഴിയുന്നതും."
+"ഞങ്ങളുടെ നോ-ലോഗ്, വേഗതയേറിയ VPN ഉപയോഗിച്ച് നിങ്ങളുടെ ഓൺലൈൻ പ്രവർത്തനം സംരക്ഷിക്കൂ. "
+"സജ്ജീകരിക്കാൻ ലളിതവും എപ്പോൾ വേണമെങ്കിലും എളുപ്പത്തിൽ ഓൺ ചെയ്യാനും ഓഫ് ചെയ്യാനും കഴിയുന്നതും."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18767,9 +18840,7 @@ msgstr "DuckAssist <sup>BETA</sup> കാണിക്കുക"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും "
-"%1$sഓഫാക്കാം%2$s.)"
+msgstr "DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും %1$sഓഫാക്കാം%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18952,9 +19023,7 @@ msgstr "സൈഡ്ബാർ കാണിക്കുക"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Duck.ai പരമാവധി പ്രയോജനപ്പെടുത്തുന്നതിനുള്ള ഘട്ടം ഘട്ടമായുള്ള നുറുങ്ങുകൾ "
-"കാണിക്കുക."
+msgstr "Duck.ai പരമാവധി പ്രയോജനപ്പെടുത്തുന്നതിനുള്ള ഘട്ടം ഘട്ടമായുള്ള നുറുങ്ങുകൾ കാണിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19009,9 +19078,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു "
-"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
-"കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. "
+"ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19019,9 +19087,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു "
-"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
-"കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും ബാധിക്കുന്നില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ "
+"കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും "
+"ബാധിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19032,8 +19100,7 @@ msgstr "ഫല പേജ് ഇടവേളകളിൽ തിരശ്ചീന
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള "
-"ലിങ്കുകൾ കാണിക്കുന്നു"
+"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള ലിങ്കുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19050,23 +19117,21 @@ msgstr "പുതിയ ടാബ് പേജിൽ ഏറ്റവും ക�
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
-"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
-"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് "
-"ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19174,16 +19239,12 @@ msgstr "സൈറ്റുകളുടെ പേരുകൾ"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ "
-"പ്രവർത്തിക്കുന്നു."
+msgstr "സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും "
-"മറയ്ക്കും"
+msgstr "നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും മറയ്ക്കും"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19327,6 +19388,12 @@ msgid "Something went wrong"
 msgstr "എന്തോ കുഴപ്പം സംഭവിച്ചു"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19337,8 +19404,7 @@ msgstr "സെർവറിലേക്ക് സംരക്ഷിക്കു�
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
 msgstr ""
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി "
-"വീണ്ടും ശ്രമിക്കുക."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19369,8 +19435,8 @@ msgstr "ചിലപ്പോൾ"
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
 msgstr ""
-"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു "
-"രീതിയിൽ വിവരിക്കുക."
+"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു രീതിയിൽ "
+"വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19409,8 +19475,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി "
-"മറ്റൊരു ചിത്രമോ ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
+"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി മറ്റൊരു ചിത്രമോ "
+"ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19419,16 +19485,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ "
-"ചെയ്തതെന്ന് ഉറപ്പാക്കുക."
+"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ ചെയ്തതെന്ന് "
+"ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. "
-"നിങ്ങൾക്ക് Duck.ai-യോട് ചോദിക്കാൻ ശ്രമിക്കാം."
+"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. നിങ്ങൾക്ക് Duck.ai-യോട് "
+"ചോദിക്കാൻ ശ്രമിക്കാം."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19437,16 +19503,15 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. "
-"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
+"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. വീണ്ടും ശ്രമിക്കാൻ "
+"%1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് "
-"വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19501,8 +19566,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് "
-"തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
+"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും "
+"ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19707,9 +19772,7 @@ msgstr "DuckDuckGo-യിൽ തുടരുക"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും "
-"അറിവുള്ളവരായും തുടരുക."
+msgstr "ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും അറിവുള്ളവരായും തുടരുക."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19759,9 +19822,7 @@ msgstr "സൃഷ്ടിക്കൽ നിർത്തുക"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ "
-"പ്രതിരോധിക്കുക."
+msgstr "മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ പ്രതിരോധിക്കുക."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -19856,8 +19917,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, "
-"അല്ലെങ്കിൽ കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
+"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, അല്ലെങ്കിൽ "
+"കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19926,8 +19987,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ "
-"എഴുതാൻ ഒരു വാക്യം നിർദ്ദേശിക്കാമോ?"
+"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ എഴുതാൻ ഒരു വാക്യം "
+"നിർദ്ദേശിക്കാമോ?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20181,6 +20242,12 @@ msgid "Switch model"
 msgstr "മോഡൽ മാറ്റുക"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20257,9 +20324,7 @@ msgstr "%1$sഎന്നതിലേക്ക് മാറി"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് "
-"അയയ്ക്കും"
+msgstr "മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് അയയ്ക്കും"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20313,9 +20378,7 @@ msgstr "Sync & Backup പ്രവർത്തനക്ഷമമാക്കി!
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ "
-"കഴിയില്ല."
+msgstr "Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20364,27 +20427,25 @@ msgid ""
 msgstr ""
 "വീണ്ടെടുക്കൽ കോഡ് സമന്വയിപ്പിക്കുക\n"
 "\n"
-" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, "
-"ഡാറ്റ ഓട്ടോഫിൽ ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു "
-"ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ നിങ്ങളുടെ സമന്വയിപ്പിച്ച "
-"ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
+" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, ഡാറ്റ ഓട്ടോഫിൽ "
+"ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ "
+"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
 "\n"
 "ഈ വിവരങ്ങൾ സുരക്ഷിതമായി സൂക്ഷിക്കുക.\n"
-"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ "
-"കഴിയും.\n"
+"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ കഴിയും.\n"
 "\n"
 "%1$s\n"
 "\n"
 "ഈ കോഡ് എങ്ങനെയാണ് പ്രവർത്തിക്കുന്നത്?\n"
 "1. നിങ്ങളുടെ ബ്രൗസറിൽ Duck.ai-ലേക്ക് പോയി Duck.ai സെറ്റിംഗ്സ് തുറക്കുക.\n"
-"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ "
-"വീണ്ടെടുക്കുക\" തിരഞ്ഞെടുക്കുക.\n"
-"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" "
-"എന്ന് പറയുന്നിടത്ത് ഒട്ടിക്കുക.\n"
+"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കുക\" "
+"തിരഞ്ഞെടുക്കുക.\n"
+"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" എന്ന് പറയുന്നിടത്ത് "
+"ഒട്ടിക്കുക.\n"
 "\n"
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ "
-"18 മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് "
-"ഇല്ലാതാക്കപ്പെടും, അത് പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ 18 "
+"മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് ഇല്ലാതാക്കപ്പെടും, അത് "
+"പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20441,6 +20502,13 @@ msgid "Synced Devices"
 msgstr "സമന്വയിപ്പിച്ച ഉപകരണങ്ങൾ"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "സിറിയ"
 
@@ -20471,6 +20539,12 @@ msgstr "TBD"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "ടിവി"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20504,9 +20578,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെയായിരുന്നാലും "
-"വേഗത്തിൽ ആക്സസ് ചെയ്യുന്നതിന് ഞങ്ങളുടെ സൗജന്യ ആപ്പിൽ ഇത് ബിൽറ്റ് ഇൻ ചെയ്ത് "
-"നേടൂ."
+"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെയായിരുന്നാലും വേഗത്തിൽ ആക്സസ് "
+"ചെയ്യുന്നതിന് ഞങ്ങളുടെ സൗജന്യ ആപ്പിൽ ഇത് ബിൽറ്റ് ഇൻ ചെയ്ത് നേടൂ."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20515,9 +20588,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെ ബ്രൗസ് "
-"ചെയ്യുമ്പോഴും വേഗത്തിലുള്ള ആക്സസിനായി ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ ഇത് "
-"ഉൾപ്പെടുത്തൂ."
+"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെ ബ്രൗസ് ചെയ്യുമ്പോഴും വേഗത്തിലുള്ള "
+"ആക്സസിനായി ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ ഇത് ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20540,9 +20612,7 @@ msgstr "നിങ്ങളുടെ സ്വകാര്യ ഡാറ്റയ�
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ "
-"പങ്കെടുക്കൂ."
+msgstr "Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ പങ്കെടുക്കൂ."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20763,10 +20833,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ "
-"ഒരു മൂന്നാം കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. "
-"അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ "
-"ഉൾപ്പെടുന്നു."
+"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ ഒരു മൂന്നാം "
+"കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ "
+"പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ ഉൾപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20775,8 +20844,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ "
-"സംരക്ഷിക്കാൻ Cloud Save ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
+"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ സംരക്ഷിക്കാൻ Cloud Save "
+"ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20806,17 +20875,15 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ "
-"സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
+"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ "
+"നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് "
-"ഇല്ലാതാക്കും."
+msgstr "ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20889,9 +20956,9 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക "
-"ഡാറ്റ സംഭരണം പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി "
-"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുക."
+"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക ഡാറ്റ സംഭരണം "
+"പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ "
+"പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20906,8 +20973,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ "
-"വീണ്ടും ശ്രമിക്കുന്നതിന് മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
+"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ വീണ്ടും ശ്രമിക്കുന്നതിന് "
+"മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20926,10 +20993,10 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ "
-"എൻക്രിപ്റ്റ് ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ "
-"എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ "
-"സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ ഉപയോഗിക്കുന്നു."
+"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ എൻക്രിപ്റ്റ് "
+"ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും "
+"നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ "
+"ഉപയോഗിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20975,8 +21042,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ "
-"പതിപ്പിൽ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
+"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ പതിപ്പിൽ ഒരു പുതിയ "
+"ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21006,9 +21073,7 @@ msgstr "ഈ ആഴ്ച"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
-"ഈ ചാറ്റ് Duck.ai-യിൽ തന്നെ തുടരുകയും നിങ്ങൾക്ക് സ്വകാര്യമായിരിക്കുകയും "
-"ചെയ്യും."
+msgstr "ഈ ചാറ്റ് Duck.ai-യിൽ തന്നെ തുടരുകയും നിങ്ങൾക്ക് സ്വകാര്യമായിരിക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21017,9 +21082,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
-"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം "
-"(കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
+"ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
+"%4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21029,9 +21094,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
-"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
-"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
+"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
+"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
+"%2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21040,9 +21105,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
-"കൃത്യതയില്ലാത്തതോ കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%2$s കാണുക)."
+"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI കൃത്യതയില്ലാത്തതോ "
+"കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21052,9 +21116,25 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ "
-"സംഭാഷണം സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
-"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
+"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ "
+"വിവരങ്ങൾക്ക് %4$s കാണുക)."
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21086,9 +21166,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s "
-"അറ്റാച്ചുചെയ്യുക"
+msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ചുചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21096,9 +21174,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് "
-"ചെയ്യുക."
+msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21130,8 +21206,7 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
-"ചേർക്കുക"
+"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21139,13 +21214,18 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
-"ചേർക്കുക."
+"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "ഈ വിവരങ്ങൾ ഉപയോഗപ്രദമല്ല"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21154,8 +21234,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. നിങ്ങളുടെ ചാറ്റുകളുടെ മുകളിൽ നിലനിർത്താൻ "
-"ഇതിന്റെ മെനു (മൂന്ന് ഡോട്ടുകൾ) തുറന്ന് പിൻ തിരഞ്ഞെടുക്കുക!"
+"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. നിങ്ങളുടെ ചാറ്റുകളുടെ മുകളിൽ നിലനിർത്താൻ ഇതിന്റെ മെനു (മൂന്ന് "
+"ഡോട്ടുകൾ) തുറന്ന് പിൻ തിരഞ്ഞെടുക്കുക!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21164,8 +21244,7 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. ഇത് ഇല്ലാതാക്കാൻ വശത്തുള്ള മെനുവിലെ Fire "
-"Button ഉപയോഗിക്കുക!"
+"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. ഇത് ഇല്ലാതാക്കാൻ വശത്തുള്ള മെനുവിലെ Fire Button ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21186,8 +21265,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ "
-"ഇല്ലാതാക്കും. മറ്റ് മോഡൽ ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ ഇല്ലാതാക്കും. മറ്റ് മോഡൽ "
+"ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21196,8 +21275,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് "
-"മോഡൽ ദാതാക്കൾ ഒരു പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് മോഡൽ ദാതാക്കൾ ഒരു "
+"പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21234,9 +21313,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് "
-"എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് "
-"ആക്‌സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് "
+"സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് ആക്‌സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21245,9 +21323,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
-"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
-"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
+"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21257,10 +21334,22 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
-"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
-"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. എന്നിരുന്നാലും, %1$s-ൽ AI "
-"സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും ഞങ്ങൾക്ക് ഉണ്ട്."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
+"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. "
+"എന്നിരുന്നാലും, %1$s-ൽ AI സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും "
+"ഞങ്ങൾക്ക് ഉണ്ട്."
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21289,9 +21378,7 @@ msgstr "ഈ വീഡിയോ ഇതുവരെ ഇവിടെ കാണാ�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) "
-"ഉപയോഗിക്കുന്നില്ല."
+msgstr "ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21301,10 +21388,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും "
-"Sync & Backup വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് "
-"ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് "
-"ചെയ്യാൻ കഴിയും."
+"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും Sync & Backup "
+"വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ "
+"നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21313,8 +21399,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. "
-"ഇത് പഴയപടിയാക്കാനാവില്ല."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. ഇത് "
+"പഴയപടിയാക്കാനാവില്ല."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21333,8 +21419,7 @@ msgstr "ഇത് എല്ലാ ക്രമീകരണവും മായ്
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
 msgstr ""
-"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് "
-"പുനഃക്രമീകരിക്കും. തുടരണോ?"
+"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് പുനഃക്രമീകരിക്കും. തുടരണോ?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21431,9 +21516,7 @@ msgstr "ശീർഷക അടിവര"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ "
-"ചേർക്കാൻ:"
+msgstr "മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ ചേർക്കാൻ:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -21456,8 +21539,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് "
-"ചെയ്യേണ്ട റൂട്ട് തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
+"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് ചെയ്യേണ്ട റൂട്ട് "
+"തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21467,10 +21550,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം "
-"സജ്ജമാക്കുമ്പോൾ സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം "
-"സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് "
-"ചെയ്‌തിരിക്കാം."
+"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം സജ്ജമാക്കുമ്പോൾ "
+"സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച "
+"ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് ചെയ്‌തിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21479,8 +21561,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും "
-"പുതിയ പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും പുതിയ "
+"പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21488,8 +21570,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ "
-"ആക്‌സസ് ചെയ്യാൻ അനുവദിക്കുക."
+"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യാൻ "
+"അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21512,8 +21594,8 @@ msgstr "ഇന്ന്"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"സ്വകാര്യ AI ചാറ്റ് പരീക്ഷിക്കാൻ ടോഗിൾ ചെയ്യുക, അല്ലെങ്കിൽ %1$s %2$s മെനുവിൽ "
-"ഇത് പ്രവർത്തനരഹിതമാക്കുക.%3$s"
+"സ്വകാര്യ AI ചാറ്റ് പരീക്ഷിക്കാൻ ടോഗിൾ ചെയ്യുക, അല്ലെങ്കിൽ %1$s %2$s മെനുവിൽ ഇത് "
+"പ്രവർത്തനരഹിതമാക്കുക.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21687,8 +21769,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം "
-"ബ്ലോക്ക് ചെയ്യുന്നു എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
+"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം ബ്ലോക്ക് ചെയ്യുന്നു "
+"എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21736,8 +21818,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
-"ഞാൻ എങ്ങനെ എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
+"എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21746,8 +21828,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
-"ഞാൻ എങ്ങനെ എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
+"എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21909,6 +21991,12 @@ msgid "Try Free"
 msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21989,8 +22077,8 @@ msgstr "വ്യത്യസ്ത കീവേഡുകൾ പരീക്ഷ�
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ "
-"പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുക."
+"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ പ്രവർത്തനരഹിതമാക്കാൻ "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22024,6 +22112,12 @@ msgid "Try for Free"
 msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
 msgctxt ""
 "Link text shown to unauthenticated users in the subscription promo card to "
@@ -22049,9 +22143,7 @@ msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ "
-"പലതും."
+msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ പലതും."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22184,8 +22276,7 @@ msgstr "അടുത്തിടെ ചേർത്തിട്ടുള്ള o
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
 msgstr ""
-"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ "
-"സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
+"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22219,9 +22310,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
-"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. "
-"%3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
+"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22230,9 +22320,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
-"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. "
-"%3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
+"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22271,6 +22360,12 @@ msgid "Turkmenistan"
 msgstr "തുർക്ക്മെനിസ്ഥാൻ"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22281,6 +22376,12 @@ msgstr "Sync & Backup ഓഫ് ചെയ്യുക"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Sync & Backup ഓഫ് ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22421,9 +22522,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് "
-"തിരയലിനും ഉത്തരം കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് "
-"കാരണമായേക്കാം."
+"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് തിരയലിനും ഉത്തരം "
+"കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് കാരണമായേക്കാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22521,17 +22621,13 @@ msgstr "ഫീഡ് ബാക്ക് അയയ്ക്കുവാൻ സാ
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും "
-"ശ്രമിക്കുക."
+msgstr "വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr ""
-"നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും "
-"ശ്രമിക്കുക."
+msgstr "നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -22557,8 +22653,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് "
-"ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് ക്ലിക്ക് "
+"ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22566,22 +22662,21 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ "
-"ചെയ്യുക: https://duckduckgo.com"
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ ചെയ്യുക: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
 msgstr ""
-"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ "
-"പേജുകൾ%4$s തിരഞ്ഞെടുക്കുക"
+"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ പേജുകൾ%4$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: "
-"https://duckduckgo.com"
+"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22592,32 +22687,30 @@ msgstr "%1$sതിരയൽ ക്രമീകരണം%2$s എന്നതി�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
 msgstr ""
-"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s "
-"എന്നത് തിരഞ്ഞെടുക്കുക"
+"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s "
-"ക്ലിക്ക് ചെയ്യുക"
+"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
 msgstr ""
-"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ "
-"തുറക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ തുറക്കുക%2$s "
+"എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22695,8 +22788,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് "
-"പ്ലാനിനേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
+"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് പ്ലാനിനേക്കാൾ 2 മടങ്ങ് "
+"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22718,8 +22811,7 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും "
-"അൺലോക്ക് ചെയ്യുക"
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22750,9 +22842,7 @@ msgstr "നൂതന മോഡലുകൾ അൺലോക്ക് ചെയ്
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് "
-"ചെയ്യുക"
+msgstr "DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -22760,9 +22850,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് "
-"ചെയ്യുക. %1$s"
+msgstr "DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് ചെയ്യുക. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -22775,6 +22863,12 @@ msgstr "പ്രീമിയം പരിരക്ഷകൾ അൺലോക്�
 msgctxt "voice chat"
 msgid "Unmute"
 msgstr "അൺമ്യൂട്ട് ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22810,6 +22904,12 @@ msgstr "അപ്ഡേറ്റ് ചെയ്യുക"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "ബ്രൗസർ അപ്ഡേറ്റ് ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22848,8 +22948,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് "
-"ചെയ്യാനും DuckDuckGo ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
+"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് ചെയ്യാനും DuckDuckGo "
+"ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22974,16 +23074,15 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
-"ചെയ്യുക, അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക, "
+"അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
-"ചെയ്യുക"
+"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23079,9 +23178,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, "
-"സ്കാമർമാരിൽ നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. "
-"വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
+"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, സ്കാമർമാരിൽ "
+"നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. "
+"സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23094,8 +23193,8 @@ msgstr "DuckDuckGo Private Search ഉപയോഗിക്കുക"
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
 msgstr ""
-"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private "
-"search ഉപയോഗിക്കുക!"
+"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private search "
+"ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23138,8 +23237,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ "
-"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
+"ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23147,8 +23246,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ "
-"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
+"ഉപയോഗിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23298,8 +23397,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ "
-"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ ക്ലിക്കുകൾ "
+"നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23308,8 +23407,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ "
-"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ ക്ലിക്കുകൾ "
+"നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23321,8 +23420,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
-"%1$sAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sAssist "
+"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23331,8 +23430,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
-"%1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sDuckAssist "
+"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23341,8 +23440,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ "
-"നിർദേശങ്ങൾ പാലിക്കുക."
+"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ നിർദേശങ്ങൾ "
+"പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23357,9 +23456,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > "
-"%3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു "
-"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & "
+"Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു ഉപകരണവുമായി "
+"സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23369,10 +23468,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
-"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു "
-"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
-"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & "
+"Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" "
+"തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23382,10 +23480,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, "
-"%1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് "
-"ചെയ്യുക%6$s എന്നിടത്ത് %7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s "
-"തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, %1$sDuck.ai "
+"ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നിടത്ത് "
+"%7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23395,10 +23492,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai "
-"ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" "
-"തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. "
-"അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
+"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി "
+"സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23451,8 +23547,8 @@ msgstr "വോയ്സ് ചാറ്റ് അവസാനിച്ചു"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിച്ചിട്ടില്ല."
+"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"ഉപയോഗിച്ചിട്ടില്ല."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23596,9 +23692,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച "
-"പ്രവർത്തനത്തെ YouTube ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck "
-"Player-ൽ കാണുക."
+"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച പ്രവർത്തനത്തെ YouTube "
+"ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck Player-ൽ കാണുക."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23618,11 +23713,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന "
-"വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ "
-"നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. DuckDuckGo ഒരു സ്വതന്ത്ര "
-"കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി യാതൊരു "
-"ബന്ധവുമില്ല."
+"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് "
+"ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. "
+"DuckDuckGo ഒരു സ്വതന്ത്ര കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി "
+"യാതൊരു ബന്ധവുമില്ല."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23635,8 +23729,8 @@ msgstr "ഞങ്ങൾ അജ്ഞാതമാക്കുന്നു"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ "
-"ലൊക്കേഷൻ%2$s അജ്ഞാതമാക്കാൻ കഴിയും."
+"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ ലൊക്കേഷൻ%2$s "
+"അജ്ഞാതമാക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23648,10 +23742,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
-"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി "
-"പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ "
-"കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
+"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി പങ്കിടുക, അതുവഴി "
+"ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23663,18 +23756,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
-"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും "
-"പ്രതികരണവും പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ "
-"കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
+"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രതികരണവും പങ്കിടുക, അതുവഴി "
+"ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s "
-"ലൊക്കേഷൻ%2$s ഉപയോഗിക്കാനാകും."
+"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s ലൊക്കേഷൻ%2$s "
+"ഉപയോഗിക്കാനാകും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -23682,8 +23774,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ "
-"ഞങ്ങൾക്ക് അവ വായിക്കാൻ കഴിയില്ല."
+"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ ഞങ്ങൾക്ക് അവ "
+"വായിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23694,16 +23786,13 @@ msgstr "പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്�
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ "
-"സംഭരിക്കുന്നില്ല."
+msgstr "ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ സംഭരിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ "
-"ഇല്ല. എപ്പോഴും."
+"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ ഇല്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23715,8 +23804,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ "
-"നിങ്ങളെ പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
+"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്ങളെ "
+"പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23730,9 +23819,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ "
-"കൊണ്ടുവന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് "
-"ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ കൊണ്ടുവന്നത് എന്താണെന്ന് "
+"ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23741,9 +23829,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ "
-"നിങ്ങൾക്ക് ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം "
-"ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ നിങ്ങൾക്ക് "
+"ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23754,9 +23841,7 @@ msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ "
-"നയം."
+msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ നയം."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23785,8 +23870,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ "
-"ഉടനീളം പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
+"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ ഉടനീളം "
+"പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23806,14 +23891,22 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "നിഷ്ക്രിയത്വം കാരണം ഞങ്ങൾ ചാറ്റ് അവസാനിപ്പിച്ചു. വീണ്ടും ശ്രമിക്കണോ?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് "
-"ഉറപ്പാക്കാൻ എല്ലാ AI ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
+"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് ഉറപ്പാക്കാൻ എല്ലാ AI "
+"ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23830,9 +23923,7 @@ msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെ�
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ "
-"ശ്രമിക്കൂ."
+msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -23840,8 +23931,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന "
-"തിരയൽ പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
+"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന തിരയൽ "
+"പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23850,24 +23941,28 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത "
-"ലൊക്കേഷൻ ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് "
-"മാറ്റാൻ കഴിയും."
+"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ലൊക്കേഷൻ "
+"ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ "
-"ആശ്രയിക്കുന്നു."
+"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ ആശ്രയിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ "
-"തടയുന്നു."
+msgstr "ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23883,16 +23978,23 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് "
-"ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ "
-"സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം ദൃശ്യമാകണമെന്നില്ല."
+"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ "
+"വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം "
+"ദൃശ്യമാകണമെന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന "
-"ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
+"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23902,8 +24004,8 @@ msgid ""
 "continue to see this error, please reach out to %s."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, "
-"ദയവായി %1$s-നെ സമീപിക്കുക."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, ദയവായി %1$s-നെ "
+"സമീപിക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23913,8 +24015,7 @@ msgid ""
 "clearing your browser's cache can help."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ "
-"മായ്ക്കുന്നത് സഹായിക്കാം."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ മായ്ക്കുന്നത് സഹായിക്കാം."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23929,8 +24030,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ "
-"ഞങ്ങൾ കഠിനമായി പരിശ്രമിക്കുന്നു."
+"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ ഞങ്ങൾ കഠിനമായി "
+"പരിശ്രമിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23939,8 +24040,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് "
-"വീണ്ടും ലോഡ് ചെയ്യേണ്ടതുണ്ട്."
+"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് വീണ്ടും ലോഡ് "
+"ചെയ്യേണ്ടതുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24048,9 +24149,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr ""
-"പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
-"തുടരാം."
+msgstr "പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24064,9 +24163,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
-"സ്വകാര്യമാണ്, അവ ഞങ്ങൾ അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കുന്നില്ല."
+"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഞങ്ങൾ "
+"അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24075,9 +24173,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
-"സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ "
+"ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ "
+"ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24087,17 +24185,16 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s "
-"ആണ്. ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും "
-"DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s ആണ്. "
+"ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ "
-"ഇംപോർട്ട് ചെയ്യാം."
+"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24165,8 +24262,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു "
-"പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
+"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. "
+"പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24181,8 +24278,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും "
-"പ്രതിവാദങ്ങളും എന്തൊക്കെയാണ്?"
+"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും പ്രതിവാദങ്ങളും "
+"എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24203,14 +24300,20 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' "
-"എന്ന വാക്കിനുള്ള ചില ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
+"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' എന്ന വാക്കിനുള്ള ചില "
+"ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "ആന്വിറ്റികളുടെ ചില ഗുണങ്ങളും ദോഷങ്ങളും എന്തൊക്കെയാണ്?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24223,12 +24326,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് "
-"ചെയ്യുന്നതിന്റെ പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ "
-"മാത്രം അവലംബിക്കുന്നു. Duck.ai സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും "
-"ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് പ്രതികരണത്തെ വ്യക്തമായ "
-"വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം കൂടുതലുള്ളവർക്കും "
-"ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
+"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് ചെയ്യുന്നതിന്റെ "
+"പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ മാത്രം അവലംബിക്കുന്നു. Duck.ai "
+"സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് "
+"പ്രതികരണത്തെ വ്യക്തമായ വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം "
+"കൂടുതലുള്ളവർക്കും ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24314,8 +24416,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
 msgstr ""
-"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ "
-"എന്തൊക്കെയാണ്?"
+"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24466,8 +24567,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ "
-"ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
+"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ "
+"വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24543,8 +24644,7 @@ msgstr "നിങ്ങൾ എന്തിനെക്കുറിച്ചാ�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
-"സ്വാധീനിക്കില്ല."
+"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24570,8 +24670,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ "
-"പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
+"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന "
+"ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24595,8 +24695,7 @@ msgstr "<strong>%1$s</strong> എവിടെ കാണാം"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
 msgstr ""
-"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s "
-"എന്നത് ക്ലിക്ക് ചെയ്യുക."
+"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24637,8 +24736,7 @@ msgstr "ആരാണ് ഞങ്ങൾ"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
-"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് "
-"അറിയപ്പെടുന്നത്?"
+"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് അറിയപ്പെടുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24776,15 +24874,23 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai ഉപയോഗിച്ച്, നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കപ്പെടുന്നു, കൂടാതെ AI "
-"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല. '%1$s' മെനുവിൽ എപ്പോൾ വേണമെങ്കിലും "
-"ഇത് ഓണാക്കുകയോ ഓഫാക്കുകയോ ചെയ്യാം."
+"Duck.ai ഉപയോഗിച്ച്, നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കപ്പെടുന്നു, കൂടാതെ AI പരിശീലിപ്പിക്കാൻ "
+"ഒരിക്കലും ഉപയോഗിക്കില്ല. '%1$s' മെനുവിൽ എപ്പോൾ വേണമെങ്കിലും ഇത് ഓണാക്കുകയോ ഓഫാക്കുകയോ "
+"ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "ദാതാവിന്റെ ദൃശ്യപരതയില്ലാതെ"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25033,8 +25139,7 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് "
-"വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25054,8 +25159,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
-"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
+"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25064,8 +25169,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ "
-"DuckDuckGo-യിൽ നിന്ന് മറ്റ് തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
+"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ DuckDuckGo-യിൽ നിന്ന് മറ്റ് "
+"തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25079,8 +25184,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ "
-"ക്രമീകരണങ്ങൾ%3$s-ൽ എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
+"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ ക്രമീകരണങ്ങൾ%3$s-ൽ "
+"എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25089,22 +25194,21 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ "
-"ക്രമീകരണങ്ങൾ%2$s-ൽ അത് എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
+"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s-ൽ അത് "
+"എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s "
-"ഉപയോഗിക്കാം."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI "
-"Chat%2$s ഉപയോഗിക്കാനും കഴിയും."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI Chat%2$s "
+"ഉപയോഗിക്കാനും കഴിയും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25118,8 +25222,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist "
-"കാണണമെന്നത് മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
+"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist കാണണമെന്നത് "
+"മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25140,8 +25244,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു "
-"പാസ്‌ഫ്രെയ്സിന് കീഴിൽ സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
+"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു പാസ്‌ഫ്രെയ്സിന് കീഴിൽ "
+"സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25171,8 +25275,7 @@ msgstr "നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉ
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് "
-"തുടർന്നോളൂ!"
+"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് തുടർന്നോളൂ!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25236,8 +25339,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം "
-"മറ്റൊരു സൈറ്റ് അൺബ്ലോക്ക് ചെയ്യണം."
+"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം മറ്റൊരു സൈറ്റ് "
+"അൺബ്ലോക്ക് ചെയ്യണം."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25273,9 +25376,7 @@ msgstr "നിങ്ങൾക്ക് ഈ പുതിയ ഡൊമെയ്ന
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ "
-"സൂക്ഷിക്കാം."
+msgstr "പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ സൂക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -25290,14 +25391,21 @@ msgid "You have 1 attempt left."
 msgstr "നിങ്ങൾക്ക് 1 ശ്രമം ശേഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, "
-"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
+"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, Plus-നേക്കാൾ 2 മടങ്ങ് "
+"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25306,9 +25414,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് "
-"DuckDuckGo ബ്രൗസറിൽ VPN, മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് "
-"ചെയ്യാം."
+"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് DuckDuckGo ബ്രൗസറിൽ VPN, "
+"മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25330,9 +25437,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് "
-"ചെയ്യാൻ കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. "
-"ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന "
+"30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് "
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25342,9 +25449,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ "
-"കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് "
-"എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന 30 "
+"ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ "
+"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25358,8 +25465,8 @@ msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
 msgstr ""
-"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo "
-"ആപ്പ് അപ്ഡേറ്റുകൾ ലഭിക്കും."
+"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo ആപ്പ് അപ്ഡേറ്റുകൾ "
+"ലഭിക്കും."
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -25374,9 +25481,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് "
-"ചെയ്യുന്നതിന് Chrome-ന് പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം "
-"ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് ചെയ്യുന്നതിന് Chrome-ന് "
+"പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25389,8 +25495,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും "
-"കുറയ്ക്കുന്നതിന് നുറുങ്ങുകൾ നേടുക."
+"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും കുറയ്ക്കുന്നതിന് "
+"നുറുങ്ങുകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25440,8 +25546,8 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. "
-"ദയവായി വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. ദയവായി വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25468,9 +25574,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം "
-"തീർന്നു. സമന്വയം പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ "
-"ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം തീർന്നു. സമന്വയം "
+"പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25481,8 +25586,8 @@ msgid ""
 "deleted."
 msgstr ""
 "Duck.ai ചാറ്റുകൾക്കുള്ള Sync & Backup സ്റ്റോറേജ് തീർന്നിരിക്കുന്നു. സമന്വയം "
-"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ "
-"ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത "
+"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25496,9 +25601,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ "
-"അനുവദിക്കുന്നില്ല. അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് "
-"YouTube/Google ട്രാക്ക് ചെയ്യും."
+"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ അനുവദിക്കുന്നില്ല. "
+"അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് YouTube/Google ട്രാക്ക് ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25510,6 +25614,23 @@ msgstr "YouTube സ്വകാര്യതാ മുന്നറിയിപ്
 msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube സ്റ്റാൻഡേർഡ്"
+
+# smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25535,6 +25656,14 @@ msgid "Your actual location remains private."
 msgstr "നിങ്ങളുടെ യഥാർത്ഥ ലൊക്കേഷന്‍ രഹസ്യമായി തുടരുന്നു."
 
 # smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
 msgctxt "Body copy for the Delete Server Data confirmation modal"
 msgid ""
@@ -25542,9 +25671,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
-"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
-"%1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
+"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
+"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25554,9 +25683,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
-"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
-"100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
+"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ 100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
+"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25572,9 +25701,7 @@ msgstr "നിങ്ങൾ ഈ ലിങ്ക് സന്ദർശിച്ച
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
-"നൽകുന്നു."
+msgstr "നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -25583,8 +25710,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
-"നൽകുന്നു. DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു. DuckDuckGo-"
+"യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25592,8 +25719,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. "
-"DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. DuckDuckGo-യ്ക്ക് "
+"ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25602,8 +25729,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
-"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
+"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25616,16 +25743,15 @@ msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോൾ 
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഒരിക്കലും സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിക്കില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25651,8 +25777,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25660,8 +25786,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25676,9 +25802,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് "
-"അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ പാലിക്കൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ "
+"പാലിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25687,8 +25813,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി "
-"Duck.ai-ൽ നിർത്തിയിടത്ത് നിന്ന് തുടരൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി Duck.ai-ൽ നിർത്തിയിടത്ത് "
+"നിന്ന് തുടരൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25736,8 +25862,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല."
+"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25766,11 +25892,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് "
-"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ "
-"ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ "
-"ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-യ്ക്ക് "
-"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
+"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് "
+"ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ "
+"ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-"
+"യ്ക്ക് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25785,10 +25910,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി "
-"തിരിച്ചറിയാൻ കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ "
-"ദാതാക്കൾക്ക് നിങ്ങളുടെ സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ "
-"കഴിയില്ല."
+"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി തിരിച്ചറിയാൻ "
+"കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ ദാതാക്കൾക്ക് നിങ്ങളുടെ "
+"സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25802,8 +25926,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ "
-"പരിശോധിക്കാനോ എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ പരിശോധിക്കാനോ "
+"എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25835,9 +25959,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് "
-"അവയെ പുനഃസജ്ജമാക്കും. ഇത് സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ "
-"പ്രവർത്തനക്ഷമമാക്കുക."
+"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് അവയെ പുനഃസജ്ജമാക്കും. ഇത് "
+"സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25846,9 +25969,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് "
-"അവയെ പുനഃസജ്ജമാക്കും. ഇത് സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ "
-"ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ അറിയുക%4$s"
+"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് അവയെ പുനഃസജ്ജമാക്കും. ഇത് "
+"സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ "
+"അറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25868,9 +25991,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി "
-"Chrome-ന് പകരം ഞങ്ങളുടെ ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ "
-"ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി Chrome-ന് പകരം ഞങ്ങളുടെ "
+"ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25879,8 +26001,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം "
-"ചുരുക്കി വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം ചുരുക്കി വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25889,8 +26011,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button "
-"ഉപയോഗിച്ച് ഈ സംഭാഷണം മായ്ക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button ഉപയോഗിച്ച് ഈ "
+"സംഭാഷണം മായ്ക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25899,8 +26021,7 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ "
-"ചാറ്റ് ആരംഭിക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25915,8 +26036,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി "
-"നാളെ ഈ ചാറ്റ് തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി നാളെ ഈ ചാറ്റ് "
+"തുടരുക."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26219,8 +26340,8 @@ msgstr "ഔദ്യോഗിക വെബ്സൈറ്റ്"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു "
-"എന്‍കോഡ് ചെയ്ത %3$s പ്രതീകം ആണ്)."
+"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു എന്‍കോഡ് ചെയ്ത %3$s "
+"പ്രതീകം ആണ്)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ml_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (ഈ ഉപകരണം)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -190,8 +190,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
-"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
+"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -201,8 +202,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
-"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
+"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -218,8 +220,9 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് തുടരാൻ, നിങ്ങളുടെ "
-"സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് "
+"തുടരാൻ, നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
+"മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -228,8 +231,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ പിന്നീട് വീണ്ടും "
-"ശ്രമിക്കുക."
+"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ "
+"പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -306,7 +309,8 @@ msgstr "%1$s റാങ്കിംഗുകൾ ഇതുവരെ ലഭ്യ�
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
 msgstr ""
-"%1$s അടിസ്ഥാന മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധികളിൽ എത്തുന്നു. %2$s"
+"%1$s അടിസ്ഥാന മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധികളിൽ "
+"എത്തുന്നു. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -327,9 +331,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് പോലും "
-"നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് അവരുടെ സെർവറുകളിൽ "
-"സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
+"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് "
+"പോലും നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് "
+"അവരുടെ സെർവറുകളിൽ സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -415,8 +419,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ ചാറ്റ് "
-"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ "
+"ചാറ്റ് തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -427,8 +431,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് തുടരുന്നതിന് "
-"നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് "
+"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -441,8 +445,8 @@ msgstr "%1$s വാക്കുകൾ"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, തുടർന്ന് "
-"%6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, "
+"തുടർന്ന് %6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -450,8 +454,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s "
-"ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് "
+"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -461,8 +465,9 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s ക്ലിക്ക് "
-"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s "
+"ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s "
+"ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -471,8 +476,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ "
-"കരുതുന്നുണ്ടെങ്കിൽ."
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ "
+"ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ കരുതുന്നുണ്ടെങ്കിൽ."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -491,14 +496,15 @@ msgstr "%1$sകൂടുതലറിയുക%2$s ."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക%2$s."
+"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
+"മനസ്സിലാക്കുക%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -506,16 +512,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
+"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
+"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -528,7 +534,8 @@ msgstr "ഹോം സ്ക്രീനിൽ DuckDuckGo ആപ്പ് ഐക�
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s വീണ്ടും ശ്രമിക്കുക."
+"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -795,7 +802,7 @@ msgstr "%1$s ഗ്രൂപ്പിൽ 2-ാമത്"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "രണ്ടാമതൊരു അഭിപ്രായം"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -886,7 +893,9 @@ msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -940,8 +949,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. നിങ്ങളുടെ കണക്ഷൻ "
-"പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. "
+"നിങ്ങളുടെ കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -999,10 +1008,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
-"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത മറയ്ക്കും. %1$sduckduckgo.com/"
-"aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ "
-"കഴിയും."
+"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത "
+"മറയ്ക്കും. %1$sduckduckgo.com/aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് "
+"ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1063,10 +1072,11 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് പിന്തുണയ്ക്കുന്നില്ല. "
-"എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി %1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും "
-"പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് "
-"മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് "
+"പിന്തുണയ്ക്കുന്നില്ല. എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി "
+"%1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, "
+"ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1251,8 +1261,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
-"മോഡലിലേക്ക് മാറുക."
+"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു "
+"സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1288,8 +1298,8 @@ msgstr "പരസ്യം"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ നിങ്ങളെ "
-"തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
+"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ "
+"നിങ്ങളെ തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1297,8 +1307,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ "
-"ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
+"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1349,8 +1359,8 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ചേർക്കുക"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy Essentials "
-"ചേർക്കുക:"
+"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy "
+"Essentials ചേർക്കുക:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1480,7 +1490,7 @@ msgstr "ഹോംസ്ക്രീനിലേക്കു ചേർക്ക�
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "എന്റെ ചാറ്റുകളിലേക്ക് ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1584,8 +1594,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധിയിൽ "
-"എത്തിച്ചേരാൻ കഴിഞ്ഞേക്കാം. %1$s"
+"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ "
+"പരിധിയിൽ എത്തിച്ചേരാൻ കഴിഞ്ഞേക്കാം. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1594,8 +1604,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
-"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2-5 മടങ്ങ് വേഗത്തിൽ പരിധികൾ ഉപയോഗിക്കാൻ കഴിഞ്ഞേക്കാം. "
-"%1$s"
+"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2-5 മടങ്ങ് വേഗത്തിൽ പരിധികൾ ഉപയോഗിക്കാൻ "
+"കഴിഞ്ഞേക്കാം. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1631,15 +1641,17 @@ msgstr "ആഫ്രികാൻസ്"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
 msgstr ""
-"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് ഡബിൾ ക്ലിക്ക് "
-"ചെയ്യുക"
+"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് "
+"ഡബിൾ ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1775,8 +1787,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ DuckDuckGo "
-"അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല"
+"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ "
+"DuckDuckGo അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1809,8 +1822,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ ദാതാക്കളെയും "
-"അനുവദിക്കില്ല."
+"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ "
+"ദാതാക്കളെയും അനുവദിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1825,8 +1838,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും (ഉദാഹരണത്തിന്, "
-"നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
+"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും "
+"(ഉദാഹരണത്തിന്, നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1851,7 +1864,7 @@ msgstr "എല്ലാ തരവും"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെട്ടിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1865,7 +1878,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ ആക്സസ് അനുവദിക്കുക."
+"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ "
+"ആക്സസ് അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1897,10 +1911,11 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ %1$s-നെ "
-"അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച "
-"ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ "
-"ദൃശ്യപരത പൂജ്യം ആണ്%4$s."
+"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ "
+"%1$s-നെ അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് "
+"എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള "
+"പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ ദൃശ്യപരത പൂജ്യം "
+"ആണ്%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2047,8 +2062,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
-"അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
+"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2057,8 +2072,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
-"അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
+"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2072,8 +2087,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്നു. ഇത് "
-"എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
+"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
+"സൃഷ്ടിക്കുന്നു. ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, "
+"അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2241,8 +2257,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ "
-"ചാറ്റുകളും ഇല്ലാതാക്കും."
+"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത "
+"ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ ചാറ്റുകളും ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2251,8 +2267,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് ചെയ്ത സമീപകാല "
-"ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
+"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് "
+"ചെയ്ത സമീപകാല ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2290,8 +2306,9 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും ശേഖരിക്കുകയോ "
-"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും "
+"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2375,7 +2392,7 @@ msgstr "എന്തും സ്വകാര്യമായി ചോദിക�
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "എന്തും സ്വകാര്യമായി ചോദിക്കൂ"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2433,13 +2450,15 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ ഉത്തരങ്ങൾ അജ്ഞാതമായി "
-"സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
-"ഒരിക്കലും ഇല്ല (തിരയൽ ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
-"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ചിലപ്പോൾ "
-"(വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ "
-"തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. "
-"(ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
+"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ "
+"ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ "
+"പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും ഇല്ല (തിരയൽ "
+"ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
+"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
+"കാണിക്കൂ), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
+"കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി "
+"കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. (ഇംഗ്ലീഷ്) മേഖലയിൽ "
+"മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2451,13 +2470,14 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
-"അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
-"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ %1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് "
-"പ്രധാനമാണ്."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. "
+"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
+"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
+"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2483,8 +2503,9 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"കഫേയിലോ വിമാനത്താവളത്തിലോ ഹോട്ടലിലോ ആയിരിക്കുമ്പോൾ, DuckDuckGo VPN നിങ്ങളുടെ കണക്ഷൻ "
-"എൻക്രിപ്റ്റ് ചെയ്യുകയും Wi-Fi-യിൽ നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുകയും ചെയ്യുന്നു."
+"കഫേയിലോ വിമാനത്താവളത്തിലോ ഹോട്ടലിലോ ആയിരിക്കുമ്പോൾ, DuckDuckGo VPN നിങ്ങളുടെ "
+"കണക്ഷൻ എൻക്രിപ്റ്റ് ചെയ്യുകയും Wi-Fi-യിൽ നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുകയും "
+"ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2600,15 +2621,16 @@ msgstr "സ്വയമേവയുള്ള-ഉത്തരം"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ "
+"അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. പ്രതികരണങ്ങളിൽ അപാകതകൾ "
-"അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. "
+"പ്രതികരണങ്ങളിൽ അപാകതകൾ അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2633,9 +2655,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി തിരയാനും ചില "
-"സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ "
-"മാത്രമേ Assist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി "
+"തിരയാനും ചില സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. "
+"ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ Assist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2644,16 +2666,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് അജ്ഞാതമായി "
-"തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് "
-"പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് "
+"അജ്ഞാതമായി തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
+"കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
 msgstr ""
-"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ സ്വയമേവ പ്ലേ ചെയ്യുക."
+"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ "
+"സ്വയമേവ പ്ലേ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2685,7 +2708,9 @@ msgstr "ശരാശരി വോളിയം"
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr "നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് ഒഴിവാക്കുക."
+msgstr ""
+"നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് "
+"ഒഴിവാക്കുക."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2853,8 +2878,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ "
-"എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
+"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, "
+"തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo "
+"നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2984,8 +3010,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"ഉപദ്രവകരമായ സൈറ്റുകൾ തടയുക, നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുക, കൂടാതെ ഞങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വഴി "
-"കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ നേടുക."
+"ഉപദ്രവകരമായ സൈറ്റുകൾ തടയുക, നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുക, കൂടാതെ ഞങ്ങളുടെ "
+"സബ്സ്ക്രിപ്ഷൻ വഴി കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3245,18 +3271,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
-"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
-"ഒരുമിച്ചുചേർത്തു."
+"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ "
+"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
+"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
-"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
-"ഒരുമിച്ചുചേർത്തു."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ "
+"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
+"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3264,9 +3290,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. %1$sപ്രധാന "
-"ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ "
-"മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. "
+"%1$sപ്രധാന ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, "
+"സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3352,7 +3378,9 @@ msgstr "'%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നി�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം അംഗീകരിക്കുന്നു."
+msgstr ""
+"“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം "
+"അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3373,10 +3401,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), ക്രമീകരണം "
-"സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ "
-"ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി "
-"തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
+"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), "
+"ക്രമീകരണം സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു "
+"വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത "
+"Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
+"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
 "നിങ്ങളുടെ ബ്രൗസറിൽ നിന്ന് പുറത്തുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -3385,8 +3414,9 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ ശബ്ദ ഡാറ്റ "
-"OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
+"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
+"നിങ്ങളുടെ ശബ്ദ ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
+"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3395,9 +3425,9 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ വോയ്സ് "
-"ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s "
-"കാണൂ."
+"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
+"നിങ്ങളുടെ വോയ്സ് ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
+"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3433,8 +3463,8 @@ msgstr "കാമറൂൺ"
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
 msgstr ""
-"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ പാചകക്കുറിപ്പുകൾ "
-"സൃഷ്ടിക്കാൻ കഴിയുമോ?"
+"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ "
+"പാചകക്കുറിപ്പുകൾ സൃഷ്ടിക്കാൻ കഴിയുമോ?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3736,7 +3766,8 @@ msgstr "ഫലങ്ങളുടെ URL-കൾ എങ്ങനെ പ്രദ�
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
 msgstr ""
-"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ പെരുമാറ്റവും മാറുന്നു"
+"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ "
+"പെരുമാറ്റവും മാറുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3755,13 +3786,17 @@ msgstr "മുഴുവൻ സൈറ്റിലും പശ്ചാത്ത�
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം മാറ്റുന്നു"
+msgstr ""
+"ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം "
+"മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം മാറ്റുന്നു"
+msgstr ""
+"ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം "
+"മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3884,10 +3919,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ ചാറ്റ് (Duck.ai "
-"സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. "
-"ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. "
-"എന്നിരുന്നാലും, %1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
+"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ "
+"ചാറ്റ് (Duck.ai സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic "
+"തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo "
+"Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, "
+"%1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
 "നിങ്ങൾക്ക് ചാറ്റ് ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
@@ -3944,8 +3980,8 @@ msgstr "സ്വകാര്യമായി ചാറ്റ് ചെയ്യ�
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
-"ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
+"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3953,8 +3989,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
-"ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
+"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4023,9 +4059,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത "
-"ചാറ്റുകൾ നീക്കം ചെയ്യും."
+"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത ചാറ്റുകൾ നീക്കം ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4037,11 +4073,13 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും "
-"അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് "
-"നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും "
-"പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ "
+"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
+"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4064,8 +4102,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ അപ്‌ലോഡ് ചെയ്യുന്ന "
-"എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് അജ്ഞാതമായി പരിശോധിക്കുന്നു."
+"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ "
+"അപ്‌ലോഡ് ചെയ്യുന്ന എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് "
+"അജ്ഞാതമായി പരിശോധിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4073,8 +4112,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. സമന്വയം പുനരാരംഭിക്കാൻ "
-"സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
+"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. "
+"സമന്വയം പുനരാരംഭിക്കാൻ സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4127,7 +4166,9 @@ msgstr "സ്പെല്ലിംഗ് പരിശോധിക്കുക"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് പരിശോധിക്കുക."
+msgstr ""
+"ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് "
+"പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4198,7 +4239,9 @@ msgstr "%1$s , %2$s എന്നിവ ഉൾപ്പെടെ AI മോഡല�
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s തിരഞ്ഞെടുക്കുക."
+msgstr ""
+"നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4230,8 +4273,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"ഉപദ്രവകരമായ സൈറ്റുകളെയും തട്ടിപ്പുകളെയും തടയാൻ ലോകമെമ്പാടുമുള്ള 40-ലധികം സെർവർ "
-"ലൊക്കേഷനുകളിൽ നിന്ന് തിരഞ്ഞെടുക്കുക."
+"ഉപദ്രവകരമായ സൈറ്റുകളെയും തട്ടിപ്പുകളെയും തടയാൻ ലോകമെമ്പാടുമുള്ള 40-ലധികം "
+"സെർവർ ലൊക്കേഷനുകളിൽ നിന്ന് തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4249,8 +4292,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് ആപ്പ് "
-"ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
+"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് "
+"ആപ്പ് ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4431,9 +4474,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ നടന്ന ചാറ്റുകൾ "
-"അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി "
-"ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ "
+"നടന്ന ചാറ്റുകൾ അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 "
+"ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4443,9 +4486,10 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ Duck.ai "
-"ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ "
-"ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ ആശ്രയിച്ചിരിക്കുന്നു."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ "
+"Duck.ai ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ "
+"യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ "
+"ആശ്രയിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4454,8 +4498,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് "
-"ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. "
+"നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4464,9 +4508,10 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ %1$sDuck.ai%2$s "
-"വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
-"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI ചാറ്റ് സേവനം."
+"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ "
+"%1$sDuck.ai%2$s വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic "
+"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI "
+"ചാറ്റ് സേവനം."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4525,7 +4570,9 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ച�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4542,8 +4589,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ വലതുവശത്തുള്ള "
-"%3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
+"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ "
+"വലതുവശത്തുള്ള %3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4561,7 +4608,8 @@ msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sക്രമീകരണം%
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
 msgstr ""
-"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി ക്ലിക്ക് ചെയ്യുക%4$s."
+"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി "
+"ക്ലിക്ക് ചെയ്യുക%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4574,7 +4622,8 @@ msgstr "%1$sഉവ്വ്%2$s ക്ലിക്ക് ചെയ്യുക"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് ചെയ്യുക."
+"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4636,9 +4685,10 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
-"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s "
-"ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
+"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ "
+"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
+"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4649,9 +4699,10 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
-"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/"
-"ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
+"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ "
+"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
+"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4720,8 +4771,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ "
-"ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
+"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ "
+"മെനുവിൽ ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4729,8 +4780,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ ബ്രൗസറിന്റെ "
-"മുകളിൽ വലത് കോണിലായിരിക്കും."
+"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ "
+"ബ്രൗസറിന്റെ മുകളിൽ വലത് കോണിലായിരിക്കും."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4931,8 +4982,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി സംരക്ഷിക്കാൻ അനുവദിക്കും. "
-"ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
+"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി "
+"സംരക്ഷിക്കാൻ അനുവദിക്കും. ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5203,7 +5254,9 @@ msgstr "പരസ്യങ്ങൾ തടയുന്നത് തുടരു�
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "സമീപകാല ചാറ്റുകൾ ഇവിടെ തുടരുക. അല്ലെങ്കിൽ Fire Button ഉപയോഗിച്ച് അവ ഇല്ലാതാക്കുക."
+msgstr ""
+"സമീപകാല ചാറ്റുകൾ ഇവിടെ തുടരുക. അല്ലെങ്കിൽ Fire Button ഉപയോഗിച്ച് അവ "
+"ഇല്ലാതാക്കുക."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5310,7 +5363,7 @@ msgstr "പകർത്തുക"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "പകർത്തുക"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5359,13 +5412,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "പങ്കുവെച്ച ലിങ്ക് പകർത്തുക"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "മറ്റൊരു ഉപകരണത്തിൽ നിന്ന് കോഡ് പകർത്തുക"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5374,6 +5427,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"മറ്റൊരു ഉപകരണത്തിൽ നിന്ന് കോഡ് പകർത്തുക. %1$sDuck.ai ക്രമീകരണങ്ങൾ › ചാറ്റുകൾ "
+"› Sync & Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%2$s എന്നതിലേക്ക് പോയി "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5425,7 +5481,9 @@ msgstr "കോസ്റ്റാ റിക്ക"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും ശ്രമിക്കു."
+msgstr ""
+"നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും "
+"ശ്രമിക്കു."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5526,8 +5584,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
-"ഒരു ലിങ്ക് നിർമ്മിക്കുന്നത് ചാറ്റിന്റെ ഒരു പകർപ്പ് ഉണ്ടാക്കുന്നു, അത് തുറക്കുന്ന ആർക്കും അത് കാണാൻ "
-"കഴിയും."
+"ഒരു ലിങ്ക് നിർമ്മിക്കുന്നത് ചാറ്റിന്റെ ഒരു പകർപ്പ് ഉണ്ടാക്കുന്നു, അത് "
+"തുറക്കുന്ന ആർക്കും അത് കാണാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5766,7 +5824,9 @@ msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞ
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6042,7 +6102,9 @@ msgstr "സംഭരണ സ്ഥലം ശൂന്യമാക്കാൻ ഏ
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കണോ?"
+msgstr ""
+"സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ "
+"ഇല്ലാതാക്കണോ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6056,7 +6118,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "പങ്കുവെച്ച ലിങ്ക് ഇല്ലാതാക്കുക"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6077,6 +6139,9 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"ഒരു ലിങ്ക് ഇല്ലാതാക്കുന്നത് അത് പ്രവർത്തിക്കുന്നത് തടയുന്നു. ഇത് തുറന്ന് "
+"തങ്ങളുടെ ചാറ്റുകളിലേക്ക് സംഭാഷണം ചേർത്ത ആളുകളുടെ പക്കൽ അവരുടെ സ്വന്തം "
+"പകർപ്പ് ഉണ്ടായിരിക്കും."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6173,8 +6238,8 @@ msgstr "Duck.ai-യിലെ ഡിക്റ്റേഷൻ"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിക്കാറില്ല."
+"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6192,8 +6257,9 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ ഉപയോഗിക്കുന്നു, "
-"അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് ചെയ്യാൻ സാധിക്കും."
+"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ "
+"ഉപയോഗിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് "
+"ചെയ്യാൻ സാധിക്കും."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6338,7 +6404,7 @@ msgstr "നിരസിക്കുക"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "നിരസിക്കുക"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6474,7 +6540,9 @@ msgstr "പട്ടികയിൽ DuckDuckGo കാണുന്നില്ല
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് ചെയ്യുക%4$s"
+msgstr ""
+"അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് "
+"ചെയ്യുക%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6512,8 +6580,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI ചിത്രങ്ങൾ "
-"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
+"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI "
+"ചിത്രങ്ങൾ ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6639,8 +6707,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടറിന് "
-"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു "
+"വെണ്ടറിന് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6649,8 +6717,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് "
-"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ "
+"അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6671,8 +6739,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ പോസ്റ്റിന് കുറച്ച് "
-"ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
+"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ "
+"പോസ്റ്റിന് കുറച്ച് ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6681,8 +6749,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു പോസ്റ്റിന്റെ "
-"തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
+"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു "
+"പോസ്റ്റിന്റെ തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6752,7 +6820,9 @@ msgstr "നിങ്ങളുടെ ഫോട്ടോകളോ PDF ഫയലു
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ അനുവദിക്കുന്നു"
+msgstr ""
+"ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ "
+"അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6814,9 +6884,10 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് ഉത്തരം നൽകാൻ "
-"സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ നിങ്ങൾ "
-"തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
+"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് "
+"ഉത്തരം നൽകാൻ സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ "
+"നിങ്ങൾ തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് "
+"ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6826,9 +6897,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. "
-"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ "
-"ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് "
+"ചെയ്യാൻ കഴിയില്ല. നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും "
+"എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6837,14 +6908,16 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. ദയവായി നാളെ ഈ "
-"ചാറ്റ് തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. "
+"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും മികച്ചത്!"
+msgstr ""
+"ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും "
+"മികച്ചത്!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6854,8 +6927,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ നിയന്ത്രണം തിരികെ "
-"നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
+"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ "
+"നിയന്ത്രണം തിരികെ നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര "
+"ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6870,8 +6944,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ എളുപ്പമുള്ള ഒരു "
-"വിലാസം ലഭിക്കും: https://duck.ai"
+"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ "
+"എളുപ്പമുള്ള ഒരു വിലാസം ലഭിക്കും: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6886,8 +6960,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s അജ്ഞാത കോഡ് "
-"%2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s "
+"അജ്ഞാത കോഡ് %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6908,9 +6982,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും "
-"%1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
+"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഇത് പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും "
+"മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും %1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6921,11 +6995,12 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം കക്ഷി AI ചാറ്റ് "
-"മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഈ ക്രമീകരണം "
-"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ "
-"ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai "
-"ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
+"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം "
+"കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai "
+"ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ ക്രമീകരണം ഓഫ് "
+"ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai ആക്സസ് "
+"ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6940,15 +7015,16 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. നിങ്ങൾക്ക് ഇപ്പോഴും "
-"പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
+"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. "
+"നിങ്ങൾക്ക് ഇപ്പോഴും പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
 msgstr ""
-"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് പരീക്ഷിച്ചു നോക്കൂ!"
+"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് "
+"പരീക്ഷിച്ചു നോക്കൂ!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6956,14 +7032,16 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ കൃത്യതയ്ക്കായി "
-"പരിശോധിച്ചിട്ടുമില്ല."
+"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ "
+"കൃത്യതയ്ക്കായി പരിശോധിച്ചിട്ടുമില്ല."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr "Anthropic, OpenAI, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകളെ Duck.ai പിന്തുണയ്ക്കുന്നു."
+msgstr ""
+"Anthropic, OpenAI, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകളെ Duck.ai "
+"പിന്തുണയ്ക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6982,8 +7060,8 @@ msgstr "Duck.ai അപ്ഗ്രേഡ് ചെയ്തു!"
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
 msgstr ""
-"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ "
-"DuckDuckGo ആപ്പിലാണ്!"
+"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും "
+"സൗജന്യവുമായ DuckDuckGo ആപ്പിലാണ്!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6993,9 +7071,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത AI ചാറ്റ്, "
-"സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI "
-"മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
+"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത "
+"AI ചാറ്റ്, സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, "
+"മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, "
+"അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7023,11 +7102,12 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
-"കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
-"ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-"
-"ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ "
-"പ്രസക്തമാകുമ്പോൾ മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
+"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ "
+"സംഗ്രഹിക്കാനും കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് "
+"നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist "
+"UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ "
+"ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ "
+"മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
 "കാണിക്കുന്നു). ഇപ്പോൾ, DuckAssist യുഎസ് (ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
@@ -7037,9 +7117,10 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
-"%1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ "
-"നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
+"എന്നിരുന്നാലും, ഞങ്ങൾ %1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് "
+"OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന "
+"ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7048,9 +7129,10 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
-"DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic "
-"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
+"എന്നിരുന്നാലും, ഞങ്ങൾ DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം "
+"ചെയ്യുന്നു, ഇത് OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7062,12 +7144,13 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
-"അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി "
-"വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം "
-"സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ "
-"പ്രതികരണങ്ങൾ നിലവിൽ വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും "
-"കൃത്യത പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ "
+"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ പ്രതികരണങ്ങൾ നിലവിൽ "
+"വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും കൃത്യത "
+"പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7081,14 +7164,16 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
-"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ രണ്ടോ "
-"ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ "
-"നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് "
-"പ്രതികരണങ്ങൾ സ്വയം സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് "
+"തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് "
+"ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
+"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
+"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ "
+"രണ്ടോ ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് "
+"വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ "
+"വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
 "%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
@@ -7107,8 +7192,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. ദയവായി നാളെ ഈ "
-"ചാറ്റ് തുടരുക."
+"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. "
+"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7117,8 +7202,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
-"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
+"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7127,8 +7212,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
-"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
+"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7137,8 +7222,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
-"പ്രദർശിപ്പിച്ചേക്കാം."
+"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
+"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7147,8 +7232,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ "
-"അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി "
+"ഈ അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7195,7 +7280,7 @@ msgstr "DuckDuckGo ബ്രൗസർ %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo സഹായ പേജുകൾ"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7312,8 +7397,9 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII "
-"സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ അജ്ഞാതമാക്കുന്നു."
+"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ "
+"പോലുള്ള PII സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ "
+"അജ്ഞാതമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7321,8 +7407,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ Duck.ai-"
-"യുടെ %2$s സമ്മതിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
+"നിങ്ങൾ Duck.ai-യുടെ %2$s സമ്മതിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7331,8 +7417,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ ഞങ്ങളുടെ "
-"%2$s-നെ അംഗീകരിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
+"നിങ്ങൾ ഞങ്ങളുടെ %2$s-നെ അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7341,9 +7427,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന Google, Facebook പോലുള്ള "
-"കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ "
-"DuckDuckGo തടയുന്നു."
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന "
+"Google, Facebook പോലുള്ള കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ "
+"സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ DuckDuckGo തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7355,12 +7441,13 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ "
-"ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് "
-"ഞങ്ങൾക്ക് അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് ഉപയോഗിക്കുന്നു, "
-"തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ "
-"സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ "
-"അറിയുക%2$s."
+"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ "
+"പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് "
+"സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് ഞങ്ങൾക്ക് "
+"അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് "
+"ഉപയോഗിക്കുന്നു, തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി "
+"ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ "
+"സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7380,8 +7467,9 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് കൂടുതൽ ബന്ധമുള്ള, "
-"മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് "
+"കൂടുതൽ ബന്ധമുള്ള, മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. "
+"%1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7473,10 +7561,11 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo സെർവറുകളിൽ നിന്ന് "
-"ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ "
-"നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 "
-"അക്ഷരങ്ങളെങ്കിലും ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
+"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo "
+"സെർവറുകളിൽ നിന്ന് ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. "
+"പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ "
+"തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 അക്ഷരങ്ങളെങ്കിലും "
+"ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7547,8 +7636,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും പുതിയത് സൃഷ്ടിക്കുകയും "
-"ചെയ്യും."
+"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും "
+"പുതിയത് സൃഷ്ടിക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7609,7 +7698,9 @@ msgstr "AI സവിശേഷതകൾ പ്രവർത്തനക്ഷമ�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save പ്രവർത്തനക്ഷമമാക്കുക."
+msgstr ""
+"നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save "
+"പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7686,8 +7777,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് എപ്പോൾ "
-"വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് "
+"എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7732,8 +7823,9 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, പക്ഷേ അപ്പോഴും നിങ്ങളുടെ "
-"തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
+"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, "
+"പക്ഷേ അപ്പോഴും നിങ്ങളുടെ തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് "
+"സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7810,7 +7902,8 @@ msgstr "Duck.ai ആസ്വദിക്കുകയാണോ?"
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
 msgstr ""
-"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് "
+"ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7896,8 +7989,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക. ഇത് "
-"നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
+"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് "
+"ചെയ്യുക. ഇത് നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7923,8 +8016,8 @@ msgstr "ടെക്‌സ്റ്റ് നൽകുക"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: %5$sഅപരനാമം "
-"%6$s: ഡി%7$s"
+"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: "
+"%5$sഅപരനാമം %6$s: ഡി%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7965,7 +8058,8 @@ msgstr "ഇക്വറ്റോറിയൽ ഗിനിയ"
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
 msgstr ""
-"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ മായ്ക്കുക %1$s%2$s"
+"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ "
+"മായ്ക്കുക %1$s%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8025,14 +8119,16 @@ msgstr "മാപ്പ് വികസിപ്പിക്കുക"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത ഉൽപ്പന്നങ്ങൾ."
+msgstr ""
+"സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത "
+"ഉൽപ്പന്നങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "കാലഹരണപ്പെട്ടു"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8046,7 +8142,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "%1$s-ൽ കാലഹരണപ്പെടുന്നു"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8113,7 +8209,9 @@ msgstr "ഇത് ലളിതമായി വിശദീകരിക്കു�
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr "ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും വിശദീകരിക്കുക."
+msgstr ""
+"ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും "
+"വിശദീകരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -8309,8 +8407,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
-"സ്വാധീനിക്കുന്നു."
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
+"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8319,8 +8417,9 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
-"സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
+"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
+"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും "
+"പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8328,8 +8427,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ സൈറ്റിലേക്കു പകർത്തി "
-"ഒട്ടിക്കുക"
+"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ "
+"സൈറ്റിലേക്കു പകർത്തി ഒട്ടിക്കുക"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8413,15 +8512,16 @@ msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
-"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് ഫിൽട്ടർ ചെയ്ത് "
-"ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് "
+"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. "
+"%1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8463,7 +8563,8 @@ msgstr "<b>%1$s</b> നിങ്ങളുടെ ഡൗൺലോഡുകൾ ഫ�
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
 msgstr ""
-"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s "
+"എന്നത് ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8501,8 +8602,8 @@ msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
 msgstr ""
-"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും സുരക്ഷിതവും "
-"അജ്ഞാതവുമാണ്."
+"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും "
+"സുരക്ഷിതവും അജ്ഞാതവുമാണ്."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8566,8 +8667,9 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു മെനു ഓപ്ഷൻ "
-"തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി വന്നേക്കാം."
+"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു "
+"മെനു ഓപ്ഷൻ തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി "
+"വന്നേക്കാം."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8684,7 +8786,9 @@ msgstr "സൗജന്യവും സ്വകാര്യവുമായ ച�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് ആവശ്യമില്ല."
+msgstr ""
+"സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് "
+"ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8714,7 +8818,9 @@ msgstr "പങ്കിടലും വാണിജ്യപരമായി ഉ�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+msgstr ""
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ "
+"ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8795,9 +8901,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; <strong>അപ്ഡേറ്റുകൾ "
-"പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് ഇൻസ്റ്റാൾ ചെയ്യുക</strong> "
-"തിരഞ്ഞെടുക്കുക."
+"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; "
+"<strong>അപ്ഡേറ്റുകൾ പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് "
+"ഇൻസ്റ്റാൾ ചെയ്യുക</strong> തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9083,15 +9189,14 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN, നൂതന Duck.ai എന്നിവ നേടൂ, Personal Info Removal, Identity Theft "
-"Restoration എന്നിവയും."
+"DuckDuckGo VPN, നൂതന Duck.ai എന്നിവ നേടൂ, Personal Info Removal, Identity "
+"Theft Restoration എന്നിവയും."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"DuckDuckGo VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
+msgstr "DuckDuckGo VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9171,8 +9276,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണൽ അഡ്വാൻസ്ഡ് AI ചാറ്റ്, Personal Info Removal, കൂടാതെ "
-"Identity Theft Restoration എന്നിവ നേടൂ."
+"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണൽ അഡ്വാൻസ്ഡ് AI ചാറ്റ്, Personal Info Removal, "
+"കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9181,8 +9286,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണലായ നൂതന AI ചാറ്റ്, കൂടാതെ Identity Theft Restoration "
-"നേടൂ."
+"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണലായ നൂതന AI ചാറ്റ്, കൂടാതെ Identity Theft "
+"Restoration നേടൂ."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9191,8 +9296,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo-യിലേക്ക് "
-"സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന "
+"DuckDuckGo-യിലേക്ക് സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI "
+"മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9203,8 +9309,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo സബ്സ്ക്രിപ്ഷൻ "
-"ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo "
+"സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9248,8 +9354,9 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"ഞങ്ങളുടെ വേഗതയേറിയ നോ-ലോഗ് VPN, ഉയർന്ന ചാറ്റ് പരിധികളുള്ള നൂതന AI മോഡലുകളിലേക്കുള്ള ഓപ്ഷണൽ "
-"ആക്‌സസ്, കൂടാതെ കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ എന്നിവ നേടൂ."
+"ഞങ്ങളുടെ വേഗതയേറിയ നോ-ലോഗ് VPN, ഉയർന്ന ചാറ്റ് പരിധികളുള്ള നൂതന AI "
+"മോഡലുകളിലേക്കുള്ള ഓപ്ഷണൽ ആക്‌സസ്, കൂടാതെ കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ എന്നിവ "
+"നേടൂ."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9258,8 +9365,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai നേടൂ, Personal Information Removal, "
-"കൂടാതെ Identity Theft Restoration."
+"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai നേടൂ, Personal Information "
+"Removal, കൂടാതെ Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9267,14 +9374,15 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration "
-"എന്നിവ നേടൂ."
+"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft "
+"Restoration എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
 msgstr ""
-"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ സൗജന്യമായി നേടുക:"
+"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ "
+"സൗജന്യമായി നേടുക:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9370,8 +9478,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
-"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക › "
-"ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
+"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
+"സമന്വയിപ്പിക്കുക › ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9406,8 +9514,8 @@ msgid ""
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
 "എന്നതിലേക്ക് പോയി %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ "
-"ചെയ്യുക."
+"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
+"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9416,6 +9524,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"മറ്റൊരു ഉപകരണത്തിലെ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
+"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോവുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9430,8 +9540,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് പോയി "
-"\"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് "
+"പോയി \"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9531,7 +9641,7 @@ msgstr "മനസ്സിലായി"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "മനസ്സിലായി"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9697,7 +9807,9 @@ msgstr "ഗ്വാട്ടിമാല"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ നയിക്കുക."
+msgstr ""
+"ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ "
+"നയിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9897,7 +10009,9 @@ msgstr "DuckDuckGo മെച്ചപ്പെടുത്താൻ ഞങ്ങ
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ സഹായിക്കൂ"
+msgstr ""
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ "
+"സഹായിക്കൂ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9955,7 +10069,9 @@ msgstr "Duck ഭാഗത്ത് ചേരാൻ നിങ്ങളുടെ �
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ സഹായിക്കൂ!"
+msgstr ""
+"നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ "
+"സഹായിക്കൂ!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10130,8 +10246,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search Assist "
-"ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
+"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search "
+"Assist ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10158,8 +10274,9 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ %1$sമടങ്ങുക%2$s "
-"അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ "
+"%1$sമടങ്ങുക%2$s അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് "
+"ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10173,8 +10290,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, നിങ്ങൾക്ക് "
-"ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
+"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, "
+"നിങ്ങൾക്ക് ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10224,8 +10341,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
-"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ "
+"ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10334,7 +10451,9 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് ആഗ്രഹിക്കുന്നത്?"
+msgstr ""
+"നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് "
+"ആഗ്രഹിക്കുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10367,8 +10486,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ തന്ത്രപൂർവ്വം "
-"സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
+"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ "
+"തന്ത്രപൂർവ്വം സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10475,7 +10594,9 @@ msgstr "കൂടുതൽ വിൽപ്പനക്കാരിൽ നിന�
 #. Header above text explaining that passwords can't be recovered.
 msgctxt "cloudsave"
 msgid "I forgot my passphrase. Can you recover it?"
-msgstr "എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ സാധിക്കുമോ?"
+msgstr ""
+"എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ "
+"സാധിക്കുമോ?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user hits a chat limit.
@@ -10490,14 +10611,16 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് "
-"ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
+"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല "
+"പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ എനിക്ക് ആവശ്യമാണ്"
+msgstr ""
+"ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ "
+"എനിക്ക് ആവശ്യമാണ്"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10526,8 +10649,9 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > പുനഃക്രമീകരിക്കുക > "
-"'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s എന്നതിലേക്ക് പോകുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > "
+"പുനഃക്രമീകരിക്കുക > 'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s "
+"എന്നതിലേക്ക് പോകുക."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10537,9 +10661,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക %1$s⋮ > മെനു > "
-"ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് "
-"അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക "
+"%1$s⋮ > മെനു > ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് "
+"DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10554,8 +10678,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ എഞ്ചിനുകളുടെ%4$s "
-"പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
+"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ "
+"എഞ്ചിനുകളുടെ%4$s പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10564,8 +10688,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് "
-"ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് %1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
+"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് "
+"പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് "
+"%1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10574,16 +10699,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ "
-"ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച "
+"ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ "
+"ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, %1$sDuckDuckGo "
-"പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
+"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, "
+"%1$sDuckDuckGo പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10593,8 +10719,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ %1$s "
-"അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
+"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ "
+"%1$s അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10602,8 +10728,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും അടുത്തുള്ള ഹോം പേജ് "
-"തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
+"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും "
+"അടുത്തുള്ള ഹോം പേജ് തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10732,8 +10858,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് ഫലത്തിന്റെ വ്യക്തത "
-"മെച്ചപ്പെടുത്തുന്നു"
+"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് "
+"ഫലത്തിന്റെ വ്യക്തത മെച്ചപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10746,8 +10872,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ ക്ലിക്കുകൾ "
-"റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ "
+"ക്ലിക്കുകൾ റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10758,8 +10884,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, തുടർന്ന് \"മറ്റൊരു "
-"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
+"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, "
+"തുടർന്ന് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10774,8 +10900,9 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക "
-"എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി പരിശോധിക്കാവുന്നതാണ്."
+"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം "
+"വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി "
+"പരിശോധിക്കാവുന്നതാണ്."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11112,8 +11239,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ പ്രശസ്തി "
-"സംഗ്രഹിക്കുക."
+"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ "
+"പ്രശസ്തി സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11157,15 +11284,17 @@ msgstr "ഇതിന് ഏതാനും നിമിഷങ്ങൾ എടു
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr "ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും നൽകുന്നു."
+msgstr ""
+"ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും "
+"നൽകുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) ചോദിക്കുന്നതിൽ "
-"കുഴപ്പമില്ല"
+"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) "
+"ചോദിക്കുന്നതിൽ കുഴപ്പമില്ല"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11184,10 +11313,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, Microsoft-ന്റെ "
-"പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് "
-"നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം "
-"ലഭിക്കുന്നില്ല."
+"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, "
+"Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ "
+"നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് "
+"വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം ലഭിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11196,8 +11325,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 വാക്കുകൾ ഓർമിക്കുവാൻ, "
-"വളരെ അധികം സുരക്ഷിതവും."
+"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 "
+"വാക്കുകൾ ഓർമിക്കുവാൻ, വളരെ അധികം സുരക്ഷിതവും."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11270,8 +11399,8 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
 msgstr ""
-"ഒരേസമയം 5 ഉപകരണങ്ങളിൽ വരെ നിങ്ങളുടെ എല്ലാ ആപ്പുകളും ഓൺലൈൻ പ്രവർത്തനങ്ങളും സ്വകാര്യമായി "
-"സൂക്ഷിക്കുക."
+"ഒരേസമയം 5 ഉപകരണങ്ങളിൽ വരെ നിങ്ങളുടെ എല്ലാ ആപ്പുകളും ഓൺലൈൻ പ്രവർത്തനങ്ങളും "
+"സ്വകാര്യമായി സൂക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11508,7 +11637,7 @@ msgstr "%1$sകൂടുതൽ%2$s അറിയുക"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "കൂടുതലറിയുക"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11579,7 +11708,9 @@ msgstr "DuckDuckGo ക്രമീകരണങ്ങൾ എങ്ങനെ ക�
 #. Description of a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "Learn how we keep your location private"
-msgstr "നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക"
+msgstr ""
+"നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
+"മനസ്സിലാക്കുക"
 
 # smartling.placeholder_format=C
 #. Link text in the Usage section of Duck.ai settings that opens a help page explaining Duck.ai usage limits.
@@ -11621,7 +11752,9 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് അറിയുക."
+msgstr ""
+"ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് "
+"അറിയുക."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11684,8 +11817,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Duck.ai-ലേക്ക് തിരയൽ ചോദ്യങ്ങളും പ്രോംപ്റ്റുകളും സമർപ്പിക്കുന്നത് തമ്മിൽ മാറാൻ നിങ്ങളെ "
-"അനുവദിക്കുന്നു"
+"Duck.ai-ലേക്ക് തിരയൽ ചോദ്യങ്ങളും പ്രോംപ്റ്റുകളും സമർപ്പിക്കുന്നത് തമ്മിൽ "
+"മാറാൻ നിങ്ങളെ അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11743,7 +11876,9 @@ msgstr "ഈ ചാറ്റിനായി പരിമിതമായ ഡാറ
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr "ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് പരിമിതപ്പെടുത്തുന്നു"
+msgstr ""
+"ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് "
+"പരിമിതപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -11778,7 +11913,8 @@ msgstr "ലിങ്കുകൾ:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
-"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ ലിസ്റ്റ് ചെയ്യുക."
+"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ "
+"ലിസ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11890,7 +12026,8 @@ msgstr "സ്ക്രോൾ ചെയ്യുമ്പോൾ കൂടുത�
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
 msgstr ""
-"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ ലോഡ് ചെയ്യുന്നു"
+"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ "
+"ലോഡ് ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12077,7 +12214,8 @@ msgstr "എല്ലാ വാക്കുകളും അക്ഷരത്ത�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
+"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് "
+"തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12149,7 +12287,7 @@ msgstr "മാനേജ് ചെയ്യുക"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "മാനേജ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12406,7 +12544,7 @@ msgstr "മെനു"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "ഇതിന് ശേഷമുള്ള സന്ദേശങ്ങൾ നിങ്ങൾക്ക് മാത്രമേ ദൃശ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12436,7 +12574,9 @@ msgstr "മൈക്രോനേഷ്യ"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12778,7 +12918,7 @@ msgstr "Duck.ai-യെക്കുറിച്ച് കൂടുതൽ"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "കൂടുതൽ പ്രവർത്തനങ്ങൾ"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12978,7 +13118,7 @@ msgstr "ഇളം ചുവപ്പ്"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "എന്റെ ഉപകരണങ്ങൾ"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13220,10 +13360,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു "
-"DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് "
-"വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ "
-"ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
+"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
 "പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
@@ -14056,6 +14197,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
+"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$sഎന്നതിലേക്ക് പോകുക"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14064,6 +14207,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
+"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോയി ഈ കോഡ് "
+"സ്കാൻ ചെയ്യുക:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14072,6 +14218,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
+"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. "
+"അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14099,8 +14248,9 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ കൂടുതൽ പേജുകളുണ്ട്. %1$s "
-"അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുക."
+"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ "
+"കൂടുതൽ പേജുകളുണ്ട്. %1$s അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14143,8 +14293,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത പിശകുണ്ടായി. പിന്നീട് "
-"വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത "
+"പിശകുണ്ടായി. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14198,8 +14348,8 @@ msgstr "%1$s വെബ്‌സൈറ്റ് തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
 msgstr ""
-"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s "
-"ഉറപ്പാക്കുക"
+"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
+"%3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s ഉറപ്പാക്കുക"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14220,7 +14370,8 @@ msgstr "%1$sക്രമീകരണം%2$s തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
 msgstr ""
-"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
+"%1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14369,7 +14520,9 @@ msgstr "How Duck.ai വർക്ക്സ് പാനൽ തുറക്കു�
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s തിരഞ്ഞെടുക്കുക..."
+msgstr ""
+"Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s "
+"തിരഞ്ഞെടുക്കുക..."
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14470,8 +14623,9 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ നിങ്ങളുടെ "
-"തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല — കാലഘട്ടം"
+"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ "
+"നിങ്ങളുടെ തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് "
+"ചെയ്യുന്നില്ല — കാലഘട്ടം"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14485,8 +14639,9 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"ഞങ്ങളുടെ വേഗതയേറിയ, നോ-ലോഗ് VPN-നൊപ്പം ഉയർന്ന പരിധികളുള്ള മികച്ച AI ചാറ്റുകളും കൂടുതൽ "
-"പ്രീമിയം പരിരക്ഷകളും ലഭിക്കുന്നു. എല്ലാം ഉൾപ്പെട്ട ഒരു സബ്‌സ്‌ക്രിപ്‌ഷൻ."
+"ഞങ്ങളുടെ വേഗതയേറിയ, നോ-ലോഗ് VPN-നൊപ്പം ഉയർന്ന പരിധികളുള്ള മികച്ച AI "
+"ചാറ്റുകളും കൂടുതൽ പ്രീമിയം പരിരക്ഷകളും ലഭിക്കുന്നു. എല്ലാം ഉൾപ്പെട്ട ഒരു "
+"സബ്‌സ്‌ക്രിപ്‌ഷൻ."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14494,8 +14649,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും ശേഖരിക്കുകയോ "
-"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും "
+"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14503,9 +14658,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ ഉൾപ്പെടുത്തി "
-"മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, Android%2$s എന്നിവയിൽ "
-"ലഭ്യമാണ്."
+"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ "
+"ഉൾപ്പെടുത്തി മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, "
+"Android%2$s എന്നിവയിൽ ലഭ്യമാണ്."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14758,8 +14913,9 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും വിവരങ്ങൾ ഞങ്ങൾ "
-"ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും "
+"വിവരങ്ങൾ ഞങ്ങൾ ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14829,7 +14985,7 @@ msgstr "കഴിഞ്ഞ വർഷം"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "ഒട്ടിക്കുക"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14847,7 +15003,7 @@ msgstr "സമന്വയ കോഡ് പേസ്റ്റ് ചെയ്യ
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "അത് താഴെ ഒട്ടിക്കുക"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14906,7 +15062,7 @@ msgstr "പേർഷ്യൻ"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14915,6 +15071,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal നിങ്ങളുടെ വിവരങ്ങൾ വിൽക്കുന്ന ഡാറ്റ ബ്രോക്കർ "
+"സൈറ്റുകളിൽ അത് കണ്ടെത്തുന്നു. തുടർന്ന് അത് നിങ്ങൾക്കായി നീക്കം ചെയ്യാൻ ഞങ്ങൾ "
+"പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14985,9 +15144,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI സഹായമുള്ള ഉത്തരങ്ങൾ "
-"സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. "
-"അവ ഓഫാക്കാനും Assist ബട്ടൺ മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI "
+"സഹായമുള്ള ഉത്തരങ്ങൾ സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും "
+"പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. അവ ഓഫാക്കാനും Assist ബട്ടൺ "
+"മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14996,10 +15156,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist "
-"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ "
-"സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist "
-"ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
+"DuckAssist പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച "
+"ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് "
+"ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15009,9 +15169,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist സ്വയമേവ "
-"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് "
-"ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
+"DuckAssist സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും "
+"മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ "
+"മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15044,8 +15205,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
-"തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
+"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15054,8 +15215,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
-"തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
+"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15064,8 +15225,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ ആപ്പുകൾക്ക് "
-"DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
+"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ "
+"ആപ്പുകൾക്ക് DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15078,8 +15239,8 @@ msgstr "ഒരു നിർദിഷ്ട പ്രശ്നം തിരഞ്
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ നിർദ്ദേശങ്ങൾ "
-"പാലിക്കുക."
+"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ "
+"നിർദ്ദേശങ്ങൾ പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15168,7 +15329,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന ചലഞ്ച് പൂർത്തിയാക്കുക."
+"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന "
+"ചലഞ്ച് പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15177,23 +15339,24 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി പൂർത്തിയാക്കുക."
+"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി "
+"പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
-"(ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
+"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
-"(ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
+"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15214,8 +15377,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് നിങ്ങളുടെ നിലവിലെ "
-"ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
+"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് "
+"നിങ്ങളുടെ നിലവിലെ ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15224,8 +15387,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
-"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
+"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15234,8 +15398,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
-"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
+"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ "
+"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15388,7 +15553,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കുകയില്ല."
+"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
+"സ്വാധീനിക്കുകയില്ല."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15451,7 +15617,8 @@ msgstr "മോശം ഫോർമാറ്റിംഗ്"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
-"ജനപ്രിയ AI മോഡലുകൾ ലഭ്യമാണ്. അക്കൗണ്ട് ആവശ്യമില്ല. ചാറ്റുകൾ ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു."
+"ജനപ്രിയ AI മോഡലുകൾ ലഭ്യമാണ്. അക്കൗണ്ട് ആവശ്യമില്ല. ചാറ്റുകൾ ഞങ്ങൾ "
+"അജ്ഞാതമാക്കിയിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15960,7 +16127,9 @@ msgstr "എന്നെ പ്രോംപ്റ്റ് ചെയ്യു�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് നിർദേശിക്കുക."
+msgstr ""
+"സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് "
+"നിർദേശിക്കുക."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15978,7 +16147,9 @@ msgstr "നിങ്ങൾ തിരയുകയും ബ്രൗസ് ചെ
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ സംരക്ഷിക്കുക."
+msgstr ""
+"തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ "
+"സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16003,8 +16174,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. [നിങ്ങളുടെ സ്വന്തം "
-"വാചകം ഇവിടെ ചേർക്കുക.]"
+"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. "
+"[നിങ്ങളുടെ സ്വന്തം വാചകം ഇവിടെ ചേർക്കുക.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16179,7 +16350,7 @@ msgstr "വെബ്സൈറ്റ് വായിക്കുന്നു..."
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "സൂര്യഗ്രഹണത്തിന് തയ്യാറാണോ?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16222,14 +16393,16 @@ msgstr "സങ്കീർണ്ണമായ ചോദ്യങ്ങൾക്�
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധിയിലെത്തുന്നു. "
-"%1$s"
+"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ "
+"പരിധിയിലെത്തുന്നു. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ പരിധികൾ 2-5 മടങ്ങ് വേഗത്തിൽ ഉപയോഗിക്കുന്നു. %1$s"
+msgstr ""
+"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ പരിധികൾ 2-5 മടങ്ങ് വേഗത്തിൽ "
+"ഉപയോഗിക്കുന്നു. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16279,8 +16452,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16289,8 +16462,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16300,9 +16473,10 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ പ്രോംപ്റ്റുകളും "
-"പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ "
-"സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
+"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ "
+"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16376,7 +16550,7 @@ msgstr "റിക്കവറി കോഡ്"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "റിക്കവറി കോഡ്"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16444,8 +16618,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ വലുപ്പം കുറയ്ക്കുകയും "
-"ചെയ്യുന്നു"
+"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ "
+"വലുപ്പം കുറയ്ക്കുകയും ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16586,8 +16760,9 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ ബ്രൗസറിലെ "
-"&quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് ചെയ്യുക."
+"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ "
+"ബ്രൗസറിലെ &quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16633,7 +16808,7 @@ msgstr "%1$s നീക്കം ചെയ്യുക"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "ഉപകരണം നീക്കം ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16681,13 +16856,13 @@ msgstr "അനാവശ്യമായ ചിഹ്നങ്ങൾ നീക്�
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "ഇന്റർനെറ്റിൽ നിന്ന് നിങ്ങളുടെ വിവരങ്ങൾ നീക്കം ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "ഓൺലൈനിൽ നിന്ന് നിങ്ങളുടെ വിവരങ്ങൾ നീക്കം ചെയ്യുക"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16695,8 +16870,9 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
-"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
+"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും "
+"സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16704,8 +16880,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
-"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
+"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും "
+"സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16763,9 +16940,10 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് അവ "
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ "
-"അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് അയയ്ക്കാറുണ്ട്."
+"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ "
+"സഹായിക്കുന്നതിന് അവ DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ "
+"മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് "
+"അയയ്ക്കാറുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16773,8 +16951,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ "
-"തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ "
+"ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16783,9 +16961,10 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് വിവർത്തനം "
-"ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ "
-"വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് "
+"വിവർത്തനം ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ "
+"അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ "
+"വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16877,9 +17056,10 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. AI- "
-"സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന "
+"നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16888,9 +17068,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist "
-"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16900,10 +17080,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് "
-"ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search "
-"Assist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി "
+"സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search Assist "
+"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16980,8 +17161,8 @@ msgstr "ബ്ലോക്ക് ചെയ്‌ത സൈറ്റുകളി�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ കൈകാര്യം ചെയ്യാൻ "
-"കഴിയും."
+"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ "
+"കൈകാര്യം ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17330,16 +17511,17 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഏറ്റവും പുതിയ "
-"ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംരക്ഷിക്കുക."
+"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് "
+"നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ "
+"പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ പ്രാദേശികമായി "
-"സംരക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ "
+"പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17347,7 +17529,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai ചാറ്റുകൾ സംരക്ഷിക്കുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai "
+"ചാറ്റുകൾ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17383,7 +17566,7 @@ msgstr "Duck.ai-യോട് ഹലോ പറയൂ"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Duck.ai-യോട് ഹലോ പറയൂ – DuckDuckGo-യുടെ സൗജന്യവും സ്വകാര്യവുമായ AI ചാറ്റ്."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17487,13 +17670,17 @@ msgstr "സ്കോട്ട്ലൻഡ്"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
+msgstr ""
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17501,8 +17688,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
-"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
+"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17511,8 +17698,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
-"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
+"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17531,15 +17718,16 @@ msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത്, �
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ "
-"അതിനെ അനുവദിക്കുക."
+"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ "
+"ഉപയോഗിക്കാൻ അതിനെ അനുവദിക്കുക."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s ക്ലിക്ക് ചെയ്യുക."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s "
+"ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17593,12 +17781,14 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. ഇത് ചെയ്യുന്നതിന്, "
-"പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം "
-"സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
-"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ), "
-"അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ "
-"ഒരു ഭാഗത്ത് മാത്രമേ Search Assist ലഭ്യമാകൂ."
+"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. "
+"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. "
+"നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
+"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ "
+"പ്രസക്തമാകുമ്പോൾ), അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, "
+"ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ ഒരു ഭാഗത്ത് മാത്രമേ Search Assist "
+"ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17606,8 +17796,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search Assist-ന് "
-"കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
+"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search "
+"Assist-ന് കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17616,9 +17806,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ "
-"സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും "
-"കണ്ടെത്തിയ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
+"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
+"സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും കണ്ടെത്തിയ വിവരങ്ങളെ "
+"അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17739,8 +17930,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള തിരയൽ "
-"വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
+"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള "
+"തിരയൽ വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17759,9 +17950,9 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, നിങ്ങളുടെ പ്രിയപ്പെട്ട "
-"ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് "
-"തിരയുക."
+"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, "
+"നിങ്ങളുടെ പ്രിയപ്പെട്ട ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, "
+"അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് തിരയുക."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17769,8 +17960,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST അഭ്യർത്ഥനകൾ "
-"ഉപയോഗിക്കും)"
+"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST "
+"അഭ്യർത്ഥനകൾ ഉപയോഗിക്കും)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17782,10 +17973,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക സംഭരണത്തിലും നിങ്ങളുടെ "
-"ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
-"അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
-"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
+"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക "
+"സംഭരണത്തിലും നിങ്ങളുടെ ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു "
+"വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save "
+"ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ "
+"സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
 "വിട്ടുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -17881,7 +18073,8 @@ msgstr "രണ്ടാമതൊരു അഭിപ്രായം"
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
 msgstr ""
-"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
+"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും "
+"സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17890,8 +18083,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17900,8 +18094,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17910,8 +18105,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17920,15 +18116,17 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ സുരക്ഷിതമായി "
-"സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ "
+"സുരക്ഷിതമായി സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17937,8 +18135,9 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു. "
-"നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, ഞങ്ങൾക്ക് പോലും."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിച്ചിരിക്കുന്നു. നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, "
+"ഞങ്ങൾക്ക് പോലും."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18083,34 +18282,38 @@ msgstr "%1$s%2$s%3$s തിരഞ്ഞെടുക്കുക, തുടർന
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
 msgstr ""
-"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് തിരഞ്ഞെടുക്കുക."
+"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം %3$shttps://duckduckgo.com%4$s എന്ന് "
-"ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
+"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം "
+"%3$shttps://duckduckgo.com%4$s എന്ന് ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ ക്ലിക്ക് "
-"ചെയ്യുക!"
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ "
+"ക്ലിക്ക് ചെയ്യുക!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18122,7 +18325,9 @@ msgstr "ഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ ഡ്ര
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %4$sഅനുവദിക്കുക%3$s"
+msgstr ""
+"ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
+"%4$sഅനുവദിക്കുക%3$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18135,7 +18340,8 @@ msgstr "തിരയൽ ദാതാക്കളുടെ പട്ടികയ�
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
 msgstr ""
-"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
+"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18146,13 +18352,17 @@ msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sManage add-ons%s from the dropdown menu"
-msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -18160,8 +18370,8 @@ msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s എന്നും "
-"തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s "
+"എന്നും തിരഞ്ഞെടുക്കുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18169,8 +18379,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s എന്നും "
-"തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s "
+"എന്നും തിരഞ്ഞെടുക്കുക"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18235,14 +18445,16 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ "
-"നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
+"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %3$sഅനുവദിക്കുക%4$s"
+msgstr ""
+"ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
+"%3$sഅനുവദിക്കുക%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18315,7 +18527,8 @@ msgstr "%1$s-ൽ നിന്ന് തിരഞ്ഞെടുത്ത ടെ�
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
 msgstr ""
-"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
+"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് "
+"വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18359,9 +18572,9 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ സന്ദേശങ്ങളുമായി AI "
-"മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും "
-"ബാധകമാകും."
+"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ "
+"സന്ദേശങ്ങളുമായി AI മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ "
+"നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും ബാധകമാകും."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18388,7 +18601,7 @@ msgstr "സെർബിയൻ (ലാറ്റിൻ)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "സെർവർ ഡാറ്റ ഇല്ലാതാക്കി"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18484,8 +18697,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് ചരിത്രം ഓണാക്കിയ "
-"ശേഷം Sync & Backup സജ്ജമാക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് "
+"ചരിത്രം ഓണാക്കിയ ശേഷം Sync & Backup സജ്ജമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18550,7 +18763,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "പങ്കിടുക"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18567,7 +18780,9 @@ msgstr "പങ്കിടുക"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ സഹായിക്കുക!"
+msgstr ""
+"DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ "
+"സഹായിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18594,8 +18809,9 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. Duck.ai "
-"ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ വെളിപ്പെടുത്തുകയില്ല."
+"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. "
+"Duck.ai ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ "
+"വെളിപ്പെടുത്തുകയില്ല."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18691,8 +18907,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക (നിയമവിരുദ്ധവും "
-"ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
+"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക "
+"(നിയമവിരുദ്ധവും ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18704,13 +18920,13 @@ msgstr "തിരയൽ ബോക്സ് സംബന്ധിച്ച നി
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "പങ്കിട്ട ചാറ്റ് ലിങ്കുകൾ"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "പങ്കിട്ട ചാറ്റ് ലിങ്കുകൾ"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18719,8 +18935,9 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"ഞങ്ങളുടെ നോ-ലോഗ്, വേഗതയേറിയ VPN ഉപയോഗിച്ച് നിങ്ങളുടെ ഓൺലൈൻ പ്രവർത്തനം സംരക്ഷിക്കൂ. "
-"സജ്ജീകരിക്കാൻ ലളിതവും എപ്പോൾ വേണമെങ്കിലും എളുപ്പത്തിൽ ഓൺ ചെയ്യാനും ഓഫ് ചെയ്യാനും കഴിയുന്നതും."
+"ഞങ്ങളുടെ നോ-ലോഗ്, വേഗതയേറിയ VPN ഉപയോഗിച്ച് നിങ്ങളുടെ ഓൺലൈൻ പ്രവർത്തനം "
+"സംരക്ഷിക്കൂ. സജ്ജീകരിക്കാൻ ലളിതവും എപ്പോൾ വേണമെങ്കിലും എളുപ്പത്തിൽ ഓൺ "
+"ചെയ്യാനും ഓഫ് ചെയ്യാനും കഴിയുന്നതും."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18840,7 +19057,9 @@ msgstr "DuckAssist <sup>BETA</sup> കാണിക്കുക"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും %1$sഓഫാക്കാം%2$s.)"
+msgstr ""
+"DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും "
+"%1$sഓഫാക്കാം%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19023,7 +19242,9 @@ msgstr "സൈഡ്ബാർ കാണിക്കുക"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Duck.ai പരമാവധി പ്രയോജനപ്പെടുത്തുന്നതിനുള്ള ഘട്ടം ഘട്ടമായുള്ള നുറുങ്ങുകൾ കാണിക്കുക."
+msgstr ""
+"Duck.ai പരമാവധി പ്രയോജനപ്പെടുത്തുന്നതിനുള്ള ഘട്ടം ഘട്ടമായുള്ള നുറുങ്ങുകൾ "
+"കാണിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19078,8 +19299,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. "
-"ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു "
+"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
+"കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19087,9 +19309,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ "
-"കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും "
-"ബാധിക്കുന്നില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു "
+"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
+"കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും ബാധിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19100,7 +19322,8 @@ msgstr "ഫല പേജ് ഇടവേളകളിൽ തിരശ്ചീന
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള ലിങ്കുകൾ കാണിക്കുന്നു"
+"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള "
+"ലിങ്കുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19117,21 +19340,23 @@ msgstr "പുതിയ ടാബ് പേജിൽ ഏറ്റവും ക�
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് ഇടയ്ക്കിടെയുള്ള "
-"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് "
+"ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19239,12 +19464,16 @@ msgstr "സൈറ്റുകളുടെ പേരുകൾ"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ പ്രവർത്തിക്കുന്നു."
+msgstr ""
+"സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ "
+"പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും മറയ്ക്കും"
+msgstr ""
+"നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും "
+"മറയ്ക്കും"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19391,7 +19620,7 @@ msgstr "എന്തോ കുഴപ്പം സംഭവിച്ചു"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "ഈ പങ്കിട്ട ചാറ്റ് ലോഡ് ചെയ്യുന്നതിൽ എന്തോ കുഴപ്പം സംഭവിച്ചു."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19404,7 +19633,8 @@ msgstr "സെർവറിലേക്ക് സംരക്ഷിക്കു�
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
 msgstr ""
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി വീണ്ടും ശ്രമിക്കുക."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19435,8 +19665,8 @@ msgstr "ചിലപ്പോൾ"
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
 msgstr ""
-"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു രീതിയിൽ "
-"വിവരിക്കുക."
+"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു "
+"രീതിയിൽ വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19475,8 +19705,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി മറ്റൊരു ചിത്രമോ "
-"ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
+"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി "
+"മറ്റൊരു ചിത്രമോ ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19485,16 +19715,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ ചെയ്തതെന്ന് "
-"ഉറപ്പാക്കുക."
+"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ "
+"ചെയ്തതെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. നിങ്ങൾക്ക് Duck.ai-യോട് "
-"ചോദിക്കാൻ ശ്രമിക്കാം."
+"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. "
+"നിങ്ങൾക്ക് Duck.ai-യോട് ചോദിക്കാൻ ശ്രമിക്കാം."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19503,15 +19733,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. വീണ്ടും ശ്രമിക്കാൻ "
-"%1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
+"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. "
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19566,8 +19797,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും "
-"ശ്രമിക്കൂ."
+"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് "
+"തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19772,7 +20003,9 @@ msgstr "DuckDuckGo-യിൽ തുടരുക"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും അറിവുള്ളവരായും തുടരുക."
+msgstr ""
+"ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും "
+"അറിവുള്ളവരായും തുടരുക."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19822,7 +20055,9 @@ msgstr "സൃഷ്ടിക്കൽ നിർത്തുക"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ പ്രതിരോധിക്കുക."
+msgstr ""
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ "
+"പ്രതിരോധിക്കുക."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -19917,8 +20152,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, അല്ലെങ്കിൽ "
-"കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
+"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, "
+"അല്ലെങ്കിൽ കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19987,8 +20222,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ എഴുതാൻ ഒരു വാക്യം "
-"നിർദ്ദേശിക്കാമോ?"
+"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ "
+"എഴുതാൻ ഒരു വാക്യം നിർദ്ദേശിക്കാമോ?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20245,7 +20480,7 @@ msgstr "മോഡൽ മാറ്റുക"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "മോഡൽ മാറ്റുക"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20324,7 +20559,9 @@ msgstr "%1$sഎന്നതിലേക്ക് മാറി"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് അയയ്ക്കും"
+msgstr ""
+"മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് "
+"അയയ്ക്കും"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20378,7 +20615,9 @@ msgstr "Sync & Backup പ്രവർത്തനക്ഷമമാക്കി!
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ കഴിയില്ല."
+msgstr ""
+"Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20427,25 +20666,27 @@ msgid ""
 msgstr ""
 "വീണ്ടെടുക്കൽ കോഡ് സമന്വയിപ്പിക്കുക\n"
 "\n"
-" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, ഡാറ്റ ഓട്ടോഫിൽ "
-"ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ "
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
+" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, "
+"ഡാറ്റ ഓട്ടോഫിൽ ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു "
+"ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ നിങ്ങളുടെ സമന്വയിപ്പിച്ച "
+"ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
 "\n"
 "ഈ വിവരങ്ങൾ സുരക്ഷിതമായി സൂക്ഷിക്കുക.\n"
-"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ കഴിയും.\n"
+"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ "
+"കഴിയും.\n"
 "\n"
 "%1$s\n"
 "\n"
 "ഈ കോഡ് എങ്ങനെയാണ് പ്രവർത്തിക്കുന്നത്?\n"
 "1. നിങ്ങളുടെ ബ്രൗസറിൽ Duck.ai-ലേക്ക് പോയി Duck.ai സെറ്റിംഗ്സ് തുറക്കുക.\n"
-"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കുക\" "
-"തിരഞ്ഞെടുക്കുക.\n"
-"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" എന്ന് പറയുന്നിടത്ത് "
-"ഒട്ടിക്കുക.\n"
+"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ "
+"വീണ്ടെടുക്കുക\" തിരഞ്ഞെടുക്കുക.\n"
+"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" "
+"എന്ന് പറയുന്നിടത്ത് ഒട്ടിക്കുക.\n"
 "\n"
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ 18 "
-"മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് ഇല്ലാതാക്കപ്പെടും, അത് "
-"പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ "
+"18 മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് "
+"ഇല്ലാതാക്കപ്പെടും, അത് പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20506,7 +20747,7 @@ msgstr "സമന്വയിപ്പിച്ച ഉപകരണങ്ങൾ"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "%1$s-ൽ സമന്വയിപ്പിച്ചു"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20544,7 +20785,7 @@ msgstr "ടിവി"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "പട്ടിക"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20578,8 +20819,9 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെയായിരുന്നാലും വേഗത്തിൽ ആക്സസ് "
-"ചെയ്യുന്നതിന് ഞങ്ങളുടെ സൗജന്യ ആപ്പിൽ ഇത് ബിൽറ്റ് ഇൻ ചെയ്ത് നേടൂ."
+"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെയായിരുന്നാലും "
+"വേഗത്തിൽ ആക്സസ് ചെയ്യുന്നതിന് ഞങ്ങളുടെ സൗജന്യ ആപ്പിൽ ഇത് ബിൽറ്റ് ഇൻ ചെയ്ത് "
+"നേടൂ."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20588,8 +20830,9 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെ ബ്രൗസ് ചെയ്യുമ്പോഴും വേഗത്തിലുള്ള "
-"ആക്സസിനായി ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ ഇത് ഉൾപ്പെടുത്തൂ."
+"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെ ബ്രൗസ് "
+"ചെയ്യുമ്പോഴും വേഗത്തിലുള്ള ആക്സസിനായി ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ ഇത് "
+"ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20612,7 +20855,9 @@ msgstr "നിങ്ങളുടെ സ്വകാര്യ ഡാറ്റയ�
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ പങ്കെടുക്കൂ."
+msgstr ""
+"Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ "
+"പങ്കെടുക്കൂ."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20833,9 +21078,10 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ ഒരു മൂന്നാം "
-"കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ "
-"പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ ഉൾപ്പെടുന്നു."
+"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ "
+"ഒരു മൂന്നാം കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. "
+"അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ "
+"ഉൾപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20844,8 +21090,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ സംരക്ഷിക്കാൻ Cloud Save "
-"ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
+"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ "
+"സംരക്ഷിക്കാൻ Cloud Save ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20875,15 +21121,17 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ "
-"നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
+"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ "
+"സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് ഇല്ലാതാക്കും."
+msgstr ""
+"ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് "
+"ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20956,9 +21204,9 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക ഡാറ്റ സംഭരണം "
-"പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ "
-"പരിശോധിക്കുക."
+"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക "
+"ഡാറ്റ സംഭരണം പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി "
+"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20973,8 +21221,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ വീണ്ടും ശ്രമിക്കുന്നതിന് "
-"മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
+"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ "
+"വീണ്ടും ശ്രമിക്കുന്നതിന് മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20993,10 +21241,10 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ എൻക്രിപ്റ്റ് "
-"ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും "
-"നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ "
-"ഉപയോഗിക്കുന്നു."
+"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ "
+"എൻക്രിപ്റ്റ് ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ "
+"എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ "
+"സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ ഉപയോഗിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21042,8 +21290,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ പതിപ്പിൽ ഒരു പുതിയ "
-"ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
+"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ "
+"പതിപ്പിൽ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21073,7 +21321,9 @@ msgstr "ഈ ആഴ്ച"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr "ഈ ചാറ്റ് Duck.ai-യിൽ തന്നെ തുടരുകയും നിങ്ങൾക്ക് സ്വകാര്യമായിരിക്കുകയും ചെയ്യും."
+msgstr ""
+"ഈ ചാറ്റ് Duck.ai-യിൽ തന്നെ തുടരുകയും നിങ്ങൾക്ക് സ്വകാര്യമായിരിക്കുകയും "
+"ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21082,9 +21332,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
-"ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
+"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം "
+"(കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21094,9 +21344,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
-"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%2$s കാണുക)."
+"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
+"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21105,8 +21355,9 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI കൃത്യതയില്ലാത്തതോ "
-"കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
+"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
+"കൃത്യതയില്ലാത്തതോ കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് "
+"%2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21116,15 +21367,15 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
-"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ "
-"വിവരങ്ങൾക്ക് %4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ "
+"സംഭാഷണം സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "ഈ ഉപകരണം"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21135,6 +21386,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"മറ്റ് ഉപകരണങ്ങളിലുള്ള നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ ഈ "
+"ഉപകരണത്തിന് ഇനി കഴിയില്ല. അവസാന %1$s ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ "
+"ലഭ്യമാകും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21166,7 +21420,9 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ചുചെയ്യുക"
+msgstr ""
+"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s "
+"അറ്റാച്ചുചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21174,7 +21430,9 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് ചെയ്യുക."
+msgstr ""
+"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21206,7 +21464,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക"
+"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
+"ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21214,7 +21473,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക."
+"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
+"ചേർക്കുക."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21225,7 +21485,7 @@ msgstr "ഈ വിവരങ്ങൾ ഉപയോഗപ്രദമല്ല"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "ഇത് ഒരു പങ്കിട്ട ചാറ്റിന്റെ പകർപ്പാണ്."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21234,8 +21494,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. നിങ്ങളുടെ ചാറ്റുകളുടെ മുകളിൽ നിലനിർത്താൻ ഇതിന്റെ മെനു (മൂന്ന് "
-"ഡോട്ടുകൾ) തുറന്ന് പിൻ തിരഞ്ഞെടുക്കുക!"
+"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. നിങ്ങളുടെ ചാറ്റുകളുടെ മുകളിൽ നിലനിർത്താൻ "
+"ഇതിന്റെ മെനു (മൂന്ന് ഡോട്ടുകൾ) തുറന്ന് പിൻ തിരഞ്ഞെടുക്കുക!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21244,7 +21504,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. ഇത് ഇല്ലാതാക്കാൻ വശത്തുള്ള മെനുവിലെ Fire Button ഉപയോഗിക്കുക!"
+"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. ഇത് ഇല്ലാതാക്കാൻ വശത്തുള്ള മെനുവിലെ Fire "
+"Button ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21265,8 +21526,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ ഇല്ലാതാക്കും. മറ്റ് മോഡൽ "
-"ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ "
+"ഇല്ലാതാക്കും. മറ്റ് മോഡൽ ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21275,8 +21536,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് മോഡൽ ദാതാക്കൾ ഒരു "
-"പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് "
+"മോഡൽ ദാതാക്കൾ ഒരു പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21313,8 +21574,9 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് "
-"സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് ആക്‌സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് "
+"എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് "
+"ആക്‌സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21323,8 +21585,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
-"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
+"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
+"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21334,22 +21597,22 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
-"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. "
-"എന്നിരുന്നാലും, %1$s-ൽ AI സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും "
-"ഞങ്ങൾക്ക് ഉണ്ട്."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
+"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
+"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. എന്നിരുന്നാലും, %1$s-ൽ AI "
+"സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും ഞങ്ങൾക്ക് ഉണ്ട്."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "ഈ പങ്കിട്ട ചാറ്റ് തുറക്കാനായില്ല. ലിങ്ക് അപൂർണ്ണമായിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "ഈ പങ്കുവെച്ച ചാറ്റ് ലിങ്ക് ഇനി ലഭ്യമല്ല."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21378,7 +21641,9 @@ msgstr "ഈ വീഡിയോ ഇതുവരെ ഇവിടെ കാണാ�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) ഉപയോഗിക്കുന്നില്ല."
+msgstr ""
+"ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) "
+"ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21388,9 +21653,10 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും Sync & Backup "
-"വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ "
-"നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും "
+"Sync & Backup വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് "
+"ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് "
+"ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21399,8 +21665,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. ഇത് "
-"പഴയപടിയാക്കാനാവില്ല."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. "
+"ഇത് പഴയപടിയാക്കാനാവില്ല."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21419,7 +21685,8 @@ msgstr "ഇത് എല്ലാ ക്രമീകരണവും മായ്
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
 msgstr ""
-"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് പുനഃക്രമീകരിക്കും. തുടരണോ?"
+"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് "
+"പുനഃക്രമീകരിക്കും. തുടരണോ?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21516,7 +21783,9 @@ msgstr "ശീർഷക അടിവര"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr "മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ ചേർക്കാൻ:"
+msgstr ""
+"മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ "
+"ചേർക്കാൻ:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -21539,8 +21808,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് ചെയ്യേണ്ട റൂട്ട് "
-"തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
+"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് "
+"ചെയ്യേണ്ട റൂട്ട് തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21550,9 +21819,10 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം സജ്ജമാക്കുമ്പോൾ "
-"സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച "
-"ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് ചെയ്‌തിരിക്കാം."
+"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം "
+"സജ്ജമാക്കുമ്പോൾ സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം "
+"സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് "
+"ചെയ്‌തിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21561,8 +21831,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും പുതിയ "
-"പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും "
+"പുതിയ പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21570,8 +21840,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യാൻ "
-"അനുവദിക്കുക."
+"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ "
+"ആക്‌സസ് ചെയ്യാൻ അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21594,8 +21864,8 @@ msgstr "ഇന്ന്"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"സ്വകാര്യ AI ചാറ്റ് പരീക്ഷിക്കാൻ ടോഗിൾ ചെയ്യുക, അല്ലെങ്കിൽ %1$s %2$s മെനുവിൽ ഇത് "
-"പ്രവർത്തനരഹിതമാക്കുക.%3$s"
+"സ്വകാര്യ AI ചാറ്റ് പരീക്ഷിക്കാൻ ടോഗിൾ ചെയ്യുക, അല്ലെങ്കിൽ %1$s %2$s മെനുവിൽ "
+"ഇത് പ്രവർത്തനരഹിതമാക്കുക.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21769,8 +22039,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം ബ്ലോക്ക് ചെയ്യുന്നു "
-"എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
+"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം "
+"ബ്ലോക്ക് ചെയ്യുന്നു എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21818,8 +22088,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
-"എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
+"ഞാൻ എങ്ങനെ എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21828,8 +22098,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
-"എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
+"ഞാൻ എങ്ങനെ എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21994,7 +22264,7 @@ msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22077,8 +22347,8 @@ msgstr "വ്യത്യസ്ത കീവേഡുകൾ പരീക്ഷ�
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ പ്രവർത്തനരഹിതമാക്കാൻ "
-"ശ്രമിക്കുക."
+"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ "
+"പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22115,7 +22385,7 @@ msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22143,7 +22413,9 @@ msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ പലതും."
+msgstr ""
+"സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ "
+"പലതും."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22276,7 +22548,8 @@ msgstr "അടുത്തിടെ ചേർത്തിട്ടുള്ള o
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
 msgstr ""
-"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
+"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ "
+"സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22310,8 +22583,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
-"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. "
+"%3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22320,8 +22594,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
-"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. %3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. "
+"%3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22363,7 +22638,7 @@ msgstr "തുർക്ക്മെനിസ്ഥാൻ"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "ഓഫ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22381,7 +22656,7 @@ msgstr "Sync & Backup ഓഫ് ചെയ്യുക"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Sync & Backup ഓഫ് ചെയ്ത് സെർവർ ഡാറ്റ ഇല്ലാതാക്കണോ?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22522,8 +22797,9 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് തിരയലിനും ഉത്തരം "
-"കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് കാരണമായേക്കാം."
+"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് "
+"തിരയലിനും ഉത്തരം കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് "
+"കാരണമായേക്കാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22621,13 +22897,17 @@ msgstr "ഫീഡ് ബാക്ക് അയയ്ക്കുവാൻ സാ
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr "നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -22653,8 +22933,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് ക്ലിക്ക് "
-"ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് "
+"ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22662,21 +22942,22 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ ചെയ്യുക: "
-"https://duckduckgo.com"
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ "
+"ചെയ്യുക: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
 msgstr ""
-"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ പേജുകൾ%4$s "
-"തിരഞ്ഞെടുക്കുക"
+"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ "
+"പേജുകൾ%4$s തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: https://duckduckgo.com"
+"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22687,30 +22968,32 @@ msgstr "%1$sതിരയൽ ക്രമീകരണം%2$s എന്നതി�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
 msgstr ""
-"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s "
+"എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s ക്ലിക്ക് "
-"ചെയ്യുക"
+"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s "
+"ക്ലിക്ക് ചെയ്യുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
 msgstr ""
-"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ തുറക്കുക%2$s "
-"എന്നത് തിരഞ്ഞെടുക്കുക"
+"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ "
+"തുറക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22788,8 +23071,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് പ്ലാനിനേക്കാൾ 2 മടങ്ങ് "
-"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
+"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് "
+"പ്ലാനിനേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22811,7 +23094,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും അൺലോക്ക് ചെയ്യുക"
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും "
+"അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22842,7 +23126,9 @@ msgstr "നൂതന മോഡലുകൾ അൺലോക്ക് ചെയ്
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr "DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് ചെയ്യുക"
+msgstr ""
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -22850,7 +23136,9 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് ചെയ്യുക. %1$s"
+msgstr ""
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് "
+"ചെയ്യുക. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -22868,7 +23156,7 @@ msgstr "അൺമ്യൂട്ട് ചെയ്യുക"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "തലക്കെട്ടില്ലാത്ത ചാറ്റ്"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22909,7 +23197,7 @@ msgstr "ബ്രൗസർ അപ്ഡേറ്റ് ചെയ്യുക"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "ഈ പങ്കിട്ട ചാറ്റ് കാണാൻ Duck.ai അപ്ഡേറ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22948,8 +23236,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് ചെയ്യാനും DuckDuckGo "
-"ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
+"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് "
+"ചെയ്യാനും DuckDuckGo ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23074,15 +23362,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക, "
-"അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
+"ചെയ്യുക, അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക"
+"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23178,9 +23467,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, സ്കാമർമാരിൽ "
-"നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. "
-"സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
+"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, "
+"സ്കാമർമാരിൽ നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. "
+"വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23193,8 +23482,8 @@ msgstr "DuckDuckGo Private Search ഉപയോഗിക്കുക"
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
 msgstr ""
-"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private search "
-"ഉപയോഗിക്കുക!"
+"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private "
+"search ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23237,8 +23526,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
-"ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ "
+"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23246,8 +23535,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
-"ഉപയോഗിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ "
+"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23397,8 +23686,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ ക്ലിക്കുകൾ "
-"നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ "
+"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23407,8 +23696,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ ക്ലിക്കുകൾ "
-"നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ "
+"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23420,8 +23709,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sAssist "
-"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
+"%1$sAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23430,8 +23719,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sDuckAssist "
-"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
+"%1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23440,8 +23729,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ നിർദേശങ്ങൾ "
-"പാലിക്കുക."
+"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ "
+"നിർദേശങ്ങൾ പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23456,9 +23745,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & "
-"Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > "
+"%3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23468,9 +23757,10 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & "
-"Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" "
-"തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
+"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
+"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23480,9 +23770,10 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, %1$sDuck.ai "
-"ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നിടത്ത് "
-"%7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, "
+"%1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് "
+"ചെയ്യുക%6$s എന്നിടത്ത് %7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23492,9 +23783,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
-"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai "
+"ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" "
+"തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. "
+"അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23547,8 +23839,8 @@ msgstr "വോയ്സ് ചാറ്റ് അവസാനിച്ചു"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിച്ചിട്ടില്ല."
+"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിച്ചിട്ടില്ല."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23692,8 +23984,9 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച പ്രവർത്തനത്തെ YouTube "
-"ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck Player-ൽ കാണുക."
+"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച "
+"പ്രവർത്തനത്തെ YouTube ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck "
+"Player-ൽ കാണുക."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23713,10 +24006,11 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് "
-"ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. "
-"DuckDuckGo ഒരു സ്വതന്ത്ര കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി "
-"യാതൊരു ബന്ധവുമില്ല."
+"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന "
+"വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ "
+"നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. DuckDuckGo ഒരു സ്വതന്ത്ര "
+"കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി യാതൊരു "
+"ബന്ധവുമില്ല."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23729,8 +24023,8 @@ msgstr "ഞങ്ങൾ അജ്ഞാതമാക്കുന്നു"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ ലൊക്കേഷൻ%2$s "
-"അജ്ഞാതമാക്കാൻ കഴിയും."
+"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ "
+"ലൊക്കേഷൻ%2$s അജ്ഞാതമാക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23742,9 +24036,10 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
-"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി പങ്കിടുക, അതുവഴി "
-"ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി "
+"പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23756,17 +24051,18 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
-"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രതികരണവും പങ്കിടുക, അതുവഴി "
-"ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും "
+"പ്രതികരണവും പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s ലൊക്കേഷൻ%2$s "
-"ഉപയോഗിക്കാനാകും."
+"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s "
+"ലൊക്കേഷൻ%2$s ഉപയോഗിക്കാനാകും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -23774,8 +24070,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ ഞങ്ങൾക്ക് അവ "
-"വായിക്കാൻ കഴിയില്ല."
+"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ "
+"ഞങ്ങൾക്ക് അവ വായിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23786,13 +24082,16 @@ msgstr "പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്�
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ സംഭരിക്കുന്നില്ല."
+msgstr ""
+"ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ "
+"സംഭരിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ ഇല്ല. എപ്പോഴും."
+"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ "
+"ഇല്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23804,8 +24103,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്ങളെ "
-"പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
+"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ "
+"നിങ്ങളെ പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23819,8 +24118,9 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ കൊണ്ടുവന്നത് എന്താണെന്ന് "
-"ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ "
+"കൊണ്ടുവന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് "
+"ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23829,8 +24129,9 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ നിങ്ങൾക്ക് "
-"ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ "
+"നിങ്ങൾക്ക് ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം "
+"ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23841,7 +24142,9 @@ msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ നയം."
+msgstr ""
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ "
+"നയം."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23870,8 +24173,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ ഉടനീളം "
-"പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
+"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ "
+"ഉടനീളം പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23897,6 +24200,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ "
+"കണ്ടെത്തി നീക്കം ചെയ്യുന്നു. Plus, ഒരു VPN-ഉം അതിലധികവും നേടൂ."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23905,8 +24210,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് ഉറപ്പാക്കാൻ എല്ലാ AI "
-"ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
+"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് "
+"ഉറപ്പാക്കാൻ എല്ലാ AI ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23923,7 +24228,9 @@ msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെ�
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ ശ്രമിക്കൂ."
+msgstr ""
+"ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ "
+"ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -23931,8 +24238,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന തിരയൽ "
-"പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
+"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന "
+"തിരയൽ പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23941,8 +24248,9 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ലൊക്കേഷൻ "
-"ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത "
+"ലൊക്കേഷൻ ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് "
+"മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -23951,18 +24259,24 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾക്കായി ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകൾ പതിവായി "
+"സ്കാൻ ചെയ്യുകയും, ഉപയോഗിക്കാൻ എളുപ്പമുള്ള ഡാഷ്‌ബോർഡിൽ ഞങ്ങളുടെ പുരോഗതി "
+"നിങ്ങളുമായി പങ്കിടുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ ആശ്രയിക്കുന്നു."
+"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ "
+"ആശ്രയിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ തടയുന്നു."
+msgstr ""
+"ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ "
+"തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23978,15 +24292,16 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ "
-"വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം "
-"ദൃശ്യമാകണമെന്നില്ല."
+"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് "
+"ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ "
+"സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം ദൃശ്യമാകണമെന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
+"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന "
+"ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -23995,6 +24310,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും മറ്റും ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ "
+"സൈറ്റുകളിൽ സ്കാൻ ചെയ്യുകയും, നിങ്ങളെക്കുറിച്ച് കണ്ടെത്തുന്നത് നീക്കം ചെയ്യാൻ "
+"പ്രവർത്തിക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24004,8 +24322,8 @@ msgid ""
 "continue to see this error, please reach out to %s."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, ദയവായി %1$s-നെ "
-"സമീപിക്കുക."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, "
+"ദയവായി %1$s-നെ സമീപിക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24015,7 +24333,8 @@ msgid ""
 "clearing your browser's cache can help."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ മായ്ക്കുന്നത് സഹായിക്കാം."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ "
+"മായ്ക്കുന്നത് സഹായിക്കാം."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24030,8 +24349,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ ഞങ്ങൾ കഠിനമായി "
-"പരിശ്രമിക്കുന്നു."
+"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ "
+"ഞങ്ങൾ കഠിനമായി പരിശ്രമിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24040,8 +24359,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് വീണ്ടും ലോഡ് "
-"ചെയ്യേണ്ടതുണ്ട്."
+"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് "
+"വീണ്ടും ലോഡ് ചെയ്യേണ്ടതുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24149,7 +24468,9 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24163,8 +24484,9 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഞങ്ങൾ "
-"അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
+"സ്വകാര്യമാണ്, അവ ഞങ്ങൾ അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24173,9 +24495,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ "
-"ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ "
-"ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
+"സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24185,16 +24507,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s ആണ്. "
-"ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s "
+"ആണ്. ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും "
+"DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്യാം."
+"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ "
+"ഇംപോർട്ട് ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24262,8 +24585,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. "
-"പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
+"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു "
+"പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24278,8 +24601,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും പ്രതിവാദങ്ങളും "
-"എന്തൊക്കെയാണ്?"
+"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും "
+"പ്രതിവാദങ്ങളും എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24300,8 +24623,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' എന്ന വാക്കിനുള്ള ചില "
-"ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
+"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' "
+"എന്ന വാക്കിനുള്ള ചില ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24313,7 +24636,7 @@ msgstr "ആന്വിറ്റികളുടെ ചില ഗുണങ്ങ�
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Duck.ai-യുടെ പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24326,11 +24649,12 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് ചെയ്യുന്നതിന്റെ "
-"പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ മാത്രം അവലംബിക്കുന്നു. Duck.ai "
-"സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് "
-"പ്രതികരണത്തെ വ്യക്തമായ വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം "
-"കൂടുതലുള്ളവർക്കും ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
+"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് "
+"ചെയ്യുന്നതിന്റെ പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ "
+"മാത്രം അവലംബിക്കുന്നു. Duck.ai സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും "
+"ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് പ്രതികരണത്തെ വ്യക്തമായ "
+"വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം കൂടുതലുള്ളവർക്കും "
+"ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24416,7 +24740,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
 msgstr ""
-"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ എന്തൊക്കെയാണ്?"
+"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ "
+"എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24567,8 +24892,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ "
-"വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
+"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ "
+"ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24644,7 +24969,8 @@ msgstr "നിങ്ങൾ എന്തിനെക്കുറിച്ചാ�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കില്ല."
+"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
+"സ്വാധീനിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24670,8 +24996,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന "
-"ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
+"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ "
+"പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24695,7 +25021,8 @@ msgstr "<strong>%1$s</strong> എവിടെ കാണാം"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
 msgstr ""
-"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
+"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s "
+"എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24736,7 +25063,8 @@ msgstr "ആരാണ് ഞങ്ങൾ"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
-"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് അറിയപ്പെടുന്നത്?"
+"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് "
+"അറിയപ്പെടുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24874,9 +25202,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai ഉപയോഗിച്ച്, നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കപ്പെടുന്നു, കൂടാതെ AI പരിശീലിപ്പിക്കാൻ "
-"ഒരിക്കലും ഉപയോഗിക്കില്ല. '%1$s' മെനുവിൽ എപ്പോൾ വേണമെങ്കിലും ഇത് ഓണാക്കുകയോ ഓഫാക്കുകയോ "
-"ചെയ്യാം."
+"Duck.ai ഉപയോഗിച്ച്, നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കപ്പെടുന്നു, കൂടാതെ AI "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല. '%1$s' മെനുവിൽ എപ്പോൾ വേണമെങ്കിലും "
+"ഇത് ഓണാക്കുകയോ ഓഫാക്കുകയോ ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24891,6 +25219,9 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"ഡാറ്റ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും "
+"അതിലേറെയും നീക്കം ചെയ്യാൻ നിങ്ങളുടെ ഉപകരണത്തിൽ നിന്ന് നേരിട്ട് "
+"പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25139,7 +25470,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് "
+"വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25159,8 +25491,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
+"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25169,8 +25501,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ DuckDuckGo-യിൽ നിന്ന് മറ്റ് "
-"തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
+"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ "
+"DuckDuckGo-യിൽ നിന്ന് മറ്റ് തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25184,8 +25516,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ ക്രമീകരണങ്ങൾ%3$s-ൽ "
-"എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
+"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ "
+"ക്രമീകരണങ്ങൾ%3$s-ൽ എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25194,21 +25526,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s-ൽ അത് "
-"എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
+"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ "
+"ക്രമീകരണങ്ങൾ%2$s-ൽ അത് എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s ഉപയോഗിക്കാം."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s "
+"ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI Chat%2$s "
-"ഉപയോഗിക്കാനും കഴിയും."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI "
+"Chat%2$s ഉപയോഗിക്കാനും കഴിയും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25222,8 +25555,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist കാണണമെന്നത് "
-"മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
+"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist "
+"കാണണമെന്നത് മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25244,8 +25577,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു പാസ്‌ഫ്രെയ്സിന് കീഴിൽ "
-"സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
+"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു "
+"പാസ്‌ഫ്രെയ്സിന് കീഴിൽ സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25275,7 +25608,8 @@ msgstr "നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉ
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് തുടർന്നോളൂ!"
+"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് "
+"തുടർന്നോളൂ!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25339,8 +25673,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം മറ്റൊരു സൈറ്റ് "
-"അൺബ്ലോക്ക് ചെയ്യണം."
+"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം "
+"മറ്റൊരു സൈറ്റ് അൺബ്ലോക്ക് ചെയ്യണം."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25376,7 +25710,9 @@ msgstr "നിങ്ങൾക്ക് ഈ പുതിയ ഡൊമെയ്ന
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ സൂക്ഷിക്കാം."
+msgstr ""
+"പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ "
+"സൂക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -25395,7 +25731,7 @@ msgstr "നിങ്ങൾക്ക് 1 ശ്രമം ശേഷിക്ക�
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "നിങ്ങൾക്ക് പങ്കുവെച്ച ചാറ്റ് ലിങ്കുകളൊന്നുമില്ല."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25404,8 +25740,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, Plus-നേക്കാൾ 2 മടങ്ങ് "
-"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
+"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, "
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25414,8 +25750,9 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് DuckDuckGo ബ്രൗസറിൽ VPN, "
-"മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് ചെയ്യാം."
+"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് "
+"DuckDuckGo ബ്രൗസറിൽ VPN, മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് "
+"ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25437,9 +25774,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന "
-"30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് "
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് "
+"ചെയ്യാൻ കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. "
+"ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25449,9 +25786,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന 30 "
-"ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ "
-"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ "
+"കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് "
+"എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25465,8 +25802,8 @@ msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
 msgstr ""
-"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo ആപ്പ് അപ്ഡേറ്റുകൾ "
-"ലഭിക്കും."
+"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo "
+"ആപ്പ് അപ്ഡേറ്റുകൾ ലഭിക്കും."
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -25481,8 +25818,9 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് ചെയ്യുന്നതിന് Chrome-ന് "
-"പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് "
+"ചെയ്യുന്നതിന് Chrome-ന് പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം "
+"ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25495,8 +25833,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും കുറയ്ക്കുന്നതിന് "
-"നുറുങ്ങുകൾ നേടുക."
+"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും "
+"കുറയ്ക്കുന്നതിന് നുറുങ്ങുകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25546,8 +25884,8 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. ദയവായി വീണ്ടും "
-"ശ്രമിക്കുക."
+"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. "
+"ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25574,8 +25912,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം തീർന്നു. സമന്വയം "
-"പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം "
+"തീർന്നു. സമന്വയം പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ "
+"ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25586,8 +25925,8 @@ msgid ""
 "deleted."
 msgstr ""
 "Duck.ai ചാറ്റുകൾക്കുള്ള Sync & Backup സ്റ്റോറേജ് തീർന്നിരിക്കുന്നു. സമന്വയം "
-"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത "
-"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ "
+"ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25601,8 +25940,9 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ അനുവദിക്കുന്നില്ല. "
-"അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് YouTube/Google ട്രാക്ക് ചെയ്യും."
+"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ "
+"അനുവദിക്കുന്നില്ല. അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് "
+"YouTube/Google ട്രാക്ക് ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25624,6 +25964,8 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ "
+"ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -25631,6 +25973,8 @@ msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
 msgstr ""
+"നിങ്ങളുടെ Duck.ai ചാറ്റുകൾ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ "
+"സമന്വയിപ്പിക്കപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25662,6 +26006,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
+"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25671,9 +26017,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
-"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
-"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
+"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"%1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25683,9 +26029,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
-"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ 100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
-"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
+"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25701,7 +26047,9 @@ msgstr "നിങ്ങൾ ഈ ലിങ്ക് സന്ദർശിച്ച
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr "നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു."
+msgstr ""
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
+"നൽകുന്നു."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -25710,8 +26058,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു. DuckDuckGo-"
-"യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
+"നൽകുന്നു. DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25719,8 +26067,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. DuckDuckGo-യ്ക്ക് "
-"ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. "
+"DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25729,8 +26077,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
+"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25743,15 +26091,16 @@ msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോൾ 
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഒരിക്കലും സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"ഉപയോഗിക്കില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25777,8 +26126,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25786,8 +26135,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25802,9 +26151,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ "
-"പാലിക്കൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് "
+"അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ പാലിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25813,8 +26162,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി Duck.ai-ൽ നിർത്തിയിടത്ത് "
-"നിന്ന് തുടരൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി "
+"Duck.ai-ൽ നിർത്തിയിടത്ത് നിന്ന് തുടരൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25862,8 +26211,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കാറില്ല."
+"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25892,10 +26241,11 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് "
-"ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ "
-"ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-"
-"യ്ക്ക് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
+"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് "
+"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ "
+"ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ "
+"ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-യ്ക്ക് "
+"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25910,9 +26260,10 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി തിരിച്ചറിയാൻ "
-"കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ ദാതാക്കൾക്ക് നിങ്ങളുടെ "
-"സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ കഴിയില്ല."
+"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി "
+"തിരിച്ചറിയാൻ കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ "
+"ദാതാക്കൾക്ക് നിങ്ങളുടെ സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25926,8 +26277,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ പരിശോധിക്കാനോ "
-"എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ "
+"പരിശോധിക്കാനോ എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25959,8 +26310,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് അവയെ പുനഃസജ്ജമാക്കും. ഇത് "
-"സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ പ്രവർത്തനക്ഷമമാക്കുക."
+"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് "
+"അവയെ പുനഃസജ്ജമാക്കും. ഇത് സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ "
+"പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25969,9 +26321,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് അവയെ പുനഃസജ്ജമാക്കും. ഇത് "
-"സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ "
-"അറിയുക%4$s"
+"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് "
+"അവയെ പുനഃസജ്ജമാക്കും. ഇത് സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ "
+"ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ അറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25991,8 +26343,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി Chrome-ന് പകരം ഞങ്ങളുടെ "
-"ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി "
+"Chrome-ന് പകരം ഞങ്ങളുടെ ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ "
+"ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26001,8 +26354,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം ചുരുക്കി വീണ്ടും "
-"ശ്രമിക്കുക."
+"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം "
+"ചുരുക്കി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26011,8 +26364,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button ഉപയോഗിച്ച് ഈ "
-"സംഭാഷണം മായ്ക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button "
+"ഉപയോഗിച്ച് ഈ സംഭാഷണം മായ്ക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26021,7 +26374,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ "
+"ചാറ്റ് ആരംഭിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26036,8 +26390,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി നാളെ ഈ ചാറ്റ് "
-"തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി "
+"നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26340,8 +26694,8 @@ msgstr "ഔദ്യോഗിക വെബ്സൈറ്റ്"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു എന്‍കോഡ് ചെയ്ത %3$s "
-"പ്രതീകം ആണ്)."
+"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു "
+"എന്‍കോഡ് ചെയ്ത %3$s പ്രതീകം ആണ്)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/mn_MN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mn_MN/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr ""
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr ""
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4193,6 +4227,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4225,6 +4264,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4785,6 +4843,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4793,6 +4858,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -4999,6 +5071,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5646,6 +5724,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6308,9 +6392,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7401,6 +7498,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7485,6 +7589,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9069,6 +9178,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9586,6 +9700,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9791,6 +9911,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10093,6 +10218,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10249,6 +10379,11 @@ msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
+msgstr ""
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
 msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -11127,6 +11262,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11731,6 +11887,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11739,6 +11900,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11783,6 +11949,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12797,6 +12975,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12946,6 +13129,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13153,6 +13341,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13186,6 +13379,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13734,6 +13937,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14498,6 +14706,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14622,6 +14836,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14741,6 +14962,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15288,6 +15519,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15977,6 +16213,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16174,6 +16415,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16198,6 +16445,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16651,6 +16903,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16719,6 +16985,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16802,6 +17073,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17316,6 +17597,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17408,6 +17694,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17607,6 +17898,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17615,6 +17911,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -17992,6 +18293,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18019,6 +18325,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18785,6 +19096,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18819,6 +19137,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18843,6 +19168,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19087,6 +19419,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19549,6 +19886,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19949,6 +20293,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20113,6 +20463,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20130,6 +20495,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/mr_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mr_IN/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1181,6 +1199,11 @@ msgstr "%s मध्ये घाला"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr ""
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4196,6 +4230,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4228,6 +4267,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4788,6 +4846,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4796,6 +4861,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5002,6 +5074,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5649,6 +5727,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6319,9 +6403,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7412,6 +7509,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7496,6 +7600,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9081,6 +9190,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9598,6 +9712,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9803,6 +9923,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10105,6 +10230,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10262,6 +10392,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "मंद लाल"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11139,6 +11274,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11743,6 +11899,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11751,6 +11912,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11795,6 +11961,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12809,6 +12987,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12958,6 +13141,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13165,6 +13353,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13198,6 +13391,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13746,6 +13949,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14512,6 +14720,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14636,6 +14850,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14755,6 +14976,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15302,6 +15533,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15991,6 +16227,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16188,6 +16429,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16212,6 +16459,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16665,6 +16917,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16733,6 +16999,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16816,6 +17087,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17330,6 +17611,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17422,6 +17708,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17621,6 +17912,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17629,6 +17925,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18006,6 +18307,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18033,6 +18339,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18799,6 +19110,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18833,6 +19151,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18857,6 +19182,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19101,6 +19433,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19563,6 +19900,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19963,6 +20307,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20127,6 +20477,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20144,6 +20509,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/ms_MY/LC_MESSAGES/duckduckgo.po
+++ b/locales/ms_MY/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Tambah kepada %s"
 msgid "Add to Home Screen"
 msgstr "Tambah pada Skrin Utama"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Tambahan"
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4204,6 +4238,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4236,6 +4275,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4796,6 +4854,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4804,6 +4869,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5010,6 +5082,12 @@ msgstr "Tutup"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5657,6 +5735,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6319,9 +6403,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7415,6 +7512,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7499,6 +7603,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9088,6 +9197,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Pelajari %slagi%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9606,6 +9720,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9811,6 +9931,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10113,6 +10238,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Lebih lagi di"
@@ -10270,6 +10400,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Merah lembut"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11151,6 +11286,27 @@ msgstr ""
 "Pada Mac, %sKlik Maxthon > Tetapan%s, Pada Windows, %sKlik pada ikon %s > "
 "Tetapan%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11757,6 +11913,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11765,6 +11926,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11809,6 +11975,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12823,6 +13001,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12972,6 +13155,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13179,6 +13367,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13212,6 +13405,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13760,6 +13963,11 @@ msgstr "Menyimpan tetapan anda secara tanpa nama di awan"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14530,6 +14738,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14654,6 +14868,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14773,6 +14994,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15320,6 +15551,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16009,6 +16245,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16206,6 +16447,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16230,6 +16477,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16683,6 +16935,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16751,6 +17017,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16834,6 +17105,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17348,6 +17629,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17440,6 +17726,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17639,6 +17930,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17647,6 +17943,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18030,6 +18331,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18057,6 +18363,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18823,6 +19134,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18857,6 +19175,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18881,6 +19206,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19125,6 +19457,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19587,6 +19924,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19989,6 +20333,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20156,6 +20506,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20173,6 +20538,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% fullvaksinert"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% vaksinert"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -487,11 +495,19 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sFinn ut hvordan du kan holde lokasjonen din privat%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
+msgstr ""
+"%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -773,6 +789,12 @@ msgid "2nd in Group %s"
 msgstr "2. plass i gruppe %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -854,7 +876,8 @@ msgstr "6 timers bruksgrense er nådd."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr ""
+"6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1458,6 +1481,12 @@ msgid "Add to Home Screen"
 msgstr "Legg til på startskjermen"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Utvidelser"
@@ -1783,7 +1812,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
+msgstr ""
+"Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1820,6 +1850,13 @@ msgid "All types"
 msgstr "Alle typer"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1830,7 +1867,8 @@ msgstr "Tillat"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr "Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
+msgstr ""
+"Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1852,7 +1890,8 @@ msgstr "Vil du tillate anonym gjennomgang av filer i denne chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
+msgstr ""
+"Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2184,7 +2223,8 @@ msgstr "Er du der fortsatt?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
+msgstr ""
+"Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2337,6 +2377,12 @@ msgid "Ask anything privately"
 msgstr "Spør om hva som helst, privat"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2410,12 +2456,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere "
-"KI-assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner "
-"den nettet etter relevant innhold, og bruker deretter KI-drevet naturlig "
-"språk-teknologi til å generere et kort svar basert på relevant informasjon "
-"den har funnet. Det er viktig å huske at svarene genereres automatisk fra "
-"siterte kilder og er basert på %1$sgjennomsøking av nettet%2$s."
+"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere KI-"
+"assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner den "
+"nettet etter relevant innhold, og bruker deretter KI-drevet naturlig språk-"
+"teknologi til å generere et kort svar basert på relevant informasjon den har "
+"funnet. Det er viktig å huske at svarene genereres automatisk fra siterte "
+"kilder og er basert på %1$sgjennomsøking av nettet%2$s."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2516,7 +2562,8 @@ msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er avsluttet."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
+msgstr ""
+"Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2563,7 +2610,8 @@ msgstr "Autogenerert basert på oppførte kilder. Kan inneholde unøyaktigheter.
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
+msgstr ""
+"Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -3203,8 +3251,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Bruk nettleseren som vanlig, så legger vi til personvernbeskyttelse. Vi har "
-"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én "
-"%1$s%2$s-utvidelse%3$s."
+"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én %1$s%2$s-"
+"utvidelse%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3839,8 +3887,8 @@ msgid ""
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
 "Med chatten (via Duck.ai-tjenesten vår) kan du ha anonyme samtaler med "
-"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic "
-"m.m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
+"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic m."
+"m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
 "DuckDuckGo Search. Men du kan likevel få tilgang til chatten når denne "
 "innstillingen er av, ved å gå til %1$shttps.://duck.ai%2$s direkte."
 
@@ -3897,7 +3945,8 @@ msgstr "Chat privat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
+msgstr ""
+"Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4478,7 +4527,8 @@ msgstr "Klikk %1$sher%2$s for å laste ned DuckDuckGo-utvidelsen"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
+msgstr ""
+"Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4511,7 +4561,8 @@ msgstr "Klikk på %1$sInnstillinger%2$s i nedtrekksmenyen."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
+msgstr ""
+"Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5258,6 +5309,12 @@ msgid "Copy"
 msgstr "Kopier"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5297,6 +5354,28 @@ msgstr "Kopier eller lagre denne koden"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Kopier gjenopprettingskoden"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5967,13 +6046,22 @@ msgstr "Vil du slette de eldste chattene for å frigjøre lagringsplass?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
+msgstr ""
+"Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
 msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr "Vil du slette nylige chatter?"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -5988,10 +6076,19 @@ msgid "Deleted chats"
 msgstr "Slettede chatter"
 
 # smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr "Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
+msgstr ""
+"Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6081,7 +6178,8 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
+msgstr ""
+"Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6239,6 +6337,13 @@ msgstr "Avslå"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Lukk"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6422,8 +6527,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten "
-"AI-funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
+"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten AI-"
+"funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6825,8 +6930,8 @@ msgstr ""
 "Med Duck.ai kan du ha anonyme samtaler med tredjeparts AI-chatmodeller, som "
 "OpenAI, Anthropic og andre. Hvis du slår av denne innstillingen, skjules "
 "Duck.ai-knapper og -lenker på DuckDuckGo Search. Men du kan likevel få "
-"tilgang til Duck.ai når denne innstillingen er av, ved å gå til "
-"%1$shttps://duck.ai%2$s direkte."
+"tilgang til Duck.ai når denne innstillingen er av, ved å gå til %1$shttps://"
+"duck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7090,6 +7195,13 @@ msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo-nettleseren %1$s"
 
 # smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
 msgid "DuckDuckGo Instant Answer API"
 msgstr "DuckDuckGo øyeblikkelige svar-API"
@@ -7214,8 +7326,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du "
-"Duck.ai's %2$s."
+"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du Duck."
+"ai's %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7311,7 +7423,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
+msgstr ""
+"DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7589,7 +7702,8 @@ msgstr "Aktiver diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
+msgstr ""
+"Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7915,10 +8029,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "Fagmessig utformede produkter for folk som bryr seg om personvern."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Utløpt"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8287,7 +8416,8 @@ msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
+msgstr ""
+"Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8373,7 +8503,8 @@ msgstr "Søk nærmere der du er."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
+msgstr ""
+"Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8585,7 +8716,8 @@ msgstr "Kan deles og brukes kommersielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
+msgstr ""
+"Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9118,8 +9250,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Få vår raske VPN uten aktivitetslogger, valgfri tilgang til avanserte "
-"AI-modeller med høyere chattegrenser og flere førsteklasses beskyttelser."
+"Få vår raske VPN uten aktivitetslogger, valgfri tilgang til avanserte AI-"
+"modeller med høyere chattegrenser og flere førsteklasses beskyttelser."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9282,6 +9414,14 @@ msgstr ""
 "med en annen enhet%4$s. Eller skann QR-koden på gjenopprettings-PDF-en din."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -9390,6 +9530,12 @@ msgstr "Den er grei"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Den er grei"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10423,8 +10569,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt "
-"chat-svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
+"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt chat-"
+"svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -11364,6 +11510,12 @@ msgid "Learn %sMore%s"
 msgstr "Finn ut %1$smer%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11628,7 +11780,8 @@ msgstr "Lenker:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
+msgstr ""
+"Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11739,7 +11892,8 @@ msgstr "Laster flere bilderesultater når du ruller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
+msgstr ""
+"Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11993,6 +12147,13 @@ msgid "Manage"
 msgstr "Administrere"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12242,6 +12403,12 @@ msgstr "Meny"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Meny"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12502,7 +12669,8 @@ msgstr "Månedlig grense er nådd"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr ""
+"Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12608,6 +12776,12 @@ msgstr "Mer om !bangs"
 msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr "Mer om Duck.ai"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12802,6 +12976,12 @@ msgstr "Dempet"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Dempet rød"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13873,6 +14053,30 @@ msgstr ""
 "%4$s-ikonet > Innstillinger%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -13926,8 +14130,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"Bare innstillingene du har endret. De er spesifisert på siden "
-"%1$sURL-parameter%2$s."
+"Bare innstillingene du har endret. De er spesifisert på siden %1$sURL-"
+"parameter%2$s."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14622,6 +14826,12 @@ msgid "Past year"
 msgstr "Foregående år"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14632,6 +14842,12 @@ msgstr "Lim inn"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Lim inn Sync-kode"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14685,6 +14901,20 @@ msgstr "Stengt permanent"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persisk"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15729,7 +15959,8 @@ msgstr "Spør meg"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
+msgstr ""
+"Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15945,6 +16176,12 @@ msgid "Reading website…"
 msgstr "Leser nettsted…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -15984,7 +16221,8 @@ msgstr "Resonnering kan gi bedre svar på komplekse spørsmål."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Resonnering er grundigere, men når bruksgrensen 2–5 ganger raskere. %1$s"
+msgstr ""
+"Resonnering er grundigere, men når bruksgrensen 2–5 ganger raskere. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16040,8 +16278,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter som lagres lokalt på enheten din, i stedet for på "
-"DuckDuckGo-servere eller andre eksterne servere."
+"Nylige chatter som lagres lokalt på enheten din, i stedet for på DuckDuckGo-"
+"servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16050,8 +16288,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter lagres lokalt på enheten din i stedet for på "
-"DuckDuckGo-servere eller andre eksterne servere."
+"Nylige chatter lagres lokalt på enheten din i stedet for på DuckDuckGo-"
+"servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16132,6 +16370,12 @@ msgstr "Gjenoppretting"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Gjenopprettingskode"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16385,6 +16629,12 @@ msgid "Remove %s"
 msgstr "Fjern %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16425,6 +16675,18 @@ msgstr "Fjern den markerte teksten"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Fjern unødvendig tegnsetting"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17081,7 +17343,8 @@ msgstr "Lagre opptil 30 av de siste chattene lokalt på enheten din."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
+msgstr ""
+"Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17112,6 +17375,12 @@ msgstr "Lagre innstillingene dine anonymt i skyen"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Hils på Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17264,7 +17533,8 @@ msgstr "Rull ned til %1$sDuckDuckGo%2$s og la den bruke posisjonen din."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
+msgstr ""
+"Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17494,8 +17764,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke "
-"POST-forespørsler)"
+"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke POST-"
+"forespørsler)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17614,8 +17884,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
-"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
+"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17624,8 +17894,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
-"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
+"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17779,7 +18049,8 @@ msgstr "Se noen av våre nyeste oppdateringer"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
+msgstr ""
+"Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17933,7 +18204,8 @@ msgstr "Velg %1$sInnstillinger%2$s fra nedtrekksmenyen."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
+msgstr ""
+"Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17961,7 +18233,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
+msgstr ""
+"Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18100,6 +18373,13 @@ msgstr "Serbisk (kyrillisk)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Serbisk (latin)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18256,6 +18536,14 @@ msgid "Share"
 msgstr "Del"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18298,8 +18586,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Del plassering så nær som nærmeste by med AI-modeller for å forbedre "
-"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller "
-"AI-modeller."
+"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18403,6 +18691,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Fortell oss hva du synes om søkefeltet."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18810,12 +19110,14 @@ msgstr "Viser de mest besøkte lenkene på ny fane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
+msgstr ""
+"Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
+msgstr ""
+"Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19082,6 +19384,12 @@ msgid "Something went wrong"
 msgstr "Noe gikk galt"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19121,7 +19429,8 @@ msgstr "Noen ganger"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
+msgstr ""
+"Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19195,7 +19504,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
+msgstr ""
+"Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19249,7 +19559,8 @@ msgstr "Kildetekst fjernet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
+msgstr ""
+"Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19454,7 +19765,8 @@ msgstr "Bli på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
+msgstr ""
+"Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19924,6 +20236,12 @@ msgid "Switch model"
 msgstr "Bytt modell"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20056,7 +20374,8 @@ msgstr "Sync & Backup er aktivert!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
+msgstr ""
+"Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20105,9 +20424,9 @@ msgid ""
 msgstr ""
 "Synkroniseringsgjenopprettingskode\n"
 "\n"
-"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og "
-"Duck.ai-chatter på tvers av flere enheter, og gjenopprette synkroniserte "
-"data hvis du mister tilgangen til en enhet.\n"
+"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og Duck.ai-"
+"chatter på tvers av flere enheter, og gjenopprette synkroniserte data hvis "
+"du mister tilgangen til en enhet.\n"
 "\n"
 "Ta godt vare på denne informasjonen.\n"
 "Alle som har tilgang til denne koden kan få tilgang til de synkroniserte "
@@ -20180,6 +20499,13 @@ msgid "Synced Devices"
 msgstr "Synkroniserte enheter"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Syria"
 
@@ -20210,6 +20536,12 @@ msgstr "Kommer"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20529,7 +20861,8 @@ msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
+msgstr ""
+"De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -20551,7 +20884,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
+msgstr ""
+"Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20720,7 +21054,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
+msgstr ""
+"Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20753,9 +21088,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss "
-"%3$s-modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s "
-"for mer informasjon)."
+"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss %3$s-"
+"modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s for mer "
+"informasjon)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20790,6 +21125,22 @@ msgstr ""
 "Denne samtalen ble generert med DuckDuckGo AI Chat (%1$s) ved hjelp av %2$ss "
 "%3$s-modell. AI-chatter kan vise feil eller støtende informasjon (se %4$s "
 "for mer informasjon)."
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20860,19 +21211,27 @@ msgstr "Dette bildet kunne ikke opprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
+msgstr ""
+"Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
+msgstr ""
+"Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Denne informasjonen er ikke nyttig"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -20989,6 +21348,18 @@ msgstr ""
 "%1$s."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21009,7 +21380,8 @@ msgstr "Denne oversettelsen er feil"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
+msgstr ""
+"Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21200,8 +21572,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"For å overføre chat-historikken din til Duck.ai, oppdater "
-"DuckDuckGo-nettleseren din til den nyeste versjonen og prøv igjen."
+"For å overføre chat-historikken din til Duck.ai, oppdater DuckDuckGo-"
+"nettleseren din til den nyeste versjonen og prøv igjen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21628,6 +22000,12 @@ msgid "Try Free"
 msgstr "Prøv gratis"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21741,6 +22119,12 @@ msgstr "Prøv gratis"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Prøv gratis"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21988,6 +22372,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -21998,6 +22388,12 @@ msgstr "Slå av Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Slå av synkronisering og sikkerhetskopiering"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22290,8 +22686,8 @@ msgstr "Under %1$sÅpne med%2$s velger du %3$sEn spesifikk side eller sider%4$s"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: "
-"https://duckduckgo.com"
+"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22313,7 +22709,8 @@ msgstr "Under %1$sSøke%2$sseksjon trykker du på %3$sBehandle søkemotorer …%
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
+msgstr ""
+"Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22420,8 +22817,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Få tilgang til avanserte AI-modeller og høyere grenser med et "
-"DuckDuckGo-abonnement"
+"Få tilgang til avanserte AI-modeller og høyere grenser med et DuckDuckGo-"
+"abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22477,6 +22874,12 @@ msgid "Unmute"
 msgstr "Slå på lyden"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22510,6 +22913,12 @@ msgstr "Oppdater"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Oppdater nettleseren"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23053,9 +23462,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Gå til Duck.ai i den andre nettleseren din og så til "
-"%1$sDuck.ai-innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. "
-"Velg deretter %7$sSynkroniser med en annen enhet%8$s."
+"Gå til Duck.ai i den andre nettleseren din og så til %1$sDuck.ai-"
+"innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. Velg "
+"deretter %7$sSynkroniser med en annen enhet%8$s."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23091,8 +23500,8 @@ msgid ""
 msgstr ""
 "Gå til Duck.ai i nettleseren din eller i DuckDuckGo-appen, og åpne "
 "innstillingene for Duck.ai. Velg «Slå på» under Sync & Backup og velg "
-"«Synkroniser med en annen enhet». Eller skann QR-koden på "
-"gjenopprettings-PDF-en din."
+"«Synkroniser med en annen enhet». Eller skann QR-koden på gjenopprettings-"
+"PDF-en din."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23144,7 +23553,8 @@ msgstr "Talechatten er avsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
+msgstr ""
+"Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23380,7 +23790,8 @@ msgstr "Vi følger ikke etter deg med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
+msgstr ""
+"Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23484,6 +23895,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Vi avsluttet chatten på grunn av inaktivitet. Vil du prøve igjen?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23530,6 +23949,14 @@ msgstr ""
 "nærheten av deg. Du kan ombestemme deg senere."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23540,7 +23967,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
+msgstr ""
+"Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23563,7 +23991,16 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
+msgstr ""
+"Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23597,7 +24034,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
+msgstr ""
+"Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23707,7 +24145,8 @@ msgstr "Ukentlig bruksgrense er nådd"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr ""
+"Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23760,13 +24199,15 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
+msgstr ""
+"Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
+msgstr ""
+"Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -23874,6 +24315,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Hva er noen fordeler og ulemper med livrenter?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24444,6 +24891,14 @@ msgid "Without zero provider visibility"
 msgstr "Leverandøren har innsyn"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -24689,7 +25144,8 @@ msgstr "Ja, ny bruker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
+msgstr ""
+"Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24708,7 +25164,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
+msgstr ""
+"Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24894,7 +25351,8 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr "Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
+msgstr ""
+"Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24937,6 +25395,13 @@ msgstr "Du har %1$s forsøk igjen."
 msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Du har 1 forsøk igjen."
+
+# smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25037,7 +25502,8 @@ msgstr "Du søker nå med personvern!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr "Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
+msgstr ""
+"Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25086,7 +25552,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
+msgstr ""
+"Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25157,6 +25624,23 @@ msgid "YouTube Standard"
 msgstr "YouTube-standard"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "DuckDuckGo-søkehistorikken din er privat"
@@ -25178,6 +25662,14 @@ msgstr "Den faktiske plasseringen din forblir privat"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Den nøyaktige posisjonen din forblir privat."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25259,8 +25751,8 @@ msgstr "Chattene dine blir nå lagret."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Chattene dine er private og verken lagres eller brukes til å trene opp "
-"AI-modeller"
+"Chattene dine er private og verken lagres eller brukes til å trene opp AI-"
+"modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25292,8 +25784,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
-"AI-modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25301,8 +25793,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
-"AI-modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25403,11 +25895,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure "
-"Hash-algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den "
-"tilhørende innstillingsfilen som forlater nettleseren din. Vi lagrer "
-"innstillingsfilen ved å bruke nøkkelen som navn. DuckDuckGo vet aldri "
-"passordet ditt."
+"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure Hash-"
+"algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den tilhørende "
+"innstillingsfilen som forlater nettleseren din. Vi lagrer innstillingsfilen "
+"ved å bruke nøkkelen som navn. DuckDuckGo vet aldri passordet ditt."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25853,7 +26344,8 @@ msgstr "det offisielle nettstedet"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
+msgstr ""
+"eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (denne enheten)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -499,15 +499,14 @@ msgstr "%1$sFinn ut hvordan du kan holde lokasjonen din privat%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sFinn ut mer%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
+msgstr "%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -792,7 +791,7 @@ msgstr "2. plass i gruppe %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "Ny vurdering"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -876,8 +875,7 @@ msgstr "6 timers bruksgrense er nådd."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1484,7 +1482,7 @@ msgstr "Legg til på startskjermen"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Legg til i mine chatter"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1812,8 +1810,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
+msgstr "Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1854,7 +1851,7 @@ msgstr "Alle typer"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Alle enhetene dine er koblet fra synkronisering."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1867,8 +1864,7 @@ msgstr "Tillat"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
+msgstr "Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1890,8 +1886,7 @@ msgstr "Vil du tillate anonym gjennomgang av filer i denne chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
+msgstr "Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2223,8 +2218,7 @@ msgstr "Er du der fortsatt?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
+msgstr "Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2380,7 +2374,7 @@ msgstr "Spør om hva som helst, privat"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Spør om hva som helst, privat"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2456,12 +2450,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere KI-"
-"assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner den "
-"nettet etter relevant innhold, og bruker deretter KI-drevet naturlig språk-"
-"teknologi til å generere et kort svar basert på relevant informasjon den har "
-"funnet. Det er viktig å huske at svarene genereres automatisk fra siterte "
-"kilder og er basert på %1$sgjennomsøking av nettet%2$s."
+"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere "
+"KI-assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner "
+"den nettet etter relevant innhold, og bruker deretter KI-drevet naturlig "
+"språk-teknologi til å generere et kort svar basert på relevant informasjon "
+"den har funnet. Det er viktig å huske at svarene genereres automatisk fra "
+"siterte kilder og er basert på %1$sgjennomsøking av nettet%2$s."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2562,8 +2556,7 @@ msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er avsluttet."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
+msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2610,8 +2603,7 @@ msgstr "Autogenerert basert på oppførte kilder. Kan inneholde unøyaktigheter.
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
+msgstr "Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -3251,8 +3243,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Bruk nettleseren som vanlig, så legger vi til personvernbeskyttelse. Vi har "
-"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én %1$s%2$s-"
-"utvidelse%3$s."
+"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én "
+"%1$s%2$s-utvidelse%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3887,8 +3879,8 @@ msgid ""
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
 "Med chatten (via Duck.ai-tjenesten vår) kan du ha anonyme samtaler med "
-"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic m."
-"m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
+"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic "
+"m.m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
 "DuckDuckGo Search. Men du kan likevel få tilgang til chatten når denne "
 "innstillingen er av, ved å gå til %1$shttps.://duck.ai%2$s direkte."
 
@@ -3945,8 +3937,7 @@ msgstr "Chat privat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
+msgstr "Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4527,8 +4518,7 @@ msgstr "Klikk %1$sher%2$s for å laste ned DuckDuckGo-utvidelsen"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
+msgstr "Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4561,8 +4551,7 @@ msgstr "Klikk på %1$sInnstillinger%2$s i nedtrekksmenyen."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
+msgstr "Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5312,7 +5301,7 @@ msgstr "Kopier"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopier"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5361,13 +5350,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Kopier delt lenke"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Kopier koden fra en annen enhet"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5376,6 +5365,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Kopier koden fra en annen enhet. Gå til %1$sDuck.ai-innstillinger › Chatter "
+"› Sync & Backup › Synkroniser med en annen enhet%2$s og prøv igjen."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6046,8 +6037,7 @@ msgstr "Vil du slette de eldste chattene for å frigjøre lagringsplass?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
+msgstr "Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6061,7 +6051,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Slett den delte lenken"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6082,13 +6072,14 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Når en lenke slettes, slutter den å fungere. Personer som allerede har åpnet "
+"den og lagt til samtalen i chattene sine, beholder sin egen kopi."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
+msgstr "Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6178,8 +6169,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
+msgstr "Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6343,7 +6333,7 @@ msgstr "Lukk"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Lukk"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6527,8 +6517,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten AI-"
-"funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
+"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten "
+"AI-funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6930,8 +6920,8 @@ msgstr ""
 "Med Duck.ai kan du ha anonyme samtaler med tredjeparts AI-chatmodeller, som "
 "OpenAI, Anthropic og andre. Hvis du slår av denne innstillingen, skjules "
 "Duck.ai-knapper og -lenker på DuckDuckGo Search. Men du kan likevel få "
-"tilgang til Duck.ai når denne innstillingen er av, ved å gå til %1$shttps://"
-"duck.ai%2$s direkte."
+"tilgang til Duck.ai når denne innstillingen er av, ved å gå til "
+"%1$shttps://duck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7199,7 +7189,7 @@ msgstr "DuckDuckGo-nettleseren %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo-hjelpesider"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7326,8 +7316,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du Duck."
-"ai's %2$s."
+"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du "
+"Duck.ai's %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7423,8 +7413,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
+msgstr "DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7702,8 +7691,7 @@ msgstr "Aktiver diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
+msgstr "Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8033,7 +8021,7 @@ msgstr "Fagmessig utformede produkter for folk som bryr seg om personvern."
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Utløpt"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8047,7 +8035,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Utløper %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8416,8 +8404,7 @@ msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
+msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8503,8 +8490,7 @@ msgstr "Søk nærmere der du er."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
+msgstr "Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8716,8 +8702,7 @@ msgstr "Kan deles og brukes kommersielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
+msgstr "Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9250,8 +9235,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Få vår raske VPN uten aktivitetslogger, valgfri tilgang til avanserte AI-"
-"modeller med høyere chattegrenser og flere førsteklasses beskyttelser."
+"Få vår raske VPN uten aktivitetslogger, valgfri tilgang til avanserte "
+"AI-modeller med høyere chattegrenser og flere førsteklasses beskyttelser."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9420,6 +9405,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Gå til %1$sDuck.ai-innstillinger%2$s › %3$sChatter › Sync & Backup › "
+"Synkroniser med en annen enhet%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9535,7 +9522,7 @@ msgstr "Den er grei"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Den er grei"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10569,8 +10556,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt chat-"
-"svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
+"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt "
+"chat-svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -11513,7 +11500,7 @@ msgstr "Finn ut %1$smer%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Finn ut mer"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11780,8 +11767,7 @@ msgstr "Lenker:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
+msgstr "Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11892,8 +11878,7 @@ msgstr "Laster flere bilderesultater når du ruller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
+msgstr "Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12151,7 +12136,7 @@ msgstr "Administrere"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Administrer"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12408,7 +12393,7 @@ msgstr "Meny"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Meldinger etter dette punktet er kun synlige for deg."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12669,8 +12654,7 @@ msgstr "Månedlig grense er nådd"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12781,7 +12765,7 @@ msgstr "Mer om Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Flere handlinger"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12981,7 +12965,7 @@ msgstr "Dempet rød"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Mine enheter"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14059,6 +14043,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"På en annen enhet går du til %1$sDuck.ai-innstillinger%2$s › %3$sChatter › "
+"Sync & Backup › Synkroniser med en annen enhet%4$s."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14067,6 +14053,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"På en annen enhet går du til %1$sDuck.ai-innstillinger%2$s › %3$sChatter › "
+"Sync & Backup › Synkroniser med en annen enhet%4$s og skanner denne koden:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14075,6 +14063,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"På en annen enhet går du til %1$sDuck.ai-innstillinger%2$s › %3$sChatter › "
+"Sync & Backup › Synkroniser med en annen enhet%4$s. Eller skann QR-koden på "
+"gjenopprettings-PDF-en din."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14130,8 +14121,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"Bare innstillingene du har endret. De er spesifisert på siden %1$sURL-"
-"parameter%2$s."
+"Bare innstillingene du har endret. De er spesifisert på siden "
+"%1$sURL-parameter%2$s."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14829,7 +14820,7 @@ msgstr "Foregående år"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Lim inn"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14847,7 +14838,7 @@ msgstr "Lim inn Sync-kode"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Lim den inn nedenfor"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14906,7 +14897,7 @@ msgstr "Persisk"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14915,6 +14906,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal finner personopplysningene dine på "
+"datameglernettsteder som selger dem. Deretter jobber vi for å få dem fjernet "
+"for deg."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15959,8 +15953,7 @@ msgstr "Spør meg"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
+msgstr "Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16179,7 +16172,7 @@ msgstr "Leser nettsted…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Klar for solformørkelsen?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16221,8 +16214,7 @@ msgstr "Resonnering kan gi bedre svar på komplekse spørsmål."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Resonnering er grundigere, men når bruksgrensen 2–5 ganger raskere. %1$s"
+msgstr "Resonnering er grundigere, men når bruksgrensen 2–5 ganger raskere. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16278,8 +16270,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter som lagres lokalt på enheten din, i stedet for på DuckDuckGo-"
-"servere eller andre eksterne servere."
+"Nylige chatter som lagres lokalt på enheten din, i stedet for på "
+"DuckDuckGo-servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16288,8 +16280,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter lagres lokalt på enheten din i stedet for på DuckDuckGo-"
-"servere eller andre eksterne servere."
+"Nylige chatter lagres lokalt på enheten din i stedet for på "
+"DuckDuckGo-servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16375,7 +16367,7 @@ msgstr "Gjenopprettingskode"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Gjenopprettingskode"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16632,7 +16624,7 @@ msgstr "Fjern %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Fjern enheten"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16680,13 +16672,13 @@ msgstr "Fjern unødvendig tegnsetting"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Fjern informasjon om deg fra internett"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Fjern informasjonen din på nettet"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17343,8 +17335,7 @@ msgstr "Lagre opptil 30 av de siste chattene lokalt på enheten din."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
+msgstr "Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17380,7 +17371,7 @@ msgstr "Hils på Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Hils på Duck.ai – gratis, privat AI-chat fra DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17533,8 +17524,7 @@ msgstr "Rull ned til %1$sDuckDuckGo%2$s og la den bruke posisjonen din."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
+msgstr "Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17764,8 +17754,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke POST-"
-"forespørsler)"
+"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke "
+"POST-forespørsler)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17884,8 +17874,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
-"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
+"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17894,8 +17884,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
-"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
+"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18049,8 +18039,7 @@ msgstr "Se noen av våre nyeste oppdateringer"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
+msgstr "Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18204,8 +18193,7 @@ msgstr "Velg %1$sInnstillinger%2$s fra nedtrekksmenyen."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
+msgstr "Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18233,8 +18221,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
+msgstr "Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18379,7 +18366,7 @@ msgstr "Serbisk (latin)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Serverdata slettet"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18541,7 +18528,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Del"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18586,8 +18573,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Del plassering så nær som nærmeste by med AI-modeller for å forbedre "
-"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller AI-"
-"modeller."
+"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18696,13 +18683,13 @@ msgstr "Fortell oss hva du synes om søkefeltet."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Delte chatlenker"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Delte chatlenker"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19110,14 +19097,12 @@ msgstr "Viser de mest besøkte lenkene på ny fane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
+msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
+msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19387,7 +19372,7 @@ msgstr "Noe gikk galt"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Noe gikk galt med innlastingen av denne delte chatten."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19429,8 +19414,7 @@ msgstr "Noen ganger"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
+msgstr "Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19504,8 +19488,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
+msgstr "Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19559,8 +19542,7 @@ msgstr "Kildetekst fjernet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
+msgstr "Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19765,8 +19747,7 @@ msgstr "Bli på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
+msgstr "Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20239,7 +20220,7 @@ msgstr "Bytt modell"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Bytt modell"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20374,8 +20355,7 @@ msgstr "Sync & Backup er aktivert!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
+msgstr "Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20424,9 +20404,9 @@ msgid ""
 msgstr ""
 "Synkroniseringsgjenopprettingskode\n"
 "\n"
-"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og Duck.ai-"
-"chatter på tvers av flere enheter, og gjenopprette synkroniserte data hvis "
-"du mister tilgangen til en enhet.\n"
+"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og "
+"Duck.ai-chatter på tvers av flere enheter, og gjenopprette synkroniserte "
+"data hvis du mister tilgangen til en enhet.\n"
 "\n"
 "Ta godt vare på denne informasjonen.\n"
 "Alle som har tilgang til denne koden kan få tilgang til de synkroniserte "
@@ -20503,7 +20483,7 @@ msgstr "Synkroniserte enheter"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Synkronisert %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20541,7 +20521,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabell"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20861,8 +20841,7 @@ msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
+msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -20884,8 +20863,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
+msgstr "Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21054,8 +21032,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
+msgstr "Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21088,9 +21065,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss %3$s-"
-"modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s for mer "
-"informasjon)."
+"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss "
+"%3$s-modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s "
+"for mer informasjon)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21130,7 +21107,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Denne enheten"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21141,6 +21118,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Denne enheten får ikke lenger tilgang til de synkroniserte dataene dine på "
+"andre enheter. De siste %1$s chattene blir fortsatt tilgjengelige i lokal "
+"lagring."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21211,16 +21191,14 @@ msgstr "Dette bildet kunne ikke opprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
+msgstr "Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
+msgstr "Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21231,7 +21209,7 @@ msgstr "Denne informasjonen er ikke nyttig"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Dette er en kopi av en delt chat."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21351,13 +21329,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Denne delte chatten kunne ikke åpnes. Lenken kan være ufullstendig."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Denne delte chatlenken er ikke lenger tilgjengelig."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21380,8 +21358,7 @@ msgstr "Denne oversettelsen er feil"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
+msgstr "Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21572,8 +21549,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"For å overføre chat-historikken din til Duck.ai, oppdater DuckDuckGo-"
-"nettleseren din til den nyeste versjonen og prøv igjen."
+"For å overføre chat-historikken din til Duck.ai, oppdater "
+"DuckDuckGo-nettleseren din til den nyeste versjonen og prøv igjen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22003,7 +21980,7 @@ msgstr "Prøv gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Prøv gratis!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22124,7 +22101,7 @@ msgstr "Prøv gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Prøv det gratis!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22375,7 +22352,7 @@ msgstr "Turkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Slå av"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22393,7 +22370,7 @@ msgstr "Slå av synkronisering og sikkerhetskopiering"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Vil du slå av Sync & Backup og slette serverdata?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22686,8 +22663,8 @@ msgstr "Under %1$sÅpne med%2$s velger du %3$sEn spesifikk side eller sider%4$s"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: https://"
-"duckduckgo.com"
+"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22709,8 +22686,7 @@ msgstr "Under %1$sSøke%2$sseksjon trykker du på %3$sBehandle søkemotorer …%
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
+msgstr "Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22817,8 +22793,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Få tilgang til avanserte AI-modeller og høyere grenser med et DuckDuckGo-"
-"abonnement"
+"Få tilgang til avanserte AI-modeller og høyere grenser med et "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22877,7 +22853,7 @@ msgstr "Slå på lyden"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Chat uten tittel"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22918,7 +22894,7 @@ msgstr "Oppdater nettleseren"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Oppdater Duck.ai for å se denne delte chatten."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23462,9 +23438,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Gå til Duck.ai i den andre nettleseren din og så til %1$sDuck.ai-"
-"innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. Velg "
-"deretter %7$sSynkroniser med en annen enhet%8$s."
+"Gå til Duck.ai i den andre nettleseren din og så til "
+"%1$sDuck.ai-innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. "
+"Velg deretter %7$sSynkroniser med en annen enhet%8$s."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23500,8 +23476,8 @@ msgid ""
 msgstr ""
 "Gå til Duck.ai i nettleseren din eller i DuckDuckGo-appen, og åpne "
 "innstillingene for Duck.ai. Velg «Slå på» under Sync & Backup og velg "
-"«Synkroniser med en annen enhet». Eller skann QR-koden på gjenopprettings-"
-"PDF-en din."
+"«Synkroniser med en annen enhet». Eller skann QR-koden på "
+"gjenopprettings-PDF-en din."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23553,8 +23529,7 @@ msgstr "Talechatten er avsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
+msgstr "Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23790,8 +23765,7 @@ msgstr "Vi følger ikke etter deg med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
+msgstr "Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23901,6 +23875,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Vi finner og fjerner personopplysningene dine hos datameglere. I tillegg får "
+"du en VPN m.m."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23955,6 +23931,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Vi skanner datameglernettsteder regelmessig for personopplysningene dine, og "
+"vi deler fremdriften vår med deg i et brukervennlig dashbord."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23967,8 +23945,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
+msgstr "Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23991,8 +23968,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
+msgstr "Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24001,6 +23977,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Vi skanner datameglernettsteder for e-postadresse, navn, adresse og andre "
+"opplysninger, og jobber for å få fjernet alt vi finner om deg."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24034,8 +24012,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
+msgstr "Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24145,8 +24122,7 @@ msgstr "Ukentlig bruksgrense er nådd"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24199,15 +24175,13 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
+msgstr "Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
+msgstr "Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24320,7 +24294,7 @@ msgstr "Hva er noen fordeler og ulemper med livrenter?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Hva er fordelene med Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24897,6 +24871,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Jobber direkte fra enheten din for å fjerne e-postadresse, navn, adresse og "
+"andre opplysninger fra datameglere."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25144,8 +25120,7 @@ msgstr "Ja, ny bruker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
+msgstr "Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25164,8 +25139,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
+msgstr "Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25351,8 +25325,7 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr ""
-"Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
+msgstr "Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25401,7 +25374,7 @@ msgstr "Du har 1 forsøk igjen."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Du har ingen delte chatlenker."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25502,8 +25475,7 @@ msgstr "Du søker nå med personvern!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
+msgstr "Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25552,8 +25524,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
+msgstr "Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25632,13 +25603,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"De %1$s siste chattene blir tilgjengelige i lokal lagring i disse "
+"nettleserne:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Duck.ai-chattene synkroniseres med ende-til-ende-kryptering."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25670,6 +25643,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Sikkerhetskopien din blir slettet fra DuckDuckGos server. Alle enheter blir "
+"koblet fra synkroniseringen."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25751,8 +25726,8 @@ msgstr "Chattene dine blir nå lagret."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Chattene dine er private og verken lagres eller brukes til å trene opp AI-"
-"modeller"
+"Chattene dine er private og verken lagres eller brukes til å trene opp "
+"AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25784,8 +25759,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
-"modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25793,8 +25768,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
-"modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25895,10 +25870,11 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure Hash-"
-"algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den tilhørende "
-"innstillingsfilen som forlater nettleseren din. Vi lagrer innstillingsfilen "
-"ved å bruke nøkkelen som navn. DuckDuckGo vet aldri passordet ditt."
+"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure "
+"Hash-algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den "
+"tilhørende innstillingsfilen som forlater nettleseren din. Vi lagrer "
+"innstillingsfilen ved å bruke nøkkelen som navn. DuckDuckGo vet aldri "
+"passordet ditt."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26344,8 +26320,7 @@ msgstr "det offisielle nettstedet"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
+msgstr "eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ne_NP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ne_NP/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1181,6 +1199,11 @@ msgstr "%sमा थप्नुहोस"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "जोडिएको"
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4195,6 +4229,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4227,6 +4266,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4787,6 +4845,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4795,6 +4860,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5001,6 +5073,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5650,6 +5728,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6322,9 +6406,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7415,6 +7512,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7499,6 +7603,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9087,6 +9196,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9604,6 +9718,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9809,6 +9929,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10111,6 +10236,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10268,6 +10398,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr " मौन रातो"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11145,6 +11280,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11749,6 +11905,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11757,6 +11918,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11801,6 +11967,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12815,6 +12993,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12964,6 +13147,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13171,6 +13359,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13204,6 +13397,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13752,6 +13955,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14518,6 +14726,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14642,6 +14856,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14761,6 +14982,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15308,6 +15539,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15997,6 +16233,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16194,6 +16435,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16218,6 +16465,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16671,6 +16923,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16739,6 +17005,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16822,6 +17093,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17336,6 +17617,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17428,6 +17714,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17627,6 +17918,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17635,6 +17931,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18012,6 +18313,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18039,6 +18345,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18805,6 +19116,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18839,6 +19157,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18863,6 +19188,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19107,6 +19439,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19569,6 +19906,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19969,6 +20313,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20133,6 +20483,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20150,6 +20515,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/nl_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_BE/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Voeg toe aan %s"
 msgid "Add to Home Screen"
 msgstr "Toevoegen aan het Hoofdscherm"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr ""
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4206,6 +4240,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4238,6 +4277,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4798,6 +4856,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4806,6 +4871,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5012,6 +5084,12 @@ msgstr "Afwijzen"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5659,6 +5737,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6322,9 +6406,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7417,6 +7514,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7501,6 +7605,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9089,6 +9198,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Meer %sInformatie%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9606,6 +9720,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9811,6 +9931,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10113,6 +10238,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Meer op"
@@ -10270,6 +10400,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Gedempt rood"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11149,6 +11284,27 @@ msgstr ""
 "Op Mac, %sKlik Maxthon > Voorkeuren%s, Op Windows, %sKlik het %sicoon > "
 "Instellingen%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11759,6 +11915,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11767,6 +11928,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11811,6 +11977,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12825,6 +13003,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12974,6 +13157,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13181,6 +13369,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13214,6 +13407,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13762,6 +13965,11 @@ msgstr "Bewaar je instellingen anoniem in de cloud"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14537,6 +14745,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14663,6 +14877,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14782,6 +15003,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15329,6 +15560,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16019,6 +16255,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16216,6 +16457,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16240,6 +16487,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16693,6 +16945,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16761,6 +17027,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16844,6 +17115,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17359,6 +17640,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17452,6 +17738,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17651,6 +17942,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17659,6 +17955,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18042,6 +18343,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18069,6 +18375,11 @@ msgstr "Updaten"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18843,6 +19154,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18877,6 +19195,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18901,6 +19226,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19145,6 +19477,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19607,6 +19944,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20011,6 +20355,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20178,6 +20528,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube Standaard licentie"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20195,6 +20560,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% volledig gevaccineerd"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% gevaccineerd"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -87,7 +95,8 @@ msgstr "%1$s en %2$s AI-modellen"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr "%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
+msgstr ""
+"%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -434,7 +443,8 @@ msgstr "%1$s woorden"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
+msgstr ""
+"%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -485,6 +495,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sOntdek hoe we je locatie privé houden%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -497,7 +514,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
+msgstr ""
+"%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -777,6 +795,12 @@ msgid "2nd in Group %s"
 msgstr "2e in groep %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -858,7 +882,8 @@ msgstr "De 6-uurs gebruikslimiet is bereikt."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr ""
+"De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1462,6 +1487,12 @@ msgid "Add to Home Screen"
 msgstr "Toevoegen aan startscherm"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Add-ons"
@@ -1823,6 +1854,13 @@ msgid "All types"
 msgstr "Alle types"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1857,7 +1895,8 @@ msgstr "Anonieme bestandscontrole toestaan voor deze chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
+msgstr ""
+"Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2017,8 +2056,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
-"open-source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
+"source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2027,8 +2066,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
-"open-source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
+"source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2348,6 +2387,12 @@ msgid "Ask anything privately"
 msgstr "Vraag iets privé"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2407,8 +2452,8 @@ msgstr ""
 "relevante webinhoud samen te vatten. Je kunt kiezen hoe vaak je wilt dat "
 "Assist wordt weergegeven: 'Nooit' (de Assist-gebruikersinterface wordt "
 "helemaal uit de zoekresultaten verwijderd), 'Op verzoek' (AI-antwoorden "
-"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' "
-"(AI-antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
+"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' (AI-"
+"antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
 "'Vaak' (wordt vaker weergegeven bij een breder scala aan zoekopdrachten). "
 "Voorlopig zijn AI-antwoorden alleen beschikbaar in de Amerikaanse regio."
 
@@ -2422,8 +2467,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist is een optionele functie in onze zoekresultaten die anoniem "
-"AI-ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
+"Assist is een optionele functie in onze zoekresultaten die anoniem AI-"
+"ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
 "het web op relevante inhoud en gebruikt vervolgens AI-technologie op basis "
 "van natuurlijke taal om een kort antwoord te genereren aan de hand van de "
 "gevonden relevante informatie. Het is belangrijk om te onthouden dat "
@@ -3716,7 +3761,8 @@ msgstr "Wijzigt hoe URL's van resultaten worden weergegeven"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
+msgstr ""
+"Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3927,14 +3973,16 @@ msgstr "Privé chatten"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
+msgstr ""
+"Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
+msgstr ""
+"Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -5290,6 +5338,12 @@ msgid "Copy"
 msgstr "Kopiëren"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5329,6 +5383,28 @@ msgstr "Kopieer of sla deze code op"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Herstelcode kopiëren"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5380,7 +5456,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
+msgstr ""
+"Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5435,7 +5512,8 @@ msgstr "Deellink aanmaken"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr "Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
+msgstr ""
+"Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5714,7 +5792,8 @@ msgstr "Dagelijkse limiet bereikt"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr ""
+"Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6008,6 +6087,14 @@ msgid "Delete recent chats?"
 msgstr "Recente chats verwijderen?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6018,6 +6105,14 @@ msgstr "Deze chat verwijderen?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Verwijderde chats"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6214,7 +6309,8 @@ msgstr "Uitschakelen en loskoppelen"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
+msgstr ""
+"Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6273,6 +6369,13 @@ msgstr "Afwijzen"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Afwijzen"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6456,8 +6559,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder "
-"AI-functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
+"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder AI-"
+"functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6686,7 +6789,8 @@ msgstr "Sleep je foto's of PDF-bestanden"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
+msgstr ""
+"Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6822,8 +6926,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een "
-"e-mail met deze anonieme code %1$s naar %2$s"
+"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een e-"
+"mail met deze anonieme code %1$s naar %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6885,7 +6989,8 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr "Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
+msgstr ""
+"Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6929,8 +7034,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privé AI-chatbot, gratis AI-chat, anonieme AI-chat, "
-"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open "
-"source  AI-modellen, privacy  AI, AI-chat zonder account"
+"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open source  AI-"
+"modellen, privacy  AI, AI-chat zonder account"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7002,9 +7107,9 @@ msgid ""
 msgstr ""
 "DuckAssist is een nieuwe functie in onze zoekresultaten die anoniem "
 "antwoorden voor zoekopdrachten kan genereren. Hij scant daarvoor Wikipedia "
-"en gerelateerde sites op relevante inhoud en gebruikt vervolgens "
-"AI-technologie voor natuurlijke taal om die informatie samen te vatten. Let "
-"op: de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
+"en gerelateerde sites op relevante inhoud en gebruikt vervolgens AI-"
+"technologie voor natuurlijke taal om die informatie samen te vatten. Let op: "
+"de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
 "inhoud en worden niet gecontroleerd op juistheid."
 
 # smartling.placeholder_format=C
@@ -7102,7 +7207,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
+msgstr ""
+"DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7129,6 +7235,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo-browser %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7354,7 +7467,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
+msgstr ""
+"DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7745,7 +7859,8 @@ msgstr "Ben je tevreden met Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
+msgstr ""
+"Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7959,13 +8074,29 @@ msgstr "Kaart uitvouwen"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
+msgstr ""
+"Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
+
+# smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Verlopen"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8326,7 +8457,8 @@ msgstr "Filters niet effectief"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
+msgstr ""
+"Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8719,9 +8851,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Selecteer in de menubalk van de app voor Mac de optie "
-"<strong>DuckDuckGo</strong> &gt; <strong>Controleren op updates...</strong> "
-"en selecteer vervolgens <strong>Update installeren</strong>."
+"Selecteer in de menubalk van de app voor Mac de optie <strong>DuckDuckGo</"
+"strong> &gt; <strong>Controleren op updates...</strong> en selecteer "
+"vervolgens <strong>Update installeren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9014,7 +9146,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "Krijg DuckDuckGo VPN, geavanceerde Duck.ai en Identity Theft Restoration."
+msgstr ""
+"Krijg DuckDuckGo VPN, geavanceerde Duck.ai en Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9128,9 +9261,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een "
-"DuckDuckGo-abonnement, dat ook onze VPN en andere premium "
-"privacybeschermingen omvat."
+"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een DuckDuckGo-"
+"abonnement, dat ook onze VPN en andere premium privacybeschermingen omvat."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9174,8 +9306,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Krijg onze snelle, no-log VPN, optionele toegang tot geavanceerde "
-"AI-modellen met hogere chatlimieten en meer premium beschermingen."
+"Krijg onze snelle, no-log VPN, optionele toegang tot geavanceerde AI-"
+"modellen met hogere chatlimieten en meer premium beschermingen."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9309,9 +9441,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
-"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
-"Synchroniseren met een ander apparaat%4$s"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
+"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
+"een ander apparaat%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9321,9 +9453,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
-"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
-"Synchroniseren met een ander apparaat%4$s en scan deze code:"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
+"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
+"een ander apparaat%4$s en scan deze code:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9335,8 +9467,16 @@ msgid ""
 msgstr ""
 "Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of naar de "
 "DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
-"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je "
-"herstel-PDF."
+"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je herstel-"
+"PDF."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9447,6 +9587,12 @@ msgstr "Ik snap het"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Ik snap het"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10650,8 +10796,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbetert de leesbaarheid van het resultaat met een bijgewerkte "
-"URL-indeling, -plaatsing en -kleur"
+"Verbetert de leesbaarheid van het resultaat met een bijgewerkte URL-"
+"indeling, -plaatsing en -kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11425,6 +11571,12 @@ msgid "Learn %sMore%s"
 msgstr "Meer %1$sinformatie%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11535,7 +11687,8 @@ msgstr "Lees meer over hoe het werkt"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "Informatie over waarom het terugdringen van online tracking belangrijk is."
+msgstr ""
+"Informatie over waarom het terugdringen van online tracking belangrijk is."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11994,7 +12147,8 @@ msgstr "Zorg ervoor dat alle woorden correct gespeld zijn."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
+msgstr ""
+"Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12060,6 +12214,13 @@ msgstr "Malware"
 #. Text for generic link to send the user to a page to manage their settings.
 msgid "Manage"
 msgstr "Beheren"
+
+# smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12311,6 +12472,12 @@ msgstr "Menu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12683,6 +12850,12 @@ msgid "More about Duck.ai"
 msgstr "Meer over Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Meer op"
@@ -12875,6 +13048,12 @@ msgstr "Gedempt"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Gedempt rood"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13435,7 +13614,8 @@ msgstr "Geen resultaten gevonden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
+msgstr ""
+"Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13946,6 +14126,30 @@ msgstr ""
 "pictogram > Voorkeuren%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14069,7 +14273,8 @@ msgstr "%1$s-website openen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
+msgstr ""
+"Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14238,7 +14443,8 @@ msgstr "Open het paneel 'Hoe Duck.ai werkt'"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
+msgstr ""
+"Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14695,6 +14901,12 @@ msgid "Past year"
 msgstr "Afgelopen jaar"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14705,6 +14917,12 @@ msgstr "Plakken"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Synchronisatiecode plakken"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14758,6 +14976,20 @@ msgstr "Permanent gesloten"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Perzisch"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15523,7 +15755,8 @@ msgstr "Prijs"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr "De weergegeven prijs komt niet overeen met die op de site van de verkoper"
+msgstr ""
+"De weergegeven prijs komt niet overeen met die op de site van de verkoper"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -15806,7 +16039,8 @@ msgstr "Vraag het mij"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
+msgstr ""
+"Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16022,6 +16256,12 @@ msgid "Reading website…"
 msgstr "Website wordt gelezen …"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16210,6 +16450,12 @@ msgstr "Herstellen"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Herstelcode"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16430,7 +16676,8 @@ msgstr "Mijn keuze onthouden"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
+msgstr ""
+"Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16461,6 +16708,12 @@ msgstr "%1$s verwijderen"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "Verwijder %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16503,6 +16756,18 @@ msgstr "Tekstselectie verwijderen"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Verwijder onnodige interpunctie"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17163,7 +17428,8 @@ msgstr "Bewaar maximaal 30 van je meest recente chats op je apparaat."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
+msgstr ""
+"Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17194,6 +17460,12 @@ msgstr "Sla je instellingen anoniem op in de cloud"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Zeg hallo tegen Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17297,13 +17569,15 @@ msgstr "Schotland"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
+msgstr ""
+"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
+msgstr ""
+"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17552,8 +17826,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar "
-"\"!w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
+"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar \"!"
+"w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17738,7 +18012,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
+msgstr ""
+"Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17865,7 +18140,8 @@ msgstr "Bekijk enkele van onze nieuwste updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
+msgstr ""
+"Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17892,7 +18168,8 @@ msgstr "Selecteer %1$s%2$s%3$s en vervolgens %4$sZoekmachine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
+msgstr ""
+"Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17905,18 +18182,21 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17928,7 +18208,8 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in het uitklapmenu Standaard zoekmachine"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17940,7 +18221,8 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst met zoekmachines"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18027,7 +18309,8 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
+msgstr ""
+"Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18049,7 +18332,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
+msgstr ""
+"Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18189,6 +18473,13 @@ msgstr "Servisch (Cyrillisch)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Servisch (Latijns)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18345,6 +18636,14 @@ msgid "Share"
 msgstr "Delen"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18387,8 +18686,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Deel een locatie op stadsniveau met AI-modellen om de relevantie te "
-"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan "
-"AI-modellen."
+"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan AI-"
+"modellen."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18492,6 +18791,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Deel je mening over het zoekvak."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18901,7 +19212,8 @@ msgstr "Meest bezochte links weergeven op een nieuw tabblad"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
+msgstr ""
+"Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18915,8 +19227,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"Geeft af en toe herinneringen weer om je aan te melden voor de "
-"DuckDuckGo-nieuwsbrieven over privacy"
+"Geeft af en toe herinneringen weer om je aan te melden voor de DuckDuckGo-"
+"nieuwsbrieven over privacy"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18926,7 +19238,8 @@ msgstr "Geeft paginanummers weer naast resultaatpagina-einden"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
+msgstr ""
+"Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18955,8 +19268,8 @@ msgstr "Geeft een welkomstbericht weer bovenaan de pagina met zoekresultaten"
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
 msgstr ""
-"Geeft een welkomstbericht weer aan gebruikers van het "
-"EU-Android-voorkeursmenu"
+"Geeft een welkomstbericht weer aan gebruikers van het EU-Android-"
+"voorkeursmenu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19179,10 +19492,17 @@ msgid "Something went wrong"
 msgstr "Er is iets misgegaan"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
+msgstr ""
+"Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19220,7 +19540,8 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
+msgstr ""
+"Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19294,7 +19615,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
+msgstr ""
+"Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19610,7 +19932,8 @@ msgstr "Stop verborgen trackers die op de loer liggen op andere websites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Stop de meeste verborgen trackers die op de loer liggen op andere websites."
+msgstr ""
+"Stop de meeste verborgen trackers die op de loer liggen op andere websites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20029,6 +20352,12 @@ msgid "Switch model"
 msgstr "Wisselen van model"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20288,6 +20617,13 @@ msgid "Synced Devices"
 msgstr "Gesynchroniseerde apparaten"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Syrië"
 
@@ -20318,6 +20654,12 @@ msgstr "n.n.b."
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "Televisie"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20631,13 +20973,15 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
+msgstr ""
+"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
+msgstr ""
+"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -20693,7 +21037,8 @@ msgstr "Het verzoek is verlopen. Probeer het opnieuw."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr "De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
+msgstr ""
+"De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -20833,7 +21178,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
+msgstr ""
+"Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20903,6 +21249,22 @@ msgstr ""
 "Dit gesprek is gegenereerd met DuckDuckGo AI Chat (%1$s) met behulp van het "
 "%3$s-model van %2$s. AI-chats kunnen onnauwkeurige of aanstootgevende "
 "informatie bevatten (zie %4$s voor meer informatie)."
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20992,6 +21354,12 @@ msgid "This information isn’t useful"
 msgstr "Deze informatie is niet nuttig"
 
 # smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
@@ -21058,7 +21426,8 @@ msgstr "Voor deze pagina moet JavaScript zijn ingeschakeld."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
+msgstr ""
+"De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21107,6 +21476,18 @@ msgstr ""
 "AI-antwoorden toont op %1$s."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21127,13 +21508,15 @@ msgstr "Deze vertaling is onjuist"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
+msgstr ""
+"Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
+msgstr ""
+"Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21252,8 +21635,8 @@ msgstr "Tips"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij "
-"helpen.%2$s"
+"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij helpen."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21285,7 +21668,8 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr "Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
+msgstr ""
+"Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -21326,8 +21710,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je "
-"DuckDuckGo-browser naar de nieuwste versie en probeer het opnieuw."
+"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je DuckDuckGo-"
+"browser naar de nieuwste versie en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21708,7 +22092,8 @@ msgstr "Probeer %1$s om dit soort berichten niet meer te zien."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
+msgstr ""
+"Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21754,6 +22139,12 @@ msgstr "Probeer gratis"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Probeer gratis"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21843,14 +22234,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
+msgstr ""
+"Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
+msgstr ""
+"Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21869,6 +22262,12 @@ msgstr "Probeer gratis"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Probeer gratis"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21896,7 +22295,8 @@ msgstr "Probeer het gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
+msgstr ""
+"Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -21935,7 +22335,8 @@ msgstr "Probeer onze browser"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
+msgstr ""
+"Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22114,6 +22515,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22124,6 +22531,12 @@ msgstr "Sync & Backup uitschakelen"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Sync & Backup uitschakelen"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22374,7 +22787,8 @@ msgstr ""
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr "Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
+msgstr ""
+"Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -22415,7 +22829,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
+msgstr ""
+"Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22430,13 +22845,15 @@ msgstr "Bij %1$sZoekinstellingen%2$s selecteer je %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
+msgstr ""
+"Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
+msgstr ""
+"Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22450,7 +22867,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
+msgstr ""
+"Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22551,8 +22969,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Ontgrendel geavanceerde AI-modellen en hogere limieten met een "
-"DuckDuckGo-abonnement"
+"Ontgrendel geavanceerde AI-modellen en hogere limieten met een DuckDuckGo-"
+"abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22606,6 +23024,12 @@ msgid "Unmute"
 msgstr "Dempen opheffen"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22641,6 +23065,12 @@ msgstr "Updaten"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Browser bijwerken"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22812,7 +23242,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
+msgstr ""
+"Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22922,7 +23353,8 @@ msgstr "Gebruik DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
+msgstr ""
+"Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23221,10 +23653,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open "
-"'Duck.ai-instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en "
-"selecteer 'Synchroniseren met een ander apparaat'. Of scan de QR-code op je "
-"herstel-PDF."
+"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open 'Duck.ai-"
+"instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en selecteer "
+"'Synchroniseren met een ander apparaat'. Of scan de QR-code op je herstel-"
+"PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23423,8 +23855,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Kijk in Duck Player om gepersonaliseerde advertenties op YouTube te "
-"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op "
-"YouTube-aanbevelingen."
+"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op YouTube-"
+"aanbevelingen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23517,12 +23949,14 @@ msgstr "We achtervolgen je niet met advertenties."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
+msgstr ""
+"We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
+msgstr ""
+"We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23548,7 +23982,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
+msgstr ""
+"We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23556,7 +23991,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
+msgstr ""
+"We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23619,6 +24055,14 @@ msgstr ""
 "proberen?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23643,7 +24087,8 @@ msgstr "De verbinding is verbroken. Probeer het later opnieuw."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
+msgstr ""
+"We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -23665,6 +24110,14 @@ msgstr ""
 "buurt aan te bieden. Je kunt dit later altijd weer uitschakelen."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23675,7 +24128,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
+msgstr ""
+"We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23698,7 +24152,16 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
+msgstr ""
+"We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23732,7 +24195,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
+msgstr ""
+"Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23842,7 +24306,8 @@ msgstr "Wekelijkse gebruikslimiet bereikt"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr ""
+"Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23895,7 +24360,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
+msgstr ""
+"Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24011,6 +24477,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Wat zijn enkele voor- en nadelen van lijfrentes?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24582,6 +25054,14 @@ msgid "Without zero provider visibility"
 msgstr "Zonder onzichtbaarheid voor de provider"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -24926,7 +25406,8 @@ msgstr "Je kunt dit op elk moment wijzigen in %1$sZoekinstellingen%2$s"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
+msgstr ""
+"Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25085,6 +25566,13 @@ msgid "You have 1 attempt left."
 msgstr "Je hebt nog 1 poging over."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25102,8 +25590,8 @@ msgid ""
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
 "Je hebt nu toegang tot geavanceerde AI-modellen. Je hebt toegang tot de VPN "
-"en andere beveiligingen van het DuckDuckGo-abonnement in de "
-"DuckDuckGo-browser."
+"en andere beveiligingen van het DuckDuckGo-abonnement in de DuckDuckGo-"
+"browser."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25255,7 +25743,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
+msgstr ""
+"Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25307,6 +25796,23 @@ msgid "YouTube Standard"
 msgstr "YouTube-standaard"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Je DuckDuckGo-zoekgeschiedenis is privé"
@@ -25328,6 +25834,14 @@ msgstr "Je werkelijke locatie blijft privé"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Je werkelijke locatie blijft privé."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25424,8 +25938,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
-"AI-modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
+"modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25433,8 +25947,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
-"AI-modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
+"modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25467,8 +25981,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
-"AI-modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
+"modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25706,7 +26220,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
+msgstr ""
+"Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25789,7 +26304,8 @@ msgstr "door %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
+msgstr ""
+"Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Dit apparaat)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -95,8 +95,7 @@ msgstr "%1$s en %2$s AI-modellen"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
+msgstr "%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -443,8 +442,7 @@ msgstr "%1$s woorden"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
+msgstr "%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -499,7 +497,7 @@ msgstr "%1$sOntdek hoe we je locatie privé houden%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sMeer informatie%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -514,8 +512,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
+msgstr "%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -798,7 +795,7 @@ msgstr "2e in groep %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "second opinion"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -882,8 +879,7 @@ msgstr "De 6-uurs gebruikslimiet is bereikt."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1490,7 +1486,7 @@ msgstr "Toevoegen aan startscherm"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Toevoegen aan Mijn chats"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1858,7 +1854,7 @@ msgstr "Alle types"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Al je apparaten zijn losgekoppeld van Sync."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1895,8 +1891,7 @@ msgstr "Anonieme bestandscontrole toestaan voor deze chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
+msgstr "Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2056,8 +2051,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
-"source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
+"open-source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2066,8 +2061,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
-"source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
+"open-source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2390,7 +2385,7 @@ msgstr "Vraag iets privé"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Vraag iets privé"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2452,8 +2447,8 @@ msgstr ""
 "relevante webinhoud samen te vatten. Je kunt kiezen hoe vaak je wilt dat "
 "Assist wordt weergegeven: 'Nooit' (de Assist-gebruikersinterface wordt "
 "helemaal uit de zoekresultaten verwijderd), 'Op verzoek' (AI-antwoorden "
-"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' (AI-"
-"antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
+"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' "
+"(AI-antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
 "'Vaak' (wordt vaker weergegeven bij een breder scala aan zoekopdrachten). "
 "Voorlopig zijn AI-antwoorden alleen beschikbaar in de Amerikaanse regio."
 
@@ -2467,8 +2462,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist is een optionele functie in onze zoekresultaten die anoniem AI-"
-"ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
+"Assist is een optionele functie in onze zoekresultaten die anoniem "
+"AI-ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
 "het web op relevante inhoud en gebruikt vervolgens AI-technologie op basis "
 "van natuurlijke taal om een kort antwoord te genereren aan de hand van de "
 "gevonden relevante informatie. Het is belangrijk om te onthouden dat "
@@ -3761,8 +3756,7 @@ msgstr "Wijzigt hoe URL's van resultaten worden weergegeven"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
+msgstr "Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3973,16 +3967,14 @@ msgstr "Privé chatten"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
+msgstr "Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
+msgstr "Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -5341,7 +5333,7 @@ msgstr "Kopiëren"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopiëren"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5390,13 +5382,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Gedeelde link kopiëren"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Kopieer de code van een ander apparaat"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5405,6 +5397,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Kopieer de code van een ander apparaat. Ga naar %1$sDuck.ai-instellingen › "
+"Chats › Synchronisatie en back-up › Synchroniseren met een ander "
+"apparaat%2$s en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5456,8 +5451,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
+msgstr "Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5512,8 +5506,7 @@ msgstr "Deellink aanmaken"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
-"Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
+msgstr "Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5792,8 +5785,7 @@ msgstr "Dagelijkse limiet bereikt"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6092,7 +6084,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Gedeelde link verwijderen"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6113,6 +6105,9 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Het verwijderen van een link zorgt ervoor dat deze niet meer werkt. Mensen "
+"die de link al hebben geopend en het gesprek aan hun chats hebben "
+"toegevoegd, behouden hun eigen kopie."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6309,8 +6304,7 @@ msgstr "Uitschakelen en loskoppelen"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
+msgstr "Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6375,7 +6369,7 @@ msgstr "Afwijzen"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Afwijzen"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6559,8 +6553,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder AI-"
-"functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
+"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder "
+"AI-functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6789,8 +6783,7 @@ msgstr "Sleep je foto's of PDF-bestanden"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
+msgstr "Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6926,8 +6919,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een e-"
-"mail met deze anonieme code %1$s naar %2$s"
+"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een "
+"e-mail met deze anonieme code %1$s naar %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6989,8 +6982,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
+msgstr "Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7034,8 +7026,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privé AI-chatbot, gratis AI-chat, anonieme AI-chat, "
-"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open source  AI-"
-"modellen, privacy  AI, AI-chat zonder account"
+"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open "
+"source  AI-modellen, privacy  AI, AI-chat zonder account"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7107,9 +7099,9 @@ msgid ""
 msgstr ""
 "DuckAssist is een nieuwe functie in onze zoekresultaten die anoniem "
 "antwoorden voor zoekopdrachten kan genereren. Hij scant daarvoor Wikipedia "
-"en gerelateerde sites op relevante inhoud en gebruikt vervolgens AI-"
-"technologie voor natuurlijke taal om die informatie samen te vatten. Let op: "
-"de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
+"en gerelateerde sites op relevante inhoud en gebruikt vervolgens "
+"AI-technologie voor natuurlijke taal om die informatie samen te vatten. Let "
+"op: de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
 "inhoud en worden niet gecontroleerd op juistheid."
 
 # smartling.placeholder_format=C
@@ -7207,8 +7199,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
+msgstr "DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7241,7 +7232,7 @@ msgstr "DuckDuckGo-browser %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo-helppagina's"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7467,8 +7458,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
+msgstr "DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7859,8 +7849,7 @@ msgstr "Ben je tevreden met Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
+msgstr "Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8074,15 +8063,14 @@ msgstr "Kaart uitvouwen"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
+msgstr "Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Verlopen"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8096,7 +8084,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Verloopt op %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8457,8 +8445,7 @@ msgstr "Filters niet effectief"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
+msgstr "Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8851,9 +8838,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Selecteer in de menubalk van de app voor Mac de optie <strong>DuckDuckGo</"
-"strong> &gt; <strong>Controleren op updates...</strong> en selecteer "
-"vervolgens <strong>Update installeren</strong>."
+"Selecteer in de menubalk van de app voor Mac de optie "
+"<strong>DuckDuckGo</strong> &gt; <strong>Controleren op updates...</strong> "
+"en selecteer vervolgens <strong>Update installeren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9146,8 +9133,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Krijg DuckDuckGo VPN, geavanceerde Duck.ai en Identity Theft Restoration."
+msgstr "Krijg DuckDuckGo VPN, geavanceerde Duck.ai en Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9261,8 +9247,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een DuckDuckGo-"
-"abonnement, dat ook onze VPN en andere premium privacybeschermingen omvat."
+"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een "
+"DuckDuckGo-abonnement, dat ook onze VPN en andere premium "
+"privacybeschermingen omvat."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9306,8 +9293,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Krijg onze snelle, no-log VPN, optionele toegang tot geavanceerde AI-"
-"modellen met hogere chatlimieten en meer premium beschermingen."
+"Krijg onze snelle, no-log VPN, optionele toegang tot geavanceerde "
+"AI-modellen met hogere chatlimieten en meer premium beschermingen."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9441,9 +9428,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
-"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
-"een ander apparaat%4$s"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
+"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
+"Synchroniseren met een ander apparaat%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9453,9 +9440,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
-"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
-"een ander apparaat%4$s en scan deze code:"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
+"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
+"Synchroniseren met een ander apparaat%4$s en scan deze code:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9467,8 +9454,8 @@ msgid ""
 msgstr ""
 "Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of naar de "
 "DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
-"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je herstel-"
-"PDF."
+"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je "
+"herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9477,6 +9464,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Ga naar %1$sDuck.ai-instellingen%2$s › %3$sChats › Synchronisatie en back-up "
+"› Synchroniseren met een ander apparaat%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9592,7 +9581,7 @@ msgstr "Ik snap het"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Ik snap het"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10796,8 +10785,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbetert de leesbaarheid van het resultaat met een bijgewerkte URL-"
-"indeling, -plaatsing en -kleur"
+"Verbetert de leesbaarheid van het resultaat met een bijgewerkte "
+"URL-indeling, -plaatsing en -kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11574,7 +11563,7 @@ msgstr "Meer %1$sinformatie%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Meer informatie"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11687,8 +11676,7 @@ msgstr "Lees meer over hoe het werkt"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Informatie over waarom het terugdringen van online tracking belangrijk is."
+msgstr "Informatie over waarom het terugdringen van online tracking belangrijk is."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -12147,8 +12135,7 @@ msgstr "Zorg ervoor dat alle woorden correct gespeld zijn."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
+msgstr "Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12220,7 +12207,7 @@ msgstr "Beheren"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Beheren"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12477,7 +12464,7 @@ msgstr "Menu"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Berichten vanaf dit punt zijn alleen zichtbaar voor jou."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12853,7 +12840,7 @@ msgstr "Meer over Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Meer acties"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13053,7 +13040,7 @@ msgstr "Gedempt rood"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Mijn apparaten"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13614,8 +13601,7 @@ msgstr "Geen resultaten gevonden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
+msgstr "Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14132,6 +14118,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Ga op een ander apparaat naar %1$sDuck.ai-instellingen%2$s › %3$sChats › "
+"Synchronisatie en back-up › Synchroniseren met een ander apparaat%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14140,6 +14128,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Ga op een ander apparaat naar %1$sDuck.ai-instellingen%2$s › %3$sChats › "
+"Synchronisatie en back-up › Synchroniseren met een ander apparaat%4$s en "
+"scan deze code:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14148,6 +14139,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Ga op een ander apparaat naar %1$sDuck.ai-instellingen%2$s › %3$sChats › "
+"Synchronisatie en back-up › Synchroniseren met een ander apparaat%4$s. Of "
+"scan de QR-code op je herstel-PDF."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14273,8 +14267,7 @@ msgstr "%1$s-website openen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
+msgstr "Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14443,8 +14436,7 @@ msgstr "Open het paneel 'Hoe Duck.ai werkt'"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
+msgstr "Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14904,7 +14896,7 @@ msgstr "Afgelopen jaar"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Plakken"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14922,7 +14914,7 @@ msgstr "Synchronisatiecode plakken"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Plak het hieronder"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14981,7 +14973,7 @@ msgstr "Perzisch"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14990,6 +14982,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal vindt je gegevens op websites van databrokers "
+"die deze verkopen. Vervolgens werken we eraan om deze voor je te laten "
+"verwijderen."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15755,8 +15750,7 @@ msgstr "Prijs"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr ""
-"De weergegeven prijs komt niet overeen met die op de site van de verkoper"
+msgstr "De weergegeven prijs komt niet overeen met die op de site van de verkoper"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -16039,8 +16033,7 @@ msgstr "Vraag het mij"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
+msgstr "Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16259,7 +16252,7 @@ msgstr "Website wordt gelezen …"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Klaar voor de zonsverduistering?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16455,7 +16448,7 @@ msgstr "Herstelcode"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Herstelcode"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16676,8 +16669,7 @@ msgstr "Mijn keuze onthouden"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
+msgstr "Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16713,7 +16705,7 @@ msgstr "Verwijder %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Apparaat verwijderen"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16761,13 +16753,13 @@ msgstr "Verwijder onnodige interpunctie"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Je gegevens van het internet verwijderen"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Verwijder je gegevens online"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17428,8 +17420,7 @@ msgstr "Bewaar maximaal 30 van je meest recente chats op je apparaat."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
+msgstr "Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17465,7 +17456,7 @@ msgstr "Zeg hallo tegen Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Zeg hallo tegen Duck.ai – gratis, privé AI-chat van DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17569,15 +17560,13 @@ msgstr "Schotland"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
+msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
+msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17826,8 +17815,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar \"!"
-"w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
+"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar "
+"\"!w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -18012,8 +18001,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
+msgstr "Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18140,8 +18128,7 @@ msgstr "Bekijk enkele van onze nieuwste updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
+msgstr "Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18168,8 +18155,7 @@ msgstr "Selecteer %1$s%2$s%3$s en vervolgens %4$sZoekmachine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
+msgstr "Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18182,21 +18168,18 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18208,8 +18191,7 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in het uitklapmenu Standaard zoekmachine"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
+msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18221,8 +18203,7 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst met zoekmachines"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
+msgstr "Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18309,8 +18290,7 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
+msgstr "Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18332,8 +18312,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
+msgstr "Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18479,7 +18458,7 @@ msgstr "Servisch (Latijns)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Servergegevens verwijderd"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18641,7 +18620,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Delen"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18686,8 +18665,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Deel een locatie op stadsniveau met AI-modellen om de relevantie te "
-"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan AI-"
-"modellen."
+"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan "
+"AI-modellen."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18796,13 +18775,13 @@ msgstr "Deel je mening over het zoekvak."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Gedeelde chatlinks"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Gedeelde chatlinks"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19212,8 +19191,7 @@ msgstr "Meest bezochte links weergeven op een nieuw tabblad"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
+msgstr "Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19227,8 +19205,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"Geeft af en toe herinneringen weer om je aan te melden voor de DuckDuckGo-"
-"nieuwsbrieven over privacy"
+"Geeft af en toe herinneringen weer om je aan te melden voor de "
+"DuckDuckGo-nieuwsbrieven over privacy"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19238,8 +19216,7 @@ msgstr "Geeft paginanummers weer naast resultaatpagina-einden"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
+msgstr "Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19268,8 +19245,8 @@ msgstr "Geeft een welkomstbericht weer bovenaan de pagina met zoekresultaten"
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
 msgstr ""
-"Geeft een welkomstbericht weer aan gebruikers van het EU-Android-"
-"voorkeursmenu"
+"Geeft een welkomstbericht weer aan gebruikers van het "
+"EU-Android-voorkeursmenu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19495,14 +19472,13 @@ msgstr "Er is iets misgegaan"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Er is iets misgegaan bij het laden van deze gedeelde chat."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
+msgstr "Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19540,8 +19516,7 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
+msgstr "Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19615,8 +19590,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
+msgstr "Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19932,8 +19906,7 @@ msgstr "Stop verborgen trackers die op de loer liggen op andere websites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Stop de meeste verborgen trackers die op de loer liggen op andere websites."
+msgstr "Stop de meeste verborgen trackers die op de loer liggen op andere websites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20355,7 +20328,7 @@ msgstr "Wisselen van model"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Wisselen van model"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20621,7 +20594,7 @@ msgstr "Gesynchroniseerde apparaten"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Gesynchroniseerd op %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20659,7 +20632,7 @@ msgstr "Televisie"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabel"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20973,15 +20946,13 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
+msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
+msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21037,8 +21008,7 @@ msgstr "Het verzoek is verlopen. Probeer het opnieuw."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
+msgstr "De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -21178,8 +21148,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
+msgstr "Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21254,7 +21223,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Dit apparaat"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21265,6 +21234,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Dit apparaat heeft geen toegang meer tot je gesynchroniseerde gegevens op "
+"andere apparaten. De laatste %1$s chats blijven beschikbaar in de lokale "
+"opslag."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21357,7 +21329,7 @@ msgstr "Deze informatie is niet nuttig"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Dit is een kopie van een gedeelde chat."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21426,8 +21398,7 @@ msgstr "Voor deze pagina moet JavaScript zijn ingeschakeld."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
+msgstr "De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21479,13 +21450,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Deze gedeelde chat kon niet worden geopend. De link is mogelijk onvolledig."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Deze gedeelde chatlink is niet langer beschikbaar."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21508,15 +21479,13 @@ msgstr "Deze vertaling is onjuist"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
+msgstr "Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
+msgstr "Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21635,8 +21604,8 @@ msgstr "Tips"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij helpen."
-"%2$s"
+"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij "
+"helpen.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21668,8 +21637,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
+msgstr "Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -21710,8 +21678,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je DuckDuckGo-"
-"browser naar de nieuwste versie en probeer het opnieuw."
+"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je "
+"DuckDuckGo-browser naar de nieuwste versie en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22092,8 +22060,7 @@ msgstr "Probeer %1$s om dit soort berichten niet meer te zien."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
+msgstr "Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22144,7 +22111,7 @@ msgstr "Probeer gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Probeer gratis!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22234,16 +22201,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
+msgstr "Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
+msgstr "Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22267,7 +22232,7 @@ msgstr "Probeer gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Probeer het gratis!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22295,8 +22260,7 @@ msgstr "Probeer het gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
+msgstr "Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22335,8 +22299,7 @@ msgstr "Probeer onze browser"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
+msgstr "Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22518,7 +22481,7 @@ msgstr "Turkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Uitschakelen"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22536,7 +22499,7 @@ msgstr "Sync & Backup uitschakelen"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Sync & Backup uitschakelen en servergegevens verwijderen?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22787,8 +22750,7 @@ msgstr ""
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr ""
-"Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
+msgstr "Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -22829,8 +22791,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
+msgstr "Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22845,15 +22806,13 @@ msgstr "Bij %1$sZoekinstellingen%2$s selecteer je %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
+msgstr "Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
+msgstr "Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22867,8 +22826,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
+msgstr "Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22969,8 +22927,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Ontgrendel geavanceerde AI-modellen en hogere limieten met een DuckDuckGo-"
-"abonnement"
+"Ontgrendel geavanceerde AI-modellen en hogere limieten met een "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23027,7 +22985,7 @@ msgstr "Dempen opheffen"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Chat zonder titel"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23070,7 +23028,7 @@ msgstr "Browser bijwerken"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Werk Duck.ai bij om deze gedeelde chat te bekijken."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23242,8 +23200,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
+msgstr "Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23353,8 +23310,7 @@ msgstr "Gebruik DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
+msgstr "Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23653,10 +23609,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open 'Duck.ai-"
-"instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en selecteer "
-"'Synchroniseren met een ander apparaat'. Of scan de QR-code op je herstel-"
-"PDF."
+"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open "
+"'Duck.ai-instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en "
+"selecteer 'Synchroniseren met een ander apparaat'. Of scan de QR-code op je "
+"herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23855,8 +23811,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Kijk in Duck Player om gepersonaliseerde advertenties op YouTube te "
-"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op YouTube-"
-"aanbevelingen."
+"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op "
+"YouTube-aanbevelingen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23949,14 +23905,12 @@ msgstr "We achtervolgen je niet met advertenties."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
+msgstr "We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
+msgstr "We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23982,8 +23936,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
+msgstr "We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23991,8 +23944,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
+msgstr "We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24061,6 +24013,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"We zoeken en verwijderen je persoonlijke gegevens van databroker-sites. Plus "
+"heeft een VPN en meer."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24087,8 +24041,7 @@ msgstr "De verbinding is verbroken. Probeer het later opnieuw."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
+msgstr "We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24116,6 +24069,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"We scannen regelmatig databroker-sites op je persoonlijke gegevens, en we "
+"delen onze voortgang met je in een gebruiksvriendelijk dashboard."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24128,8 +24083,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
+msgstr "We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24152,8 +24106,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
+msgstr "We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24162,6 +24115,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"We scannen sites van databrokers op je e-mail, naam, adres en meer, en "
+"werken eraan om alles wat we over je vinden te laten verwijderen."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24195,8 +24150,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
+msgstr "Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24306,8 +24260,7 @@ msgstr "Wekelijkse gebruikslimiet bereikt"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24360,8 +24313,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
+msgstr "Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24482,7 +24434,7 @@ msgstr "Wat zijn enkele voor- en nadelen van lijfrentes?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Wat zijn de voordelen van Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -25060,6 +25012,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Werkt rechtstreeks vanaf je apparaat om je e-mail, naam, adres en meer te "
+"verwijderen van sites van databrokers."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25406,8 +25360,7 @@ msgstr "Je kunt dit op elk moment wijzigen in %1$sZoekinstellingen%2$s"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
+msgstr "Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25570,7 +25523,7 @@ msgstr "Je hebt nog 1 poging over."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Je hebt geen gedeelde chatlinks."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25590,8 +25543,8 @@ msgid ""
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
 "Je hebt nu toegang tot geavanceerde AI-modellen. Je hebt toegang tot de VPN "
-"en andere beveiligingen van het DuckDuckGo-abonnement in de DuckDuckGo-"
-"browser."
+"en andere beveiligingen van het DuckDuckGo-abonnement in de "
+"DuckDuckGo-browser."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25743,8 +25696,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
+msgstr "Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25804,13 +25756,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Je %1$s meest recente chats zijn beschikbaar in de lokale opslag van deze "
+"browsers:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Je Duck.ai-chats worden gesynchroniseerd met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25842,6 +25796,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Je back-up wordt verwijderd van de server van DuckDuckGo. De "
+"synchronisatieverbinding van alle apparaten wordt verbroken."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25938,8 +25894,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25947,8 +25903,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25981,8 +25937,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26220,8 +26176,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
+msgstr "Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26304,8 +26259,7 @@ msgstr "door %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
+msgstr "Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/nn_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nn_NO/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Legg til %s"
 msgid "Add to Home Screen"
 msgstr "Legg til på heimskjermen"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Utvidingar"
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4204,6 +4238,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4236,6 +4275,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4796,6 +4854,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4804,6 +4869,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5010,6 +5082,12 @@ msgstr "Avvis"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5657,6 +5735,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6321,9 +6405,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7416,6 +7513,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7500,6 +7604,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9086,6 +9195,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Finn ut %smeir%s "
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9603,6 +9717,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9809,6 +9929,11 @@ msgstr "Meny"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Meny"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10110,6 +10235,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Meir på"
@@ -10267,6 +10397,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Matt raud"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11146,6 +11281,27 @@ msgstr ""
 "På Mac, %sKlikk Maxthon > Innstillingar%s, På Windows, %sKlikk på %sikonet > "
 "Innstillingar%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11756,6 +11912,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11764,6 +11925,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11808,6 +11974,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12822,6 +13000,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12971,6 +13154,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13178,6 +13366,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13211,6 +13404,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13759,6 +13962,11 @@ msgstr "Lagra innstillingane dine anonymt i skya"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14533,6 +14741,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14657,6 +14871,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14777,6 +14998,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15324,6 +15555,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16013,6 +16249,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16210,6 +16451,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16234,6 +16481,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16687,6 +16939,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16755,6 +17021,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16838,6 +17109,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17354,6 +17635,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17446,6 +17732,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17645,6 +17936,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17653,6 +17949,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18034,6 +18335,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18061,6 +18367,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18837,6 +19148,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18871,6 +19189,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18895,6 +19220,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19139,6 +19471,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19601,6 +19938,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20003,6 +20347,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20169,6 +20519,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Standard for YouTube"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20186,6 +20551,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/od_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/od_IN/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -395,6 +402,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -629,6 +642,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1182,6 +1200,11 @@ msgstr "%s ରେ ଯୋଡ଼ନ୍ତୁ"
 msgid "Add to Home Screen"
 msgstr "ଘର ପରଦାରେ ଯୋଡ଼ନ୍ତୁ"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "ଯୋଗୋପକରଣ"
@@ -1472,6 +1495,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1884,6 +1913,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4200,6 +4234,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4232,6 +4271,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4792,6 +4850,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4800,6 +4865,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5006,6 +5078,12 @@ msgstr "ଖାରଜ"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5653,6 +5731,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6316,9 +6400,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7411,6 +7508,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7495,6 +7599,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9085,6 +9194,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "%sଅଧିକ%s ଜାଣନ୍ତୁ"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9602,6 +9716,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9808,6 +9928,11 @@ msgstr "ମେନୁ"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "ମେନୁ"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10109,6 +10234,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "ଅଧିକ ଏଠାରେ"
@@ -10266,6 +10396,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "ଗାଢ଼ ଲାଲ"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11144,6 +11279,27 @@ msgid ""
 msgstr ""
 "ମ୍ୟାକରେ, %sClick ମାକ୍ସଥନ > ପସନ୍ଦାବଳୀ%s, ୱିଣ୍ଡୋଜ ରେ, %sକ୍ଲିକ କରନ୍ତୁ %s ଆଇକନ > ସେଟିଙ୍ଗ%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11751,6 +11907,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11759,6 +11920,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11803,6 +11969,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12817,6 +12995,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12966,6 +13149,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13173,6 +13361,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13206,6 +13399,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13754,6 +13957,11 @@ msgstr "ଆପଣଙ୍କର ସେଟିଙ୍ଗକୁ ନାମହୀନ ଭ
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14527,6 +14735,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14651,6 +14865,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14772,6 +14993,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15319,6 +15550,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16008,6 +16244,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16205,6 +16446,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16230,6 +16477,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "ଟେଲିଭିଜନ"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16688,6 +16940,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16756,6 +17022,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16839,6 +17110,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17353,6 +17634,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17445,6 +17731,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17644,6 +17935,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17652,6 +17948,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18032,6 +18333,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18059,6 +18365,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18834,6 +19145,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18868,6 +19186,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18892,6 +19217,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19136,6 +19468,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19598,6 +19935,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20000,6 +20344,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20168,6 +20518,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "ୟୁଟ୍ୟୁବ ମାନକ"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20185,6 +20550,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -41,6 +42,14 @@ msgstr "% w pełni zaszczepionych"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% zaszczepionych"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -300,7 +309,8 @@ msgstr "Rankingi %1$s nie są jeszcze dostępne"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s osiąga limity użycia 2-5 razy szybciej niż podstawowe modele. %2$s"
+msgstr ""
+"%1$s osiąga limity użycia 2-5 razy szybciej niż podstawowe modele. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -487,6 +497,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sDowiedz się, jak zapewniamy prywatność Twojej lokalizacji%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -507,7 +524,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
+msgstr ""
+"%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -777,6 +795,12 @@ msgid "2nd in Group %s"
 msgstr "2. w grupie %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -858,7 +882,8 @@ msgstr "Osiągnięto limit 6 godzin użytkowania."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -985,8 +1010,8 @@ msgstr ""
 "Funkcja AI Chat umożliwia prowadzenie anonimowych rozmów z modelami czatu AI "
 "oferowanymi przez inne firmy. Wyłączenie tej opcji spowoduje ukrycie funkcji "
 "AI Chat w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do funkcji AI Chat na stronie "
-"%1$sduckduckgo.com/aichat%2$s."
+"możesz uzyskać dostęp do funkcji AI Chat na stronie %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1462,6 +1487,12 @@ msgid "Add to Home Screen"
 msgstr "Dodaj do ekranu głównego"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Rozszerzenia"
@@ -1827,6 +1858,13 @@ msgid "All types"
 msgstr "Wszystkie typy"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1913,7 +1951,8 @@ msgstr "To urządzenie jest już zsynchronizowane."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
+msgstr ""
+"Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2350,6 +2389,12 @@ msgid "Ask anything privately"
 msgstr "Zapytaj o cokolwiek prywatnie"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2596,7 +2641,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr "Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
+msgstr ""
+"Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2993,7 +3039,8 @@ msgstr "Zablokuj tę witrynę we wszystkich wynikach"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
+msgstr ""
+"Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3333,7 +3380,8 @@ msgstr "Burundi"
 #. The first %s is the action button label ('Continue'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab.
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid "By clicking '%s' you agree to our %s."
-msgstr "Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
+msgstr ""
+"Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3724,7 +3772,8 @@ msgstr "Zmienia sposób wyświetlania adresów URL wyników"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
+msgstr ""
+"Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3743,7 +3792,8 @@ msgstr "Zmienia kolor tła na całej stronie"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
+msgstr ""
+"Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3876,8 +3926,8 @@ msgstr ""
 "rozmów z zewnętrznymi modelami czatu AI, obsługującymi modele OpenAI, "
 "Anthropic i inne. Wyłączenie tej opcji spowoduje ukrycie przycisków czatu i "
 "linków w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do czatu, przechodząc pod adres "
-"%1$shttps://duck.ai%2$s bezpośrednio."
+"możesz uzyskać dostęp do czatu, przechodząc pod adres %1$shttps://duck."
+"ai%2$s bezpośrednio."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -5201,7 +5251,8 @@ msgstr "Kontynuuj blokowanie reklam"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "Kontynuuj ostatnie czaty tutaj. Możesz też usunąć je przyciskiem Fire Button."
+msgstr ""
+"Kontynuuj ostatnie czaty tutaj. Możesz też usunąć je przyciskiem Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5305,6 +5356,12 @@ msgid "Copy"
 msgstr "Kopiuj"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5344,6 +5401,28 @@ msgstr "Skopiuj lub zapisz ten kod"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Skopiuj kod odzyskiwania"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5731,7 +5810,8 @@ msgstr "Osiągnięto dzienny limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6025,6 +6105,14 @@ msgid "Delete recent chats?"
 msgstr "Usunąć ostatnie czaty?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6035,6 +6123,14 @@ msgstr "Usunąć ten czat?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Usunięte czaty"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6290,6 +6386,13 @@ msgstr "Odrzuć"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Odrzuć"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6851,7 +6954,8 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
+msgstr ""
+"Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7124,7 +7228,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
+msgstr ""
+"DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7151,6 +7256,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Przeglądarka DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7786,7 +7898,8 @@ msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
+msgstr ""
+"Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7926,7 +8039,8 @@ msgstr "Gwinea Równikowa"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
+msgstr ""
+"Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7986,13 +8100,29 @@ msgstr "Rozwiń mapę"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
+msgstr ""
+"Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
+
+# smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Wygasła"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8635,7 +8765,8 @@ msgstr "Bezpłatne i prywatne czaty anonimizowane przez nas"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
+msgstr ""
+"Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8879,19 +9010,22 @@ msgstr "Ogólnego przeznaczenia"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr "Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
+msgstr ""
+"Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
+msgstr ""
+"Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr "Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
+msgstr ""
+"Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9267,8 +9401,8 @@ msgstr "Pobierz aplikację"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Pobierz darmową przeglądarkę DuckDuckGo, aby %1$sblokować reklamy na "
-"YouTube.%2$s"
+"Pobierz darmową przeglądarkę DuckDuckGo, aby %1$sblokować reklamy na YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9368,10 +9502,19 @@ msgstr ""
 "PDF."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
+msgstr ""
+"Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9476,6 +9619,12 @@ msgstr "Rozumiem"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Rozumiem"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9893,7 +10042,8 @@ msgstr "Podaj powód negatywnej oceny"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr "Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
+msgstr ""
+"Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -10540,7 +10690,8 @@ msgstr "Jeśli chcesz nas wesprzeć, %1$spomóż nam rozpowszechnić DuckDuckGo%
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
+msgstr ""
+"Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10732,7 +10883,8 @@ msgstr "W menu na górze ekranu wybierz %1$sNarzędzia%2$s > %3$sUstawienia%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
+msgstr ""
+"W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11110,7 +11262,8 @@ msgstr "Jest szybki, bezpłatny i zapewnia Ci jeszcze większą ochronę online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
+msgstr ""
+"Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11175,7 +11328,8 @@ msgstr "Dołącz do nas!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr "Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
+msgstr ""
+"Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -11450,6 +11604,12 @@ msgid "Learn %sMore%s"
 msgstr "Dowiedz się %1$swięcej%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11718,7 +11878,8 @@ msgstr "Linki:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
+msgstr ""
+"Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11829,7 +11990,8 @@ msgstr "Ładuj więcej obrazów podczas przewijania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
+msgstr ""
+"Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12083,6 +12245,13 @@ msgid "Manage"
 msgstr "Zarządzaj"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12332,6 +12501,12 @@ msgstr "Menu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12594,7 +12769,8 @@ msgstr "Osiągnięty limit miesięczny"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12700,6 +12876,12 @@ msgstr "Więcej o !bangs"
 msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr "Więcej o Duck.ai"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12894,6 +13076,12 @@ msgstr "Wyciszony"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Ceglany"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13965,6 +14153,30 @@ msgstr ""
 "%3$skliknij ikonę %4$s > Ustawienia%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14719,6 +14931,12 @@ msgid "Past year"
 msgstr "Ostatni rok"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14729,6 +14947,12 @@ msgstr "Wklej"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Wklej kod Sync"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14782,6 +15006,20 @@ msgstr "Zamknięte na stałe"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "perski"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15853,7 +16091,8 @@ msgstr "Chroń swoje dane podczas wyszukiwania i przeglądania."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
+msgstr ""
+"Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16051,6 +16290,12 @@ msgid "Reading website…"
 msgstr "Czytanie strony internetowej..."
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16066,19 +16311,22 @@ msgstr "Wnioskowanie AI"
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a high moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with high built-in moderation"
-msgstr "Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
+msgstr ""
+"Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr "Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
+msgstr ""
+"Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr "Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
+msgstr ""
+"Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
@@ -16098,7 +16346,8 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Rozumowanie jest dokładniejsze, ale zużywa limity 2-5 razy szybciej. %1$s"
+msgstr ""
+"Rozumowanie jest dokładniejsze, ale zużywa limity 2-5 razy szybciej. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16241,6 +16490,12 @@ msgstr "Odzyskiwanie"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Kod odzyskiwania"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16494,6 +16749,12 @@ msgid "Remove %s"
 msgstr "Usuń %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16534,6 +16795,18 @@ msgstr "Usuń zaznaczanie tekstu"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Usuń niepotrzebne znaki interpunkcyjne"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17198,8 +17471,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu "
-"end-to-end."
+"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu end-"
+"to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17230,6 +17503,12 @@ msgstr "Zapisz swoje ustawienia anonimowo do chmury"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Poznaj Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17777,7 +18056,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
+msgstr ""
+"Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17965,13 +18245,15 @@ msgstr "Wybierz %1$sDuckDuckGo%2$s i kliknij %3$sUstaw jako domyślną%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
+msgstr ""
+"Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
+msgstr ""
+"Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18062,7 +18344,8 @@ msgstr "Wybierz %1$sUstawienia%2$s z rozwijanego menu."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
+msgstr ""
+"Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18233,6 +18516,13 @@ msgid "Serbian (Latin)"
 msgstr "serbski (łaciński)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18387,6 +18677,14 @@ msgid "Share"
 msgstr "Udostępnij"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18401,7 +18699,8 @@ msgstr "Udostępnij"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
+msgstr ""
+"Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18534,6 +18833,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Podziel się opinią na temat pola wyszukiwania."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18926,7 +19237,8 @@ msgstr "Wyświetla poziome linie pomiędzy stronami z wynikami wyszukiwania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
+msgstr ""
+"Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18942,7 +19254,8 @@ msgstr "Wyświetla najczęściej odwiedzane łącza na stronie nowej karty"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
+msgstr ""
+"Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19218,6 +19531,12 @@ msgstr "Coś innego"
 msgctxt "duckai_migration"
 msgid "Something went wrong"
 msgstr "Wystąpił błąd"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19650,7 +19969,8 @@ msgstr "Zatrzymaj generowanie"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
+msgstr ""
+"Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20074,6 +20394,12 @@ msgid "Switch model"
 msgstr "Zmień model"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20206,7 +20532,8 @@ msgstr "Sync & Backup włączone!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
+msgstr ""
+"Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20331,6 +20658,13 @@ msgid "Synced Devices"
 msgstr "Zsynchronizowane urządzenia"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Syria"
 
@@ -20361,6 +20695,12 @@ msgstr "Do ustalenia"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20701,7 +21041,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
+msgstr ""
+"Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20945,6 +21286,22 @@ msgstr ""
 "obraźliwe informacje (więcej informacji można znaleźć pod adresem %4$s)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -21013,19 +21370,27 @@ msgstr "Tego obrazu nie dało się stworzyć."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
+msgstr ""
+"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
+msgstr ""
+"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Ta informacja nie jest przydatna"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21093,7 +21458,8 @@ msgstr "Ta strona do działania wymaga włączonego Javascriptu."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
+msgstr ""
+"Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21141,6 +21507,18 @@ msgstr ""
 "odpowiedzi wspomagane przez sztuczną inteligencję. Jednak mamy także stronę "
 "startową pod adresem %1$s, która nigdy nie wyświetla odpowiedzi wspomaganych "
 "przez AI."
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21201,7 +21579,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
+msgstr ""
+"Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21326,7 +21705,8 @@ msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
+msgstr ""
+"Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21390,7 +21770,8 @@ msgstr "Dziś"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "Przełącz, aby wypróbować prywatny czat AI, lub %1$swyłącz go w menu %2$s.%3$s"
+msgstr ""
+"Przełącz, aby wypróbować prywatny czat AI, lub %1$swyłącz go w menu %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21786,6 +22167,12 @@ msgid "Try Free"
 msgstr "Wypróbuj za darmo"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21865,20 +22252,23 @@ msgstr "Spróbuj innych słów kluczowych."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
+msgstr ""
+"Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
+msgstr ""
+"Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
+msgstr ""
+"Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21897,6 +22287,12 @@ msgstr "Wypróbuj bezpłatnie"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Wypróbuj bezpłatnie"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22148,6 +22544,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22158,6 +22560,12 @@ msgstr "Wyłącz Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Wyłącz Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22223,7 +22631,8 @@ msgstr "Wyłącz:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
+msgstr ""
+"Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -22447,14 +22856,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
+msgstr ""
+"Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: "
-"https://duckduckgo.com"
+"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22464,13 +22874,15 @@ msgstr "Pod %1$sUstawienia wyszukiwania%2$s wybierz %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
+msgstr ""
+"Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
+msgstr ""
+"W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22584,7 +22996,8 @@ msgstr "Odblokuj za pomocą subskrypcji DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
+msgstr ""
+"Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22623,7 +23036,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
+msgstr ""
+"Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -22636,6 +23050,12 @@ msgstr "Odblokuj zabezpieczenia premium"
 msgctxt "voice chat"
 msgid "Unmute"
 msgstr "Wyłącz wyciszenie"
+
+# smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22671,6 +23091,12 @@ msgstr "Aktualizacja"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Zaktualizuj przeglądarkę"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23015,7 +23441,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
+msgstr ""
+"Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23557,7 +23984,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
+msgstr ""
+"Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23641,7 +24069,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
+msgstr ""
+"Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -23653,7 +24082,16 @@ msgstr "Nie śledzimy Cię. To jest nasza polityka prywatności w skrócie…"
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr "Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
+msgstr ""
+"Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23702,6 +24140,14 @@ msgstr ""
 "wyniki, bliżej Ciebie. Zawsze możesz później zmienić zdanie."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23739,6 +24185,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Będziemy blokować mechanizmy śledzące próbujące gromadzić Twoje dane, gdy "
 "przeglądasz internet."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23884,7 +24338,8 @@ msgstr "Osiągnięto tygodniowy limit użycia"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24051,6 +24506,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Jakie są zalety i wady rent dożywotnich?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24306,7 +24767,8 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
+msgstr ""
+"Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24381,7 +24843,8 @@ msgstr "Na jaki temat chcesz przekazać opinię?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
+msgstr ""
+"To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24620,6 +25083,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Bez zerowej widoczności dostawcy"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24904,7 +25375,8 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr "Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
+msgstr ""
+"Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -24958,7 +25430,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
+msgstr ""
+"Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25003,7 +25476,8 @@ msgstr "Możesz kontynuować rozmowę, korzystając z limitu miesięcznego."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
+msgstr ""
+"Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25080,7 +25554,8 @@ msgstr "Można przywrócić swoje ustawienia po usunięciu plików cookie."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr "Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
+msgstr ""
+"Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -25117,6 +25592,13 @@ msgstr "Pozostałe próby: %1$s."
 msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Pozostała 1 próba."
+
+# smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25278,7 +25760,8 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
+msgstr ""
+"Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -25342,6 +25825,23 @@ msgid "YouTube Standard"
 msgstr "YouTube Standard"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Twoja historia wyszukiwania w DuckDuckGo jest prywatna."
@@ -25363,6 +25863,14 @@ msgstr "Twoja bieżąca lokalizacja pozostaje prywatna"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Twoja bieżąca lokalizacja pozostaje prywatna."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25411,8 +25919,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych "
-"witryn.DuckDuckGo nigdy nie ma dostępu do tych danych."
+"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych witryn."
+"DuckDuckGo nigdy nie ma dostępu do tych danych."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25451,7 +25959,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
+msgstr ""
+"Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -49,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (to urządzenie)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -309,8 +308,7 @@ msgstr "Rankingi %1$s nie są jeszcze dostępne"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s osiąga limity użycia 2-5 razy szybciej niż podstawowe modele. %2$s"
+msgstr "%1$s osiąga limity użycia 2-5 razy szybciej niż podstawowe modele. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -501,7 +499,7 @@ msgstr "%1$sDowiedz się, jak zapewniamy prywatność Twojej lokalizacji%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sDowiedz się więcej%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -524,8 +522,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
+msgstr "%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -798,7 +795,7 @@ msgstr "2. w grupie %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "Druga opinia"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -882,8 +879,7 @@ msgstr "Osiągnięto limit 6 godzin użytkowania."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1010,8 +1006,8 @@ msgstr ""
 "Funkcja AI Chat umożliwia prowadzenie anonimowych rozmów z modelami czatu AI "
 "oferowanymi przez inne firmy. Wyłączenie tej opcji spowoduje ukrycie funkcji "
 "AI Chat w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do funkcji AI Chat na stronie %1$sduckduckgo.com/"
-"aichat%2$s."
+"możesz uzyskać dostęp do funkcji AI Chat na stronie "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1490,7 +1486,7 @@ msgstr "Dodaj do ekranu głównego"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Dodaj do moich czatów"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1862,7 +1858,7 @@ msgstr "Wszystkie typy"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Wszystkie Twoje urządzenia zostały odłączone od synchronizacji."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1951,8 +1947,7 @@ msgstr "To urządzenie jest już zsynchronizowane."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
+msgstr "Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2392,7 +2387,7 @@ msgstr "Zapytaj o cokolwiek prywatnie"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Zapytaj o cokolwiek prywatnie"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2641,8 +2636,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
+msgstr "Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -3039,8 +3033,7 @@ msgstr "Zablokuj tę witrynę we wszystkich wynikach"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
+msgstr "Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3380,8 +3373,7 @@ msgstr "Burundi"
 #. The first %s is the action button label ('Continue'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab.
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid "By clicking '%s' you agree to our %s."
-msgstr ""
-"Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
+msgstr "Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3772,8 +3764,7 @@ msgstr "Zmienia sposób wyświetlania adresów URL wyników"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
+msgstr "Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3792,8 +3783,7 @@ msgstr "Zmienia kolor tła na całej stronie"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
+msgstr "Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3926,8 +3916,8 @@ msgstr ""
 "rozmów z zewnętrznymi modelami czatu AI, obsługującymi modele OpenAI, "
 "Anthropic i inne. Wyłączenie tej opcji spowoduje ukrycie przycisków czatu i "
 "linków w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do czatu, przechodząc pod adres %1$shttps://duck."
-"ai%2$s bezpośrednio."
+"możesz uzyskać dostęp do czatu, przechodząc pod adres "
+"%1$shttps://duck.ai%2$s bezpośrednio."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -5251,8 +5241,7 @@ msgstr "Kontynuuj blokowanie reklam"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Kontynuuj ostatnie czaty tutaj. Możesz też usunąć je przyciskiem Fire Button."
+msgstr "Kontynuuj ostatnie czaty tutaj. Możesz też usunąć je przyciskiem Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5359,7 +5348,7 @@ msgstr "Kopiuj"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopiuj"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5408,13 +5397,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Kopiuj udostępniony link"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Skopiuj kod z innego urządzenia"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5423,6 +5412,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Skopiuj kod z innego urządzenia. Przejdź do %1$sUstawienia Duck.ai › Czaty › "
+"Sync & Backup › Synchronizuj z innym urządzeniem%2$s i spróbuj ponownie."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5810,8 +5801,7 @@ msgstr "Osiągnięto dzienny limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6110,7 +6100,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Usuń udostępniony link"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6131,6 +6121,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Usunięcie linku sprawi, że przestanie on działać. Osoby, które go otworzyły "
+"i dodały rozmowę do swoich czatów, zachowają własną kopię."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6392,7 +6384,7 @@ msgstr "Odrzuć"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Odrzuć"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6954,8 +6946,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
+msgstr "Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7228,8 +7219,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
+msgstr "DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7262,7 +7252,7 @@ msgstr "Przeglądarka DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Strony pomocy DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7898,8 +7888,7 @@ msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
+msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8039,8 +8028,7 @@ msgstr "Gwinea Równikowa"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
+msgstr "Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8100,15 +8088,14 @@ msgstr "Rozwiń mapę"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
+msgstr "Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Wygasło"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8122,7 +8109,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Wygasa %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8765,8 +8752,7 @@ msgstr "Bezpłatne i prywatne czaty anonimizowane przez nas"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
+msgstr "Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9010,22 +8996,19 @@ msgstr "Ogólnego przeznaczenia"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9401,8 +9384,8 @@ msgstr "Pobierz aplikację"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Pobierz darmową przeglądarkę DuckDuckGo, aby %1$sblokować reklamy na YouTube."
-"%2$s"
+"Pobierz darmową przeglądarkę DuckDuckGo, aby %1$sblokować reklamy na "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9508,13 +9491,14 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Przejdź do opcji %1$sUstawienia Duck.ai%2$s › %3$sCzaty › Sync & Backup › "
+"Synchronizuj z innym urządzeniem%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
+msgstr "Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9624,7 +9608,7 @@ msgstr "Rozumiem"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Rozumiem"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10042,8 +10026,7 @@ msgstr "Podaj powód negatywnej oceny"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
+msgstr "Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -10690,8 +10673,7 @@ msgstr "Jeśli chcesz nas wesprzeć, %1$spomóż nam rozpowszechnić DuckDuckGo%
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
+msgstr "Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10883,8 +10865,7 @@ msgstr "W menu na górze ekranu wybierz %1$sNarzędzia%2$s > %3$sUstawienia%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
+msgstr "W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11262,8 +11243,7 @@ msgstr "Jest szybki, bezpłatny i zapewnia Ci jeszcze większą ochronę online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
+msgstr "Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11328,8 +11308,7 @@ msgstr "Dołącz do nas!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr ""
-"Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
+msgstr "Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -11607,7 +11586,7 @@ msgstr "Dowiedz się %1$swięcej%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Dowiedz się więcej"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11878,8 +11857,7 @@ msgstr "Linki:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
+msgstr "Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11990,8 +11968,7 @@ msgstr "Ładuj więcej obrazów podczas przewijania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
+msgstr "Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12249,7 +12226,7 @@ msgstr "Zarządzaj"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Zarządzaj"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12506,7 +12483,7 @@ msgstr "Menu"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Wiadomości od tego momentu są widoczne tylko dla Ciebie."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12769,8 +12746,7 @@ msgstr "Osiągnięty limit miesięczny"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12881,7 +12857,7 @@ msgstr "Więcej o Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Więcej akcji"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13081,7 +13057,7 @@ msgstr "Ceglany"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Moje urządzenia"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14159,6 +14135,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Na innym urządzeniu przejdź do opcji %1$sUstawienia Duck.ai%2$s › %3$sCzaty "
+"› Sync & Backup › Synchronizuj z innym urządzeniem%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14167,6 +14145,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Na innym urządzeniu przejdź do opcji %1$sUstawienia Duck.ai%2$s › %3$sCzaty "
+"› Sync & Backup › Synchronizuj z innym urządzeniem%4$s i zeskanuj ten kod:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14175,6 +14155,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Na innym urządzeniu przejdź do opcji %1$sUstawienia Duck.ai%2$s › %3$sCzaty "
+"› Sync & Backup › Synchronizuj z innym urządzeniem%4$s. Albo zeskanuj kod QR "
+"w swoim pliku odzyskiwania PDF."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14934,7 +14917,7 @@ msgstr "Ostatni rok"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Wklej"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14952,7 +14935,7 @@ msgstr "Wklej kod Sync"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Wklej poniżej"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -15011,7 +14994,7 @@ msgstr "perski"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -15020,6 +15003,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Funkcja Personal Information Removal wyszukuje Twoje dane w witrynach "
+"brokerów danych, którzy je sprzedają. Następnie pracujemy nad ich usunięciem "
+"dla Ciebie."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -16091,8 +16077,7 @@ msgstr "Chroń swoje dane podczas wyszukiwania i przeglądania."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
+msgstr "Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16293,7 +16278,7 @@ msgstr "Czytanie strony internetowej..."
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Chcesz obejrzeć zaćmienie słońca?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16311,22 +16296,19 @@ msgstr "Wnioskowanie AI"
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a high moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with high built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
@@ -16346,8 +16328,7 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Rozumowanie jest dokładniejsze, ale zużywa limity 2-5 razy szybciej. %1$s"
+msgstr "Rozumowanie jest dokładniejsze, ale zużywa limity 2-5 razy szybciej. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16495,7 +16476,7 @@ msgstr "Kod odzyskiwania"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Kod odzyskiwania"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16752,7 +16733,7 @@ msgstr "Usuń %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Usuń urządzenie"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16800,13 +16781,13 @@ msgstr "Usuń niepotrzebne znaki interpunkcyjne"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Usuń swoje dane z Internetu"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Usuń swoje dane z Internetu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17471,8 +17452,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu end-"
-"to-end."
+"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17508,7 +17489,7 @@ msgstr "Poznaj Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Poznaj Duck.ai – darmowy, prywatny czat AI od DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -18056,8 +18037,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
+msgstr "Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18245,15 +18225,13 @@ msgstr "Wybierz %1$sDuckDuckGo%2$s i kliknij %3$sUstaw jako domyślną%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
+msgstr "Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
+msgstr "Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18344,8 +18322,7 @@ msgstr "Wybierz %1$sUstawienia%2$s z rozwijanego menu."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
+msgstr "Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18520,7 +18497,7 @@ msgstr "serbski (łaciński)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Usunięto dane serwera"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18682,7 +18659,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Udostępnij"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18699,8 +18676,7 @@ msgstr "Udostępnij"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
+msgstr "Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18838,13 +18814,13 @@ msgstr "Podziel się opinią na temat pola wyszukiwania."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Udostępnione linki do czatów"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Udostępnione linki do czatów"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19237,8 +19213,7 @@ msgstr "Wyświetla poziome linie pomiędzy stronami z wynikami wyszukiwania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
+msgstr "Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19254,8 +19229,7 @@ msgstr "Wyświetla najczęściej odwiedzane łącza na stronie nowej karty"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
+msgstr "Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19536,7 +19510,7 @@ msgstr "Wystąpił błąd"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Nie udało się wczytać tego udostępnionego czatu."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19969,8 +19943,7 @@ msgstr "Zatrzymaj generowanie"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
+msgstr "Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20397,7 +20370,7 @@ msgstr "Zmień model"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Zmień model"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20532,8 +20505,7 @@ msgstr "Sync & Backup włączone!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
+msgstr "Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20662,7 +20634,7 @@ msgstr "Zsynchronizowane urządzenia"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Zsynchronizowano %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20700,7 +20672,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabela"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -21041,8 +21013,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
+msgstr "Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21289,7 +21260,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "To urządzenie"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21300,6 +21271,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"To urządzenie nie będzie już mieć dostępu do zsynchronizowanych danych na "
+"innych urządzeniach. Ostatnie czaty (%1$s) pozostaną nadal dostępne w "
+"pamięci lokalnej."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21370,16 +21344,14 @@ msgstr "Tego obrazu nie dało się stworzyć."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
+msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
+msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21390,7 +21362,7 @@ msgstr "Ta informacja nie jest przydatna"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "To jest kopia udostępnionego czatu."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21458,8 +21430,7 @@ msgstr "Ta strona do działania wymaga włączonego Javascriptu."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
+msgstr "Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21512,13 +21483,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Nie udało się otworzyć tego udostępnionego czatu. Link może być niekompletny."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Ten udostępniony link do czatu nie jest już dostępny."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21579,8 +21550,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
+msgstr "Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21705,8 +21675,7 @@ msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
+msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21770,8 +21739,7 @@ msgstr "Dziś"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"Przełącz, aby wypróbować prywatny czat AI, lub %1$swyłącz go w menu %2$s.%3$s"
+msgstr "Przełącz, aby wypróbować prywatny czat AI, lub %1$swyłącz go w menu %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22170,7 +22138,7 @@ msgstr "Wypróbuj za darmo"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Wypróbuj bezpłatnie!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22252,23 +22220,20 @@ msgstr "Spróbuj innych słów kluczowych."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
+msgstr "Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
+msgstr "Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
+msgstr "Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22292,7 +22257,7 @@ msgstr "Wypróbuj bezpłatnie"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Wypróbuj bezpłatnie!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22547,7 +22512,7 @@ msgstr "Turkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Wyłącz"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22565,7 +22530,7 @@ msgstr "Wyłącz Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Wyłączyć Sync & Backup i usunąć dane z serwera?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22631,8 +22596,7 @@ msgstr "Wyłącz:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
+msgstr "Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -22856,15 +22820,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
+msgstr "Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: https://"
-"duckduckgo.com"
+"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22874,15 +22837,13 @@ msgstr "Pod %1$sUstawienia wyszukiwania%2$s wybierz %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
+msgstr "Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
+msgstr "W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22996,8 +22957,7 @@ msgstr "Odblokuj za pomocą subskrypcji DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
+msgstr "Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23036,8 +22996,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
+msgstr "Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23055,7 +23014,7 @@ msgstr "Wyłącz wyciszenie"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Czat bez tytułu"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23096,7 +23055,7 @@ msgstr "Zaktualizuj przeglądarkę"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Zaktualizuj Duck.ai, aby zobaczyć ten udostępniony czat."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23441,8 +23400,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
+msgstr "Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23984,8 +23942,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
+msgstr "Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24069,8 +24026,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
+msgstr "Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24082,8 +24038,7 @@ msgstr "Nie śledzimy Cię. To jest nasza polityka prywatności w skrócie…"
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr ""
-"Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
+msgstr "Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
@@ -24092,6 +24047,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Znajdujemy i usuwamy Twoje dane osobowe z witryn brokerów danych. Zyskasz "
+"też VPN i znacznie więcej."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24146,6 +24103,9 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Regularnie skanujemy witryny brokerów danych pod kątem Twoich danych "
+"osobowych, a postępami dzielimy się z Tobą za pośrednictwem łatwego w użyciu "
+"panelu."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24193,6 +24153,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Przeskanujemy witryny brokerów danych pod kątem Twojego adresu e-mail, "
+"imienia i nazwiska, adresu i innych informacji oraz zajmiemy się usunięciem "
+"wszystkiego, co o Tobie znajdziemy."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24338,8 +24301,7 @@ msgstr "Osiągnięto tygodniowy limit użycia"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24511,7 +24473,7 @@ msgstr "Jakie są zalety i wady rent dożywotnich?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Jakie są korzyści z Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24767,8 +24729,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
+msgstr "Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24843,8 +24804,7 @@ msgstr "Na jaki temat chcesz przekazać opinię?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
+msgstr "To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25091,6 +25051,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Działa bezpośrednio z Twojego urządzenia, pozwalając usunąć Twój adres "
+"e-mail, imię i nazwisko, adres i inne dane z witryn brokerów danych."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25375,8 +25337,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
+msgstr "Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -25430,8 +25391,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
+msgstr "Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25476,8 +25436,7 @@ msgstr "Możesz kontynuować rozmowę, korzystając z limitu miesięcznego."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
+msgstr "Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25554,8 +25513,7 @@ msgstr "Można przywrócić swoje ustawienia po usunięciu plików cookie."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr ""
-"Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
+msgstr "Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -25598,7 +25556,7 @@ msgstr "Pozostała 1 próba."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Nie masz udostępnionych linków do czatu."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25760,8 +25718,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
+msgstr "Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -25833,13 +25790,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Twoje ostatnie czaty (%1$s) będą dostępne w pamięci lokalnej w następujących "
+"przeglądarkach:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Twoje czaty Duck.ai są synchronizowane z użyciem szyfrowania end-to-end."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25871,6 +25830,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Twoja kopia zapasowa zostanie usunięta z serwera DuckDuckGo. Wszystkie "
+"urządzenia zostaną odłączone od synchronizacji."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25919,8 +25880,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych witryn."
-"DuckDuckGo nigdy nie ma dostępu do tych danych."
+"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych "
+"witryn.DuckDuckGo nigdy nie ma dostępu do tych danych."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25959,8 +25920,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
+msgstr "Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.

--- a/locales/ps_AF/LC_MESSAGES/duckduckgo.po
+++ b/locales/ps_AF/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr ""
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr ""
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4193,6 +4227,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4225,6 +4264,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4785,6 +4843,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4793,6 +4858,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -4999,6 +5071,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5646,6 +5724,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6308,9 +6392,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7401,6 +7498,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7485,6 +7589,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9069,6 +9178,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9586,6 +9700,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9791,6 +9911,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10093,6 +10218,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10249,6 +10379,11 @@ msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
+msgstr ""
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
 msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -11127,6 +11262,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11731,6 +11887,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11739,6 +11900,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11783,6 +11949,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12797,6 +12975,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12946,6 +13129,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13153,6 +13341,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13186,6 +13379,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13734,6 +13937,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14498,6 +14706,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14622,6 +14836,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14741,6 +14962,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15288,6 +15519,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15977,6 +16213,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16174,6 +16415,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16198,6 +16445,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16651,6 +16903,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16719,6 +16985,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16802,6 +17073,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17316,6 +17597,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17408,6 +17694,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17607,6 +17898,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17615,6 +17911,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -17992,6 +18293,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18019,6 +18325,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18785,6 +19096,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18819,6 +19137,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18843,6 +19168,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19087,6 +19419,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19549,6 +19886,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19949,6 +20293,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20113,6 +20463,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20130,6 +20495,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/pt_BR/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_BR/LC_MESSAGES/duckduckgo.po
@@ -43,6 +43,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -400,6 +407,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%sAprenda como nós mantemos sua localização privada%s."
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -634,6 +647,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1189,6 +1207,11 @@ msgstr "Adicione ao %s"
 msgid "Add to Home Screen"
 msgstr "Adicionar à página inicial"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Complementos"
@@ -1482,6 +1505,12 @@ msgstr "Todos os tamanhos"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Todos os tipos"
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
@@ -1896,6 +1925,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4240,6 +4274,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4272,6 +4311,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4832,6 +4890,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4840,6 +4905,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5046,6 +5118,12 @@ msgstr "Dispensar"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5694,6 +5772,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6382,9 +6466,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7479,6 +7576,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7563,6 +7667,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9174,6 +9283,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Saiba %smais%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9694,6 +9808,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9900,6 +10020,11 @@ msgstr "Menu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10201,6 +10326,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Mais em"
@@ -10358,6 +10488,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Vermelho suave"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11237,6 +11372,27 @@ msgstr ""
 "No Mac, %sClique Maxthon > Preferências%s, No Windows, %sClique no %s ícone "
 "> Configurações%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11854,6 +12010,11 @@ msgstr "Semana passada"
 msgid "Past year"
 msgstr "Ano passado"
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11862,6 +12023,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11907,6 +12073,18 @@ msgstr ""
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persa"
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
 msgctxt "Assistant role option label for Personal trainer"
@@ -12922,6 +13100,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13071,6 +13254,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13278,6 +13466,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13311,6 +13504,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13859,6 +14062,11 @@ msgstr "Salve as suas configurações anonimamente na nuvem"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14645,6 +14853,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Sérvio (latim)"
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14771,6 +14985,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14892,6 +15113,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15449,6 +15680,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16138,6 +16374,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16335,6 +16576,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16360,6 +16607,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "TV"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16820,6 +17072,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16888,6 +17154,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16971,6 +17242,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17489,6 +17770,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17582,6 +17868,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17781,6 +18072,11 @@ msgstr "Turco"
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17789,6 +18085,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18173,6 +18474,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18200,6 +18506,11 @@ msgstr "Atualizar"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18980,6 +19291,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -19016,6 +19334,13 @@ msgstr ""
 "Usamos apenas sua localização anônima para entregar melhores resultados, "
 "mais perto de você. Você sempre pode mudar de ideia mais tarde."
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -19040,6 +19365,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19284,6 +19616,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19748,6 +20085,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20153,6 +20497,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20324,6 +20674,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Padrão do YouTube"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20341,6 +20706,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Este dispositivo)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -503,7 +503,7 @@ msgstr "%1$sAprende como mantemos a tua localização privada%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sSabe mais%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -526,8 +526,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
+msgstr "%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -800,7 +799,7 @@ msgstr "2.º no Grupo %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2.ª opinião"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1317,8 +1316,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr ""
-"Os cliques em anúncios não são usados para criar perfis de utilizadores"
+msgstr "Os cliques em anúncios não são usados para criar perfis de utilizadores"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1495,7 +1493,7 @@ msgstr "Adicionar à Página Inicial"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Adicionar aos meus chats"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1867,7 +1865,7 @@ msgstr "Qualquer tipo"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "A sincronização está desativada em todos os teus dispositivos."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1904,8 +1902,7 @@ msgstr "Permitir a revisão anónima de ficheiros neste chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
+msgstr "Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2399,7 +2396,7 @@ msgstr "Pergunta o que quiseres em privado"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Pergunta o que quiseres em privado"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2626,8 +2623,7 @@ msgstr "Resposta automática"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
+msgstr "Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2882,8 +2878,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Antes de guardar este relatório, o DuckDuckGo irá anonimizar a tua conversa "
-"removendo informações de identificação pessoal, como nomes, endereços de e-"
-"mail e metadados identificativos."
+"removendo informações de identificação pessoal, como nomes, endereços de "
+"e-mail e metadados identificativos."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3784,8 +3780,7 @@ msgstr "Modifica a cor de fundo em todo o site"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
+msgstr "Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4168,8 +4163,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Consulta a página de estado para atualizações sobre esta indisponibilidade."
+msgstr "Consulta a página de estado para atualizações sobre esta indisponibilidade."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4652,8 +4646,7 @@ msgstr "Clica em %1$sFornecedores de Pesquisa%2$s em tipos de Add-on"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
+msgstr "No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -5347,7 +5340,7 @@ msgstr "Copiar"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Copiar"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5396,13 +5389,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Copiar link partilhado"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Copia o código a partir de outro dispositivo"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5411,6 +5404,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Copia o código a partir de outro dispositivo. Vai a %1$sDefinições do "
+"Duck.ai › Chats › Sync & Backup › Sincronizar com outro dispositivo%2$s e "
+"tenta novamente."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5798,8 +5794,7 @@ msgstr "Limite diário atingido"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização diária atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização diária atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6098,7 +6093,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Eliminar link partilhado"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6119,6 +6114,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Se eliminares um link, este deixa de funcionar. Quem já o tiver aberto e "
+"adicionado a conversa aos próprios chats, vai ficar com uma cópia."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6380,7 +6377,7 @@ msgstr "Ignorar"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Ignorar"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6948,8 +6945,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
+msgstr "O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7029,8 +7025,7 @@ msgstr "Duck.ai atualizado!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
+msgstr "O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7249,7 +7244,7 @@ msgstr "Navegador DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Páginas de Ajuda do DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7475,8 +7470,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
+msgstr "As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7875,22 +7869,19 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
+msgstr "Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
+msgstr "Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
+msgstr "Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7930,15 +7921,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Certifica-te de que o teu navegador tem permissão para aceder à localização"
+msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Certifica-te de que o teu navegador tem permissão para aceder à localização."
+msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8103,7 +8092,7 @@ msgstr ""
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Expirado"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8117,7 +8106,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Expira em %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8760,8 +8749,7 @@ msgstr "Chats gratuitos e privados, anonimizados por nós"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
+msgstr "Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9169,8 +9157,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Obtém a VPN da DuckDuckGo, Duck.ai avançado e Identity Theft Restoration."
+msgstr "Obtém a VPN da DuckDuckGo, Duck.ai avançado e Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9314,8 +9301,7 @@ msgstr "Obter ajuda informática"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
-"Obtém limites de utilização mais elevados com uma subscrição da DuckDuckGo."
+msgstr "Obtém limites de utilização mais elevados com uma subscrição da DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9394,8 +9380,8 @@ msgstr "Descarrega a aplicação"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obtém o navegador DuckDuckGo gratuito %1$spara bloquear anúncios no YouTube."
-"%2$s"
+"Obtém o navegador DuckDuckGo gratuito %1$spara bloquear anúncios no "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9500,6 +9486,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Vai a %1$sDefinições do Duck.ai%2$s › %3$sChats › Sync & Backup › "
+"Sincronizar com outro dispositivo%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9616,7 +9604,7 @@ msgstr "Entendi"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Entendido"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -11249,8 +11237,7 @@ msgstr "É rápido, gratuito e oferece ainda mais proteção online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
+msgstr "Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11593,7 +11580,7 @@ msgstr "Sabe %1$smais%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Sabe mais"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11652,8 +11639,7 @@ msgstr "Saber mais sobre a Proteção de privacidade ativa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
+msgstr "Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11769,8 +11755,7 @@ msgstr "Deixa-te pesquisar anonimamente com o DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Permite alternar entre o envio de consultas de pesquisa e pedidos ao Duck.ai"
+msgstr "Permite alternar entre o envio de consultas de pesquisa e pedidos ao Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11862,8 +11847,7 @@ msgstr "Ligações:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
+msgstr "Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12161,8 +12145,8 @@ msgstr "Certifica-te de que todas as palavras estão escritas corretamente."
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar pré-"
-"definido\"%2$s"
+"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar "
+"pré-definido\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12234,7 +12218,7 @@ msgstr "Gerir"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Gerir"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12491,7 +12475,7 @@ msgstr "Menu"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "As mensagens a partir deste ponto só são visíveis para ti."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12695,8 +12679,7 @@ msgstr "Capitalização do mercado"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Mobile Instructions (not displayed on settings page)"
-msgstr ""
-"Instruções para dispositivos móveis (não disponível na página de definições)"
+msgstr "Instruções para dispositivos móveis (não disponível na página de definições)"
 
 # smartling.placeholder_format=C
 #. A short label indicating that a user is a moderator of a discussion.
@@ -12755,8 +12738,7 @@ msgstr "Limite mensal atingido"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12867,7 +12849,7 @@ msgstr "Mais sobre o Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Mais ações"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13067,7 +13049,7 @@ msgstr "Vermelho fosco"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Os meus dispositivos"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14147,6 +14129,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Noutro dispositivo, vai a %1$sDefinições do Duck.ai%2$s › %3$sChats › Sync & "
+"Backup › Sincronizar com outro dispositivo%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14155,6 +14139,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Noutro dispositivo, vai a %1$sDefinições do Duck.ai%2$s › %3$sChats › Sync & "
+"Backup › Sincronizar com outro dispositivo%4$s e digitaliza este código:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14163,6 +14149,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Noutro dispositivo, vai a %1$sDefinições do Duck.ai%2$s › %3$sChats › Sync & "
+"Backup › Sincronizar com outro dispositivo%4$s. Ou digitaliza o QR que está "
+"no teu PDF de recuperação."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14923,7 +14912,7 @@ msgstr "Último ano"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Colar"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14941,7 +14930,7 @@ msgstr "Colar código de sincronização"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Cola-o abaixo"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -15000,7 +14989,7 @@ msgstr "Persa"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -15009,6 +14998,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"A Personal Information Removal encontra as tuas informações em sites de "
+"corretores de dados que as estão a vender. Depois, tratamos de as remover "
+"por ti."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15281,8 +15273,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
+msgstr "Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -16280,7 +16271,7 @@ msgstr "A ler o website…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Estás pronto para o eclipse solar?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16480,7 +16471,7 @@ msgstr "Código de recuperação"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Código de recuperação"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16690,8 +16681,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão &quot;"
-"Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
+"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão "
+"&quot;Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16701,8 +16692,7 @@ msgstr "Memorizar a minha opção"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
+msgstr "Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16738,7 +16728,7 @@ msgstr "Remover %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Remover dispositivo"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16786,13 +16776,13 @@ msgstr "Remove a pontuação desnecessária"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Remove as tuas informações da Internet"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Remove as tuas informações online"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17089,8 +17079,7 @@ msgstr "Os resultados excluem informações de sites bloqueados."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
+msgstr "Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17448,8 +17437,7 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
+msgstr "Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17494,7 +17482,7 @@ msgstr "Diz olá ao Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Diz olá ao Duck.ai – chat de IA gratuito e privado da DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17641,8 +17629,7 @@ msgstr "Desce na página e localiza %1$so teu navegador%2$s na lista."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
+msgstr "Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18215,8 +18202,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
+msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18233,8 +18219,7 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sPredefinir%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
+msgstr "Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18254,8 +18239,7 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s na lista de fornecedores de pesquisa"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
+msgstr "Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18340,8 +18324,7 @@ msgstr "Seleciona %1$sDefinições%2$s e depois %3$sDefinições Avançadas%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
+msgstr "Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18512,7 +18495,7 @@ msgstr "Sérvio (latim)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Dados do servidor eliminados"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18674,7 +18657,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Partilhar"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18691,8 +18674,7 @@ msgstr "Partilhar"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
+msgstr "Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18830,13 +18812,13 @@ msgstr "Partilha as tuas opiniões sobre a caixa de pesquisa."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Links de chat partilhados"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Links de chat partilhados"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19085,8 +19067,7 @@ msgstr "Mostrar todos os resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
+msgstr "Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19228,8 +19209,7 @@ msgstr "Mostrar linhas horizontais nas quebras de página de resultados"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
+msgstr "Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19245,14 +19225,12 @@ msgstr "Mostra os links mais visitados na página de um novo separador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
+msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
+msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19283,8 +19261,7 @@ msgstr "Mostra sugestões na caixa de pesquisa enquanto digitas"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
+msgstr "Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19294,8 +19271,7 @@ msgstr "Mostra o fundo do botão de pesquisa"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
+msgstr "Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19530,7 +19506,7 @@ msgstr "Ocorreu um erro"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Ocorreu um erro ao carregar esta conversa partilhada."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19622,8 +19598,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"Este código é inválido. Confirma que introduziste ou leste o código correto."
+msgstr "Este código é inválido. Confirma que introduziste ou leste o código correto."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19910,22 +19885,19 @@ msgstr "Fica no DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
+msgstr "Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19968,8 +19940,7 @@ msgstr "Bloqueia os rastreadores ocultos que se escondem noutros sites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
+msgstr "Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20142,8 +20113,7 @@ msgstr "Sugere um título para uma publicação num blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
+msgstr "Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20388,7 +20358,7 @@ msgstr "Mudar de modelo"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Mudar de modelo"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20655,7 +20625,7 @@ msgstr "Dispositivos sincronizados"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Sincronizado em %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20693,7 +20663,7 @@ msgstr "Televisão"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabela"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -21207,8 +21177,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
+msgstr "Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21284,7 +21253,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Este dispositivo"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21295,20 +21264,21 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Este dispositivo deixará de poder aceder aos teus dados sincronizados "
+"noutros dispositivos. Os últimos %1$s chats continuarão disponíveis no "
+"armazenamento local."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
+msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
+msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21385,7 +21355,7 @@ msgstr "Esta informação não é útil"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Esta é uma cópia de um chat partilhado."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21509,12 +21479,14 @@ msgstr ""
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
 msgstr ""
+"Não foi possível abrir esta conversa partilhada. O link pode estar "
+"incompleto."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Este link de chat partilhado já não está disponível."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21537,8 +21509,7 @@ msgstr "Esta tradução está errada"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
+msgstr "Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21572,8 +21543,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
+msgstr "Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21700,8 +21670,7 @@ msgstr "Para continuar, tens de concordar com a %1$s e os %2$sdo Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
+msgstr "Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21766,8 +21735,8 @@ msgstr "Hoje"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Muda para experimentares o chat privado de IA ou %1$sdesativa-o no menu %2$s."
-"%3$s"
+"Muda para experimentares o chat privado de IA ou %1$sdesativa-o no menu "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22115,8 +22084,7 @@ msgstr "Experimenta %1$s para deixar de ver mensagens como esta."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
+msgstr "Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22167,7 +22135,7 @@ msgstr "Experimentar gratuitamente"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Experimenta gratuitamente!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22257,8 +22225,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Tenta permitir a localização anónima para obter resultados mais específicos."
+msgstr "Tenta permitir a localização anónima para obter resultados mais específicos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22289,7 +22256,7 @@ msgstr "Experimentar gratuitamente"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Experimenta gratuitamente!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22439,8 +22406,7 @@ msgstr "Experimenta o novo chat privado de voz em tempo real!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
+msgstr "Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -22545,7 +22511,7 @@ msgstr "Turquemenistão"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Desativar"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22563,7 +22529,7 @@ msgstr "Desativar Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Desativar Sync & Backup e eliminar dados do servidor?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22851,14 +22817,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
+msgstr "Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
+msgstr "Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23023,8 +22987,7 @@ msgstr "Desbloqueia modelos avançados"
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
+msgstr "Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -23052,7 +23015,7 @@ msgstr "Ativar som"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Chat sem título"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23093,7 +23056,7 @@ msgstr "Atualizar navegador"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Atualiza o Duck.ai para veres este chat partilhado."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23622,8 +23585,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
+msgstr "Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -24082,6 +24044,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Encontramos e removemos os teus dados pessoais de sites de corretores de "
+"dados. Além disso, obténs acesso a uma VPN e muito mais."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24136,6 +24100,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Procuramos regularmente as tuas informações pessoais em sites de corretores "
+"de dados e partilhamos o nosso progresso contigo num painel fácil de usar."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24184,6 +24150,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Iremos procurar o teu e-mail, nome, morada e outras informações em sites de "
+"corretores de dados e tentar remover tudo o que encontrarmos sobre ti."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24329,8 +24297,7 @@ msgstr "Limite de utilização semanal atingido"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24475,15 +24442,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Quais são alguns fatores a considerar ao comprar um monitor de computador?"
+msgstr "Quais são alguns fatores a considerar ao comprar um monitor de computador?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
+msgstr "Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24505,7 +24470,7 @@ msgstr "Quais são alguns prós e contras das anuidades?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Quais são os benefícios do Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24608,8 +24573,7 @@ msgstr "Quais são os pratos que tens de experimentar aqui?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Quais são os horários de funcionamento, localização e contactos deste local?"
+msgstr "Quais são os horários de funcionamento, localização e contactos deste local?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24759,8 +24723,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
+msgstr "O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24835,8 +24798,7 @@ msgstr "Sobre o que gostarias de dar feedback?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
+msgstr "O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25082,6 +25044,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Funciona diretamente no teu dispositivo para remover o teu e-mail, nome, "
+"morada e muito mais dos sites de corretores de dados."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25422,8 +25386,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
+msgstr "Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25468,8 +25431,7 @@ msgstr "Podes continuar a conversar usando o teu limite mensal."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
+msgstr "Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25589,7 +25551,7 @@ msgstr "Tens mais 1 tentativa."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Não tens links de chat partilhados."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25761,8 +25723,7 @@ msgstr "Atingiste o limite de chat de voz para hoje. Tente novamente amanhã."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
+msgstr "Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25823,6 +25784,8 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Os teus %1$s chats mais recentes estarão disponíveis no armazenamento local "
+"nestes navegadores:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -25830,6 +25793,8 @@ msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
 msgstr ""
+"Os teus chats do Duck.ai estão a ser sincronizados com encriptação ponto a "
+"ponto."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25861,6 +25826,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"A tua cópia de segurança será eliminada do servidor da DuckDuckGo. A "
+"sincronização será desativada em todos os teus dispositivos."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26012,8 +25979,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
+msgstr "Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26233,15 +26199,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
+msgstr "Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
+msgstr "Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26324,8 +26288,7 @@ msgstr "por %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
+msgstr "DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% totalmente vacinados"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% vacinados"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -491,6 +499,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sAprende como mantemos a tua localização privada%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -511,7 +526,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
+msgstr ""
+"%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -779,6 +795,12 @@ msgstr "Pts. ganhos no 2.º serviço"
 msgctxt "Sports module"
 msgid "2nd in Group %s"
 msgstr "2.º no Grupo %1$s"
+
+# smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1295,7 +1317,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr "Os cliques em anúncios não são usados para criar perfis de utilizadores"
+msgstr ""
+"Os cliques em anúncios não são usados para criar perfis de utilizadores"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1467,6 +1490,12 @@ msgstr "Adicionar a %1$s"
 #. Button that creates a shortcut to the current page on the home screen of the user's phone.
 msgid "Add to Home Screen"
 msgstr "Adicionar à Página Inicial"
+
+# smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1834,6 +1863,13 @@ msgid "All types"
 msgstr "Qualquer tipo"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1868,7 +1904,8 @@ msgstr "Permitir a revisão anónima de ficheiros neste chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
+msgstr ""
+"Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2359,6 +2396,12 @@ msgid "Ask anything privately"
 msgstr "Pergunta o que quiseres em privado"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2583,7 +2626,8 @@ msgstr "Resposta automática"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
+msgstr ""
+"Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2838,8 +2882,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Antes de guardar este relatório, o DuckDuckGo irá anonimizar a tua conversa "
-"removendo informações de identificação pessoal, como nomes, endereços de "
-"e-mail e metadados identificativos."
+"removendo informações de identificação pessoal, como nomes, endereços de e-"
+"mail e metadados identificativos."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3740,7 +3784,8 @@ msgstr "Modifica a cor de fundo em todo o site"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
+msgstr ""
+"Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4123,7 +4168,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Consulta a página de estado para atualizações sobre esta indisponibilidade."
+msgstr ""
+"Consulta a página de estado para atualizações sobre esta indisponibilidade."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4606,7 +4652,8 @@ msgstr "Clica em %1$sFornecedores de Pesquisa%2$s em tipos de Add-on"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
+msgstr ""
+"No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -5297,6 +5344,12 @@ msgid "Copy"
 msgstr "Copiar"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5336,6 +5389,28 @@ msgstr "Copia ou guarda este código"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Copiar o código de recuperação"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5723,7 +5798,8 @@ msgstr "Limite diário atingido"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Limite de utilização diária atingido. Podes continuar este chat após %1$s."
+msgstr ""
+"Limite de utilização diária atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6017,6 +6093,14 @@ msgid "Delete recent chats?"
 msgstr "Eliminar as conversas recentes?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6027,6 +6111,14 @@ msgstr "Eliminar esta conversa?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Conversas eliminadas"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6282,6 +6374,13 @@ msgstr "Recusar"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Ignorar"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6849,7 +6948,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr "O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
+msgstr ""
+"O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6929,7 +7029,8 @@ msgstr "Duck.ai atualizado!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
+msgstr ""
+"O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7142,6 +7243,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Navegador DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7367,7 +7475,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
+msgstr ""
+"As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7766,19 +7875,22 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
+msgstr ""
+"Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
+msgstr ""
+"Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
+msgstr ""
+"Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7818,13 +7930,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização"
+msgstr ""
+"Certifica-te de que o teu navegador tem permissão para aceder à localização"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização."
+msgstr ""
+"Certifica-te de que o teu navegador tem permissão para aceder à localização."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7985,10 +8099,25 @@ msgstr ""
 "privacidade."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Expirado"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8631,7 +8760,8 @@ msgstr "Chats gratuitos e privados, anonimizados por nós"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
+msgstr ""
+"Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9039,7 +9169,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "Obtém a VPN da DuckDuckGo, Duck.ai avançado e Identity Theft Restoration."
+msgstr ""
+"Obtém a VPN da DuckDuckGo, Duck.ai avançado e Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9183,7 +9314,8 @@ msgstr "Obter ajuda informática"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr "Obtém limites de utilização mais elevados com uma subscrição da DuckDuckGo."
+msgstr ""
+"Obtém limites de utilização mais elevados com uma subscrição da DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9262,8 +9394,8 @@ msgstr "Descarrega a aplicação"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obtém o navegador DuckDuckGo gratuito %1$spara bloquear anúncios no "
-"YouTube.%2$s"
+"Obtém o navegador DuckDuckGo gratuito %1$spara bloquear anúncios no YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9360,6 +9492,14 @@ msgstr ""
 "Acede a %1$sDefinições do Duck.ai%2$s no teu outro navegador, ou na "
 "aplicação DuckDuckGo e acede a %3$sChats › Sync & Backup › Sincronizar com "
 "outro dispositivo%4$s. Ou lê o código QR no teu PDF de recuperação."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9471,6 +9611,12 @@ msgstr "Entendido"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Entendi"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -11103,7 +11249,8 @@ msgstr "É rápido, gratuito e oferece ainda mais proteção online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
+msgstr ""
+"Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11443,6 +11590,12 @@ msgid "Learn %sMore%s"
 msgstr "Sabe %1$smais%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11499,7 +11652,8 @@ msgstr "Saber mais sobre a Proteção de privacidade ativa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr "Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
+msgstr ""
+"Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11615,7 +11769,8 @@ msgstr "Deixa-te pesquisar anonimamente com o DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Permite alternar entre o envio de consultas de pesquisa e pedidos ao Duck.ai"
+msgstr ""
+"Permite alternar entre o envio de consultas de pesquisa e pedidos ao Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11707,7 +11862,8 @@ msgstr "Ligações:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
+msgstr ""
+"Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12005,8 +12161,8 @@ msgstr "Certifica-te de que todas as palavras estão escritas corretamente."
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar "
-"pré-definido\"%2$s"
+"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar pré-"
+"definido\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12072,6 +12228,13 @@ msgstr "Malware"
 #. Text for generic link to send the user to a page to manage their settings.
 msgid "Manage"
 msgstr "Gerir"
+
+# smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12325,6 +12488,12 @@ msgid "Menu"
 msgstr "Menu"
 
 # smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
 msgstr "Métrico (quilogramas, metros, Celsius)"
@@ -12526,7 +12695,8 @@ msgstr "Capitalização do mercado"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Mobile Instructions (not displayed on settings page)"
-msgstr "Instruções para dispositivos móveis (não disponível na página de definições)"
+msgstr ""
+"Instruções para dispositivos móveis (não disponível na página de definições)"
 
 # smartling.placeholder_format=C
 #. A short label indicating that a user is a moderator of a discussion.
@@ -12585,7 +12755,8 @@ msgstr "Limite mensal atingido"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
+msgstr ""
+"Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12691,6 +12862,12 @@ msgstr "Mais sobre !bangs"
 msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr "Mais sobre o Duck.ai"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12885,6 +13062,12 @@ msgstr "Silenciado"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Vermelho fosco"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13958,6 +14141,30 @@ msgstr ""
 "ícone %4$s > Definições%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14713,6 +14920,12 @@ msgid "Past year"
 msgstr "Último ano"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14723,6 +14936,12 @@ msgstr "Colar"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Colar código de sincronização"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14776,6 +14995,20 @@ msgstr "Permanentemente encerrado"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persa"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15048,7 +15281,8 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
+msgstr ""
+"Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -16043,6 +16277,12 @@ msgid "Reading website…"
 msgstr "A ler o website…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16235,6 +16475,12 @@ msgstr "Recuperação"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Código de recuperação"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16444,8 +16690,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão "
-"&quot;Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
+"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão &quot;"
+"Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16455,7 +16701,8 @@ msgstr "Memorizar a minha opção"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
+msgstr ""
+"Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16486,6 +16733,12 @@ msgstr "Remover %1$s"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "Remover %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16528,6 +16781,18 @@ msgstr "Remover seleção de texto"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Remove a pontuação desnecessária"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16824,7 +17089,8 @@ msgstr "Os resultados excluem informações de sites bloqueados."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
+msgstr ""
+"Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17182,7 +17448,8 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr "Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
+msgstr ""
+"Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17222,6 +17489,12 @@ msgstr "Guarda as tuas definições anonimamente na Cloud"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Diz olá ao Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17368,7 +17641,8 @@ msgstr "Desce na página e localiza %1$so teu navegador%2$s na lista."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
+msgstr ""
+"Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17941,7 +18215,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
+msgstr ""
+"Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17958,7 +18233,8 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sPredefinir%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
+msgstr ""
+"Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17978,7 +18254,8 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s na lista de fornecedores de pesquisa"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
+msgstr ""
+"Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18063,7 +18340,8 @@ msgstr "Seleciona %1$sDefinições%2$s e depois %3$sDefinições Avançadas%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
+msgstr ""
+"Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18230,6 +18508,13 @@ msgid "Serbian (Latin)"
 msgstr "Sérvio (latim)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18384,6 +18669,14 @@ msgid "Share"
 msgstr "Partilhar"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18398,7 +18691,8 @@ msgstr "Partilhar"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
+msgstr ""
+"Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18531,6 +18825,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Partilha as tuas opiniões sobre a caixa de pesquisa."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18779,7 +19085,8 @@ msgstr "Mostrar todos os resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
+msgstr ""
+"Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18921,7 +19228,8 @@ msgstr "Mostrar linhas horizontais nas quebras de página de resultados"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
+msgstr ""
+"Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18937,12 +19245,14 @@ msgstr "Mostra os links mais visitados na página de um novo separador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
+msgstr ""
+"Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
+msgstr ""
+"Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18973,7 +19283,8 @@ msgstr "Mostra sugestões na caixa de pesquisa enquanto digitas"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
+msgstr ""
+"Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18983,7 +19294,8 @@ msgstr "Mostra o fundo do botão de pesquisa"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
+msgstr ""
+"Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19215,6 +19527,12 @@ msgid "Something went wrong"
 msgstr "Ocorreu um erro"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19304,7 +19622,8 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "Este código é inválido. Confirma que introduziste ou leste o código correto."
+msgstr ""
+"Este código é inválido. Confirma que introduziste ou leste o código correto."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19591,19 +19910,22 @@ msgstr "Fica no DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
+msgstr ""
+"Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr ""
+"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr ""
+"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19646,7 +19968,8 @@ msgstr "Bloqueia os rastreadores ocultos que se escondem noutros sites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
+msgstr ""
+"Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19819,7 +20142,8 @@ msgstr "Sugere um título para uma publicação num blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
+msgstr ""
+"Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20059,6 +20383,12 @@ msgstr "Mudar de modelo"
 msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr "Mudar de modelo"
+
+# smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20321,6 +20651,13 @@ msgid "Synced Devices"
 msgstr "Dispositivos sincronizados"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Síria"
 
@@ -20351,6 +20688,12 @@ msgstr "A DECIDIR"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "Televisão"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20864,7 +21207,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
+msgstr ""
+"Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20937,16 +21281,34 @@ msgstr ""
 "ofensivas (consulta %4$s para obter mais informações)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
+msgstr ""
+"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
+msgstr ""
+"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21018,6 +21380,12 @@ msgstr "Este tipo de imagem não é compatível. Anexa um JPG, PNG, WebP ou GIF.
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Esta informação não é útil"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21137,6 +21505,18 @@ msgstr ""
 "nunca mostra respostas assistidas por IA em %1$s."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21157,7 +21537,8 @@ msgstr "Esta tradução está errada"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
+msgstr ""
+"Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21191,7 +21572,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
+msgstr ""
+"Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21318,7 +21700,8 @@ msgstr "Para continuar, tens de concordar com a %1$s e os %2$sdo Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
+msgstr ""
+"Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21383,8 +21766,8 @@ msgstr "Hoje"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Muda para experimentares o chat privado de IA ou %1$sdesativa-o no menu "
-"%2$s.%3$s"
+"Muda para experimentares o chat privado de IA ou %1$sdesativa-o no menu %2$s."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21732,7 +22115,8 @@ msgstr "Experimenta %1$s para deixar de ver mensagens como esta."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
+msgstr ""
+"Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21778,6 +22162,12 @@ msgstr "Experimentar gratuitamente"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Experimentar gratuitamente"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21867,7 +22257,8 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Tenta permitir a localização anónima para obter resultados mais específicos."
+msgstr ""
+"Tenta permitir a localização anónima para obter resultados mais específicos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21893,6 +22284,12 @@ msgstr "Experimentar gratuitamente"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Experimentar gratuitamente"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22042,7 +22439,8 @@ msgstr "Experimenta o novo chat privado de voz em tempo real!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr "Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
+msgstr ""
+"Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -22144,6 +22542,12 @@ msgid "Turkmenistan"
 msgstr "Turquemenistão"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22154,6 +22558,12 @@ msgstr "Desativar Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Desativar Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22441,12 +22851,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
+msgstr ""
+"Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
+msgstr ""
+"Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22611,7 +23023,8 @@ msgstr "Desbloqueia modelos avançados"
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr "Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
+msgstr ""
+"Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -22634,6 +23047,12 @@ msgstr "Desbloquear proteções premium"
 msgctxt "voice chat"
 msgid "Unmute"
 msgstr "Ativar som"
+
+# smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22669,6 +23088,12 @@ msgstr "Atualizar"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Atualizar navegador"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23197,7 +23622,8 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
+msgstr ""
+"Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23650,6 +24076,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Encerrámos o chat devido à inatividade. Queres tentar novamente?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23696,6 +24130,14 @@ msgstr ""
 "mais perto de ti. Podes sempre mudar de ideias mais tarde."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23734,6 +24176,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Vamos bloquear os rastreadores que tentam recolher os teus dados enquanto "
 "navegas."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23879,7 +24329,8 @@ msgstr "Limite de utilização semanal atingido"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
+msgstr ""
+"Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24024,13 +24475,15 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Quais são alguns fatores a considerar ao comprar um monitor de computador?"
+msgstr ""
+"Quais são alguns fatores a considerar ao comprar um monitor de computador?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
+msgstr ""
+"Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24047,6 +24500,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Quais são alguns prós e contras das anuidades?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24149,7 +24608,8 @@ msgstr "Quais são os pratos que tens de experimentar aqui?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Quais são os horários de funcionamento, localização e contactos deste local?"
+msgstr ""
+"Quais são os horários de funcionamento, localização e contactos deste local?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24299,7 +24759,8 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
+msgstr ""
+"O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24374,7 +24835,8 @@ msgstr "Sobre o que gostarias de dar feedback?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
+msgstr ""
+"O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24612,6 +25074,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Com visibilidade do fornecedor"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24952,7 +25422,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
+msgstr ""
+"Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -24997,7 +25468,8 @@ msgstr "Podes continuar a conversar usando o teu limite mensal."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
+msgstr ""
+"Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25111,6 +25583,13 @@ msgstr "Tens mais %1$s tentativas."
 msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Tens mais 1 tentativa."
+
+# smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25282,7 +25761,8 @@ msgstr "Atingiste o limite de chat de voz para hoje. Tente novamente amanhã."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
+msgstr ""
+"Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25335,6 +25815,23 @@ msgid "YouTube Standard"
 msgstr "Standard Youtube"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "O teu histórico de pesquisas DuckDuckGo é privado"
@@ -25356,6 +25853,14 @@ msgstr "A tua localização real permanece privada"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "A tua localização real permanece privada."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25507,7 +26012,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
+msgstr ""
+"Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25727,13 +26233,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
+msgstr ""
+"Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
+msgstr ""
+"Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25816,7 +26324,8 @@ msgstr "por %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
+msgstr ""
+"DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ro_RO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -41,6 +42,14 @@ msgstr "% complet vaccinați"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% vaccinați"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -491,6 +500,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sAflă cum îți păstrăm privată locația%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -511,7 +527,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
+msgstr ""
+"%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -781,6 +798,12 @@ msgstr "Puncte câștigate la al doilea serviciu"
 msgctxt "Sports module"
 msgid "2nd in Group %s"
 msgstr "Locul 2 din grupa %1$s"
+
+# smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1473,6 +1496,12 @@ msgid "Add to Home Screen"
 msgstr "Adaugă la Ecran de pornire"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Add-on-uri"
@@ -1838,6 +1867,13 @@ msgid "All types"
 msgstr "Toate tipurile"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -2034,8 +2070,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
-"open-source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
+"source."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2044,8 +2080,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
-"open-source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
+"source."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2207,7 +2243,8 @@ msgstr "Ești încă acolo?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
+msgstr ""
+"Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2358,6 +2395,12 @@ msgstr "Întreabă despre această pagină"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask anything privately"
 msgstr "Întreabă orice în mod privat"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2543,7 +2586,8 @@ msgstr "Sunetul nu este stocat de noi sau de OpenAI după încheierea chatului."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
+msgstr ""
+"Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2584,7 +2628,8 @@ msgstr "Răspuns automat"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Generat automat pe baza surselor menționate. Poate conține inexactități."
+msgstr ""
+"Generat automat pe baza surselor menționate. Poate conține inexactități."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2961,7 +3006,8 @@ msgstr "Blochează ferestrele pop-up enervante privind modulele cookie"
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr "Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
+msgstr ""
+"Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -3057,7 +3103,8 @@ msgstr "Blocat:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr "Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
+msgstr ""
+"Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -4128,7 +4175,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Verifică pagina de stare pentru actualizări despre această întrerupere."
+msgstr ""
+"Verifică pagina de stare pentru actualizări despre această întrerupere."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4530,7 +4578,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
+msgstr ""
+"Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4557,7 +4606,8 @@ msgstr "Fă click pe %1$sSetări%2$s în meniul vertical."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
+msgstr ""
+"Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4613,7 +4663,8 @@ msgstr "Fă click pe %1$sFurnizori căutare%2$s sub Tipuri Add-on-uri"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
+msgstr ""
+"Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4688,7 +4739,8 @@ msgstr "Apasă pe pictograma %1$spermisiuni%2$s din bara de adrese"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
+msgstr ""
+"Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4740,7 +4792,8 @@ msgstr "Fă click pe lupa din bara de căutare"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr "Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
+msgstr ""
+"Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5304,6 +5357,12 @@ msgid "Copy"
 msgstr "Copiază"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5343,6 +5402,28 @@ msgstr "Copiază sau salvează acest cod"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Copiază codul de recuperare"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5394,7 +5475,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
+msgstr ""
+"Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6026,6 +6108,14 @@ msgid "Delete recent chats?"
 msgstr "Ștergi chaturile recente?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6036,6 +6126,14 @@ msgstr "Ștergi acest chat?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Chaturi șterse"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6232,7 +6330,8 @@ msgstr "Dezactivare și deconectare"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
+msgstr ""
+"Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6291,6 +6390,13 @@ msgstr "Ignoră"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Ignoră"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6727,8 +6833,8 @@ msgstr "Duck.ai"
 msgctxt "Text on link to the Duck.ai Privacy Policy & Terms of Service page."
 msgid "Duck.ai Privacy Policy and Terms of Service"
 msgstr ""
-"Politica de confidențialitate și Condițiile de utilizare a serviciului "
-"Duck.ai"
+"Politica de confidențialitate și Condițiile de utilizare a serviciului Duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Title of the modal that contains settings for Duck.ai.
@@ -6752,7 +6858,8 @@ msgstr "Condiții de utilizare Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
+msgstr ""
+"Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7124,7 +7231,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
+msgstr ""
+"DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7151,6 +7259,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Browserul DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7505,7 +7620,8 @@ msgstr "Se editează imaginea..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
+msgstr ""
+"Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7810,7 +7926,8 @@ msgstr "Asigură-te că accesul la locație este %1$spermis%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
+msgstr ""
+"Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7987,10 +8104,25 @@ msgstr ""
 "confidențialitate."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Expirat"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8015,7 +8147,8 @@ msgstr "Explică răspunsul acceptat în termeni simpli."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
+msgstr ""
+"Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8634,7 +8767,8 @@ msgstr "Chaturi gratuite și private, anonimizate de noi"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
+msgstr ""
+"Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8664,7 +8798,8 @@ msgstr "Fără restricții de distrubuire și utilizare comercială"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
+msgstr ""
+"Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8745,9 +8880,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Din bara de meniu a aplicației pe Mac, selectează "
-"<strong>DuckDuckGo</strong> &gt; <strong>Caută actualizări...</strong>, apoi "
-"selectează <strong>Instalează actualizările</strong>."
+"Din bara de meniu a aplicației pe Mac, selectează <strong>DuckDuckGo</"
+"strong> &gt; <strong>Caută actualizări...</strong>, apoi selectează "
+"<strong>Instalează actualizările</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9265,8 +9400,8 @@ msgstr "Descarcă aplicația"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obține browserul gratuit DuckDuckGo %1$spentru a bloca reclamele pe "
-"YouTube.%2$s"
+"Obține browserul gratuit DuckDuckGo %1$spentru a bloca reclamele pe YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9365,10 +9500,19 @@ msgstr ""
 "dispozitiv%4$s. Sau scanează codul QR din fișierul PDF de recuperare."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
+msgstr ""
+"Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9474,6 +9618,12 @@ msgstr "Am înțeles"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Am înțeles"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9639,7 +9789,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
+msgstr ""
+"Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10282,7 +10433,8 @@ msgstr "Cât de mult vrei să apară răspunsurile asistate de AI?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
+msgstr ""
+"Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10524,7 +10676,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
+msgstr ""
+"Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11053,7 +11206,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
+msgstr ""
+"E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11443,6 +11597,12 @@ msgid "Learn %sMore%s"
 msgstr "Află %1$smai multe%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11822,7 +11982,8 @@ msgstr "Încarcă mai multe imagini rezultate când derulezi"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
+msgstr ""
+"Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12076,6 +12237,13 @@ msgid "Manage"
 msgstr "Gestionează"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12325,6 +12493,12 @@ msgstr "Meniu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Meniu"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12587,7 +12761,8 @@ msgstr "Limita lunară a fost atinsă"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
+msgstr ""
+"Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12693,6 +12868,12 @@ msgstr "Mai multe despre !bangs"
 msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr "Mai multe despre Duck.ai"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12889,6 +13070,12 @@ msgid "Muted red"
 msgstr "Roșu estompat"
 
 # smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
 msgid "My name"
@@ -12983,7 +13170,8 @@ msgstr "Namibia"
 #. Title of the divisional championship series for the National League division of Major League Baseball
 msgctxt "Sports module"
 msgid "National League Championship Series"
-msgstr "National League Championship Series (Seria Campionatului Ligii Naționale)"
+msgstr ""
+"National League Championship Series (Seria Campionatului Ligii Naționale)"
 
 # smartling.placeholder_format=C
 #. Title of the divisional semi-final series for the National League division of Major League Baseball
@@ -13958,6 +14146,30 @@ msgstr ""
 "pe pictograma %4$s > Setări%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14081,7 +14293,8 @@ msgstr "Deschide website-ul %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
+msgstr ""
+"Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14708,6 +14921,12 @@ msgid "Past year"
 msgstr "Ultimul an"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14718,6 +14937,12 @@ msgstr "Lipește"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Lipește codul de sincronizare"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14771,6 +14996,20 @@ msgstr "Închis definitiv"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persană"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14984,7 +15223,8 @@ msgstr "Fixat"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Chaturile fixate vor apărea în partea de sus a chaturilor tale recente."
+msgstr ""
+"Chaturile fixate vor apărea în partea de sus a chaturilor tale recente."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -16036,6 +16276,12 @@ msgid "Reading website…"
 msgstr "Se citește site-ul..."
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16228,6 +16474,12 @@ msgstr "Recuperare"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Cod de recuperare"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16448,7 +16700,8 @@ msgstr "Reține alegerea mea"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
+msgstr ""
+"Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16479,6 +16732,12 @@ msgstr "Elimină %1$s"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "Elimină %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16521,6 +16780,18 @@ msgstr "Elimină selecția de text"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Elimină semnele de punctuație inutile"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16817,7 +17088,8 @@ msgstr "Rezultatele exclud informațiile de pe site-urile blocate."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
+msgstr ""
+"Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17173,14 +17445,16 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr "Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
+msgstr ""
+"Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
+msgstr ""
+"Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17211,6 +17485,12 @@ msgstr "Salvează setările anonim în cloud"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Îți prezentăm Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17709,7 +17989,8 @@ msgstr "A doua opinie"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
+msgstr ""
+"Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17867,7 +18148,8 @@ msgstr "Vezi mai multe pe %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr "Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
+msgstr ""
+"Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -17885,7 +18167,8 @@ msgstr "Vezi câteva dintre cele mai recente actualizări ale noastre"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
+msgstr ""
+"Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17912,7 +18195,8 @@ msgstr "Selectează %1$s%2$s%3$s, apoi %4$sMotor de căutare%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
+msgstr ""
+"Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17925,30 +18209,35 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17960,7 +18249,8 @@ msgstr "Selectează %1$sDuckDuckGo%2$s din lista de furnizori de căutare"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17971,7 +18261,8 @@ msgstr "Selectează %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
+msgstr ""
+"Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18067,7 +18358,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr ""
+"Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18139,7 +18431,8 @@ msgstr "Text selectat din %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
+msgstr ""
+"Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18206,6 +18499,13 @@ msgstr "Sârbă (chirilică)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Sârbă (latină)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18362,6 +18662,14 @@ msgid "Share"
 msgstr "Distribuie"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18513,6 +18821,18 @@ msgid "Share your thoughts on the search box."
 msgstr "Împărtășește-ți gândurile privind căsuța de căutare."
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
@@ -18640,7 +18960,8 @@ msgstr "Afișează DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
+msgstr ""
+"Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18900,7 +19221,8 @@ msgstr "Afișează linii orizontale la sfârșitul paginilor de rezultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
+msgstr ""
+"Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19054,7 +19376,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
+msgstr ""
+"Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19198,6 +19521,12 @@ msgid "Something went wrong"
 msgstr "Ceva nu a funcționat corect"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19207,7 +19536,8 @@ msgstr "Ceva nu a funcționat, te rugăm să încerci din nou."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
+msgstr ""
+"A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19262,7 +19592,8 @@ msgstr "Ne pare rău, a survenit o eroare neașteptată."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr "Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
+msgstr ""
+"Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -19311,7 +19642,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
+msgstr ""
+"Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19580,13 +19912,15 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr ""
+"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr ""
+"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19629,7 +19963,8 @@ msgstr "Oprește instrumentele de urmărire ascunse de pe alte site-uri."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
+msgstr ""
+"Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19803,7 +20138,8 @@ msgstr "Sugerează un titlu pentru o postare pe blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Sugerează articole sau subiecte similare care merită explorate în continuare."
+msgstr ""
+"Sugerează articole sau subiecte similare care merită explorate în continuare."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20045,6 +20381,12 @@ msgid "Switch model"
 msgstr "Schimbă modelul"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20177,7 +20519,8 @@ msgstr "Sync & Backup activat!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
+msgstr ""
+"Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20301,6 +20644,13 @@ msgid "Synced Devices"
 msgstr "Dispozitive sincronizate"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Siria"
 
@@ -20331,6 +20681,12 @@ msgstr "TBD"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20399,8 +20755,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți "
-"Duck.ai."
+"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20655,7 +21011,8 @@ msgstr "Fișierele atașate depășesc limita totală de %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
+msgstr ""
+"Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20843,7 +21200,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
+msgstr ""
+"Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20916,16 +21274,34 @@ msgstr ""
 "(a se vedea %4$s pentru mai multe informații)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
+msgstr ""
+"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
+msgstr ""
+"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21003,6 +21379,12 @@ msgid "This information isn’t useful"
 msgstr "Aceste informații nu sunt utile"
 
 # smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
@@ -21069,7 +21451,8 @@ msgstr "Această pagină necesită JavaScript pentru a funcționa."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
+msgstr ""
+"Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21116,6 +21499,18 @@ msgstr ""
 "ștergi datele din browserul duckduckgo.com, este posibil să vezi din nou "
 "răspunsuri asistate de AI. Cu toate acestea, avem și o pagină de start care "
 "nu afișează niciodată răspunsuri asistate de AI la %1$s."
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21172,7 +21567,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
+msgstr ""
+"Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21308,8 +21704,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Pentru a tipări indicații de orientare:%1$sîntoarce-te la "
-"hartă.%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
+"Pentru a tipări indicații de orientare:%1$sîntoarce-te la hartă."
+"%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
 "pictograma de tipărire.%4$s"
 
 # smartling.placeholder_format=C
@@ -21531,7 +21927,8 @@ msgstr "Instrumente de urmărire blocate în ultima oră"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr "Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
+msgstr ""
+"Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21764,6 +22161,12 @@ msgid "Try Free"
 msgstr "Încearcă gratuit"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21881,6 +22284,12 @@ msgid "Try for Free"
 msgstr "Încearcă gratuit"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
 msgctxt ""
 "Link text shown to unauthenticated users in the subscription promo card to "
@@ -21906,7 +22315,8 @@ msgstr "Încearcă gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
+msgstr ""
+"Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -21945,7 +22355,8 @@ msgstr "Încearcă browserul nostru"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
+msgstr ""
+"Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22124,6 +22535,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22134,6 +22551,12 @@ msgstr "Oprește Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Oprește Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22204,7 +22627,8 @@ msgstr "Activează %1$sLocație precisă%2$s pentru rezultate mai precise"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
+msgstr ""
+"Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22421,12 +22845,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
+msgstr ""
+"Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
+msgstr ""
+"Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22436,7 +22862,8 @@ msgstr "Sub %1$sSetări de căutare%2$s selectează %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
+msgstr ""
+"Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -22450,13 +22877,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
+msgstr ""
+"Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
+msgstr ""
+"Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22614,6 +23043,12 @@ msgid "Unmute"
 msgstr "Reactivează microfonul"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22649,6 +23084,12 @@ msgstr "Actualizează"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Actualizează browserul"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22918,9 +23359,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. "
-"Protejează-ți chaturile împotriva hackerilor, a escrocilor și a companiilor. "
-"Păstrează informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
+"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. Protejează-"
+"ți chaturile împotriva hackerilor, a escrocilor și a companiilor. Păstrează "
+"informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23473,7 +23914,8 @@ msgstr "Anonimizăm"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
+msgstr ""
+"Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23620,7 +24062,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
+msgstr ""
+"Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -23634,7 +24077,16 @@ msgstr ""
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr "Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
+msgstr ""
+"Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23684,6 +24136,14 @@ msgstr ""
 "aproape de tine. Poți să te răzgândești oricând mai târziu."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23694,7 +24154,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
+msgstr ""
+"Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23720,6 +24181,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Vom bloca instrumentele de urmărire care încearcă să colecteze datele tale "
 "în timp ce navighezi."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23989,8 +24458,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea "
-"Duck.ai. Încearcă să reîncarci pagina."
+"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea Duck."
+"ai. Încearcă să reîncarci pagina."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24041,6 +24510,12 @@ msgid "What are some pros and cons of annuities?"
 msgstr "Care sunt câteva argumente pro și contra pentru anuități?"
 
 # smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
 msgctxt "User prompt seeded by Learn More CTA"
 msgid ""
@@ -24053,10 +24528,10 @@ msgid ""
 msgstr ""
 "Care sunt beneficiile descărcării browserului DuckDuckGo pentru tine, dacă "
 "vrei să folosești Duck.ai? Citește doar surse oficiale DuckDuckGo. Împarte "
-"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările "
-"Duck.ai și pe protecția confidențialității. Păstrează-l destul de scurt, "
-"simplu și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau "
-"în domeniul tehnic."
+"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările Duck."
+"ai și pe protecția confidențialității. Păstrează-l destul de scurt, simplu "
+"și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau în "
+"domeniul tehnic."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24122,7 +24597,8 @@ msgstr "Care sunt principalele lucruri pe care le voi învăța din acest curs?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr "Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
+msgstr ""
+"Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -24294,8 +24770,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de "
-"bookmarklet-ul cu parametri URL?"
+"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de bookmarklet-"
+"ul cu parametri URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24404,7 +24880,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
+msgstr ""
+"Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24422,7 +24899,8 @@ msgstr "Unde să urmărești <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
+msgstr ""
+"Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24611,6 +25089,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Fără vizibilitate zero din partea furnizorului"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25112,6 +25598,13 @@ msgid "You have 1 attempt left."
 msgstr "Mai ai la dispoziție 1 încercare."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25259,7 +25752,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
+msgstr ""
+"Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25286,8 +25780,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile "
-"Duck.ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
+"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile Duck."
+"ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
 "sincronizarea. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
@@ -25330,6 +25824,23 @@ msgid "YouTube Standard"
 msgstr "Standard YouTube"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Istoricul căutărilor tale pe DuckDuckGo este privat"
@@ -25351,6 +25862,14 @@ msgstr "Locația ta reală rămâne confidențială"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Locația ta reală rămâne confidențială."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25502,7 +26021,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
+msgstr ""
+"Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25549,7 +26069,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
+msgstr ""
+"Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25723,13 +26244,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
+msgstr ""
+"Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
+msgstr ""
+"Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ro_RO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
-"20)) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -49,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Acest dispozitiv)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -504,7 +503,7 @@ msgstr "%1$sAflă cum îți păstrăm privată locația%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sAflă mai multe%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -527,8 +526,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
+msgstr "%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -803,7 +801,7 @@ msgstr "Locul 2 din grupa %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "A doua opinie"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1499,7 +1497,7 @@ msgstr "Adaugă la Ecran de pornire"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Adaugă la Chaturile mele"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1871,7 +1869,7 @@ msgstr "Toate tipurile"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Toate dispozitivele tale sunt deconectate de la sincronizare."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2070,8 +2068,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
-"source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
+"open-source."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2080,8 +2078,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
-"source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
+"open-source."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2243,8 +2241,7 @@ msgstr "Ești încă acolo?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
+msgstr "Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2400,7 +2397,7 @@ msgstr "Întreabă orice în mod privat"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Întreabă orice în mod privat"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2586,8 +2583,7 @@ msgstr "Sunetul nu este stocat de noi sau de OpenAI după încheierea chatului."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
+msgstr "Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2628,8 +2624,7 @@ msgstr "Răspuns automat"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Generat automat pe baza surselor menționate. Poate conține inexactități."
+msgstr "Generat automat pe baza surselor menționate. Poate conține inexactități."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3006,8 +3001,7 @@ msgstr "Blochează ferestrele pop-up enervante privind modulele cookie"
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr ""
-"Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
+msgstr "Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -3103,8 +3097,7 @@ msgstr "Blocat:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr ""
-"Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
+msgstr "Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -4175,8 +4168,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Verifică pagina de stare pentru actualizări despre această întrerupere."
+msgstr "Verifică pagina de stare pentru actualizări despre această întrerupere."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4578,8 +4570,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
+msgstr "Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4606,8 +4597,7 @@ msgstr "Fă click pe %1$sSetări%2$s în meniul vertical."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
+msgstr "Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4663,8 +4653,7 @@ msgstr "Fă click pe %1$sFurnizori căutare%2$s sub Tipuri Add-on-uri"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
+msgstr "Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4739,8 +4728,7 @@ msgstr "Apasă pe pictograma %1$spermisiuni%2$s din bara de adrese"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
+msgstr "Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4792,8 +4780,7 @@ msgstr "Fă click pe lupa din bara de căutare"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
+msgstr "Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5360,7 +5347,7 @@ msgstr "Copiază"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Copiază"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5409,13 +5396,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Copiază linkul partajat"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Copiază codul de pe un alt dispozitiv"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5424,6 +5411,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Copiază codul de pe un alt dispozitiv. Accesează %1$sSetări Duck.ai › "
+"Chaturi › Sync & Backup › Sincronizează cu un alt dispozitiv%2$s și încearcă "
+"din nou."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5475,8 +5465,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
+msgstr "Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6113,7 +6102,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Șterge linkul partajat"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6134,6 +6123,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Ștergerea unui link îl face să nu mai funcționeze. Persoanele care l-au "
+"deschis și au adăugat conversația în chaturile lor vor păstra propria copie."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6330,8 +6321,7 @@ msgstr "Dezactivare și deconectare"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
+msgstr "Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6396,7 +6386,7 @@ msgstr "Ignoră"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Ignoră"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6833,8 +6823,8 @@ msgstr "Duck.ai"
 msgctxt "Text on link to the Duck.ai Privacy Policy & Terms of Service page."
 msgid "Duck.ai Privacy Policy and Terms of Service"
 msgstr ""
-"Politica de confidențialitate și Condițiile de utilizare a serviciului Duck."
-"ai"
+"Politica de confidențialitate și Condițiile de utilizare a serviciului "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title of the modal that contains settings for Duck.ai.
@@ -6858,8 +6848,7 @@ msgstr "Condiții de utilizare Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
+msgstr "Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7231,8 +7220,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
+msgstr "DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7265,7 +7253,7 @@ msgstr "Browserul DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Pagini de ajutor DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7620,8 +7608,7 @@ msgstr "Se editează imaginea..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
+msgstr "Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7926,8 +7913,7 @@ msgstr "Asigură-te că accesul la locație este %1$spermis%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
+msgstr "Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8108,7 +8094,7 @@ msgstr ""
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Expirat"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8122,7 +8108,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Expiră la %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8147,8 +8133,7 @@ msgstr "Explică răspunsul acceptat în termeni simpli."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
+msgstr "Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8767,8 +8752,7 @@ msgstr "Chaturi gratuite și private, anonimizate de noi"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
+msgstr "Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8798,8 +8782,7 @@ msgstr "Fără restricții de distrubuire și utilizare comercială"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
+msgstr "Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8880,9 +8863,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Din bara de meniu a aplicației pe Mac, selectează <strong>DuckDuckGo</"
-"strong> &gt; <strong>Caută actualizări...</strong>, apoi selectează "
-"<strong>Instalează actualizările</strong>."
+"Din bara de meniu a aplicației pe Mac, selectează "
+"<strong>DuckDuckGo</strong> &gt; <strong>Caută actualizări...</strong>, apoi "
+"selectează <strong>Instalează actualizările</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9400,8 +9383,8 @@ msgstr "Descarcă aplicația"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obține browserul gratuit DuckDuckGo %1$spentru a bloca reclamele pe YouTube."
-"%2$s"
+"Obține browserul gratuit DuckDuckGo %1$spentru a bloca reclamele pe "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9506,13 +9489,14 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Accesează %1$sSetări Duck.ai%2$s › %3$sChaturi › Sync & Backup › "
+"Sincronizează cu un alt dispozitiv%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
+msgstr "Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9623,7 +9607,7 @@ msgstr "Am înțeles"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Am înțeles"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9789,8 +9773,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
+msgstr "Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10433,8 +10416,7 @@ msgstr "Cât de mult vrei să apară răspunsurile asistate de AI?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
+msgstr "Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10676,8 +10658,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
+msgstr "Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11206,8 +11187,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
+msgstr "E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11600,7 +11580,7 @@ msgstr "Află %1$smai multe%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Află mai multe"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11982,8 +11962,7 @@ msgstr "Încarcă mai multe imagini rezultate când derulezi"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
+msgstr "Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12241,7 +12220,7 @@ msgstr "Gestionează"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Gestionează"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12498,7 +12477,7 @@ msgstr "Meniu"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Mesajele de după acest punct sunt vizibile doar pentru tine."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12761,8 +12740,7 @@ msgstr "Limita lunară a fost atinsă"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
+msgstr "Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12873,7 +12851,7 @@ msgstr "Mai multe despre Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Mai multe acțiuni"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13073,7 +13051,7 @@ msgstr "Roșu estompat"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Dispozitivele mele"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13170,8 +13148,7 @@ msgstr "Namibia"
 #. Title of the divisional championship series for the National League division of Major League Baseball
 msgctxt "Sports module"
 msgid "National League Championship Series"
-msgstr ""
-"National League Championship Series (Seria Campionatului Ligii Naționale)"
+msgstr "National League Championship Series (Seria Campionatului Ligii Naționale)"
 
 # smartling.placeholder_format=C
 #. Title of the divisional semi-final series for the National League division of Major League Baseball
@@ -14152,6 +14129,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Pe un alt dispozitiv, accesează %1$sSetări Duck.ai%2$s › %3$sChaturi › Sync "
+"& Backup › Sincronizează cu un alt dispozitiv%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14160,6 +14139,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Pe un alt dispozitiv, accesează %1$sSetări Duck.ai%2$s › %3$sChaturi › Sync "
+"& Backup › Sincronizează cu un alt dispozitiv%4$s și scanează acest cod:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14168,6 +14149,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Pe un alt dispozitiv, accesează %1$sSetări Duck.ai%2$s › %3$sChaturi › Sync "
+"& Backup › Sincronizează cu un alt dispozitiv%4$s. Sau scanează codul QR din "
+"fișierul PDF de recuperare."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14293,8 +14277,7 @@ msgstr "Deschide website-ul %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
+msgstr "Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14924,7 +14907,7 @@ msgstr "Ultimul an"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Lipește"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14942,7 +14925,7 @@ msgstr "Lipește codul de sincronizare"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Lipește-l mai jos"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -15001,7 +14984,7 @@ msgstr "Persană"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -15010,6 +14993,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal îți găsește informațiile pe site-urile "
+"brokerilor de date care le vând. Apoi acționăm pentru a obține eliminarea "
+"lor pentru tine."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15223,8 +15209,7 @@ msgstr "Fixat"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Chaturile fixate vor apărea în partea de sus a chaturilor tale recente."
+msgstr "Chaturile fixate vor apărea în partea de sus a chaturilor tale recente."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -16279,7 +16264,7 @@ msgstr "Se citește site-ul..."
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Ești gata pentru eclipsa de soare?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16479,7 +16464,7 @@ msgstr "Cod de recuperare"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Cod de recuperare"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16700,8 +16685,7 @@ msgstr "Reține alegerea mea"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
+msgstr "Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16737,7 +16721,7 @@ msgstr "Elimină %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Elimină dispozitivul"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16785,13 +16769,13 @@ msgstr "Elimină semnele de punctuație inutile"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Șterge-ți informațiile de pe internet"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Șterge-ți informațiile din mediul online"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17088,8 +17072,7 @@ msgstr "Rezultatele exclud informațiile de pe site-urile blocate."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
+msgstr "Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17445,16 +17428,14 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
+msgstr "Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
+msgstr "Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17490,7 +17471,7 @@ msgstr "Îți prezentăm Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Îți prezentăm Duck.ai – chat IA gratuit și privat de la DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17989,8 +17970,7 @@ msgstr "A doua opinie"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
+msgstr "Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18148,8 +18128,7 @@ msgstr "Vezi mai multe pe %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr ""
-"Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
+msgstr "Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -18167,8 +18146,7 @@ msgstr "Vezi câteva dintre cele mai recente actualizări ale noastre"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
+msgstr "Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18195,8 +18173,7 @@ msgstr "Selectează %1$s%2$s%3$s, apoi %4$sMotor de căutare%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
+msgstr "Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18209,35 +18186,30 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
+msgstr "Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr "Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18249,8 +18221,7 @@ msgstr "Selectează %1$sDuckDuckGo%2$s din lista de furnizori de căutare"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
+msgstr "Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18261,8 +18232,7 @@ msgstr "Selectează %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
+msgstr "Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18358,8 +18328,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr "Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18431,8 +18400,7 @@ msgstr "Text selectat din %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
+msgstr "Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18505,7 +18473,7 @@ msgstr "Sârbă (latină)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Datele de pe server au fost șterse"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18667,7 +18635,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Distribuie"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18824,13 +18792,13 @@ msgstr "Împărtășește-ți gândurile privind căsuța de căutare."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Linkuri de chat distribuite"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Linkuri de chat distribuite"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18960,8 +18928,7 @@ msgstr "Afișează DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
+msgstr "Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19221,8 +19188,7 @@ msgstr "Afișează linii orizontale la sfârșitul paginilor de rezultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
+msgstr "Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19376,8 +19342,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
+msgstr "Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19524,7 +19489,7 @@ msgstr "Ceva nu a funcționat corect"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "A apărut o eroare la încărcarea acestui chat partajat."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19536,8 +19501,7 @@ msgstr "Ceva nu a funcționat, te rugăm să încerci din nou."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
+msgstr "A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19592,8 +19556,7 @@ msgstr "Ne pare rău, a survenit o eroare neașteptată."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
+msgstr "Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -19642,8 +19605,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
+msgstr "Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19912,15 +19874,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19963,8 +19923,7 @@ msgstr "Oprește instrumentele de urmărire ascunse de pe alte site-uri."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
+msgstr "Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20138,8 +20097,7 @@ msgstr "Sugerează un titlu pentru o postare pe blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Sugerează articole sau subiecte similare care merită explorate în continuare."
+msgstr "Sugerează articole sau subiecte similare care merită explorate în continuare."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20384,7 +20342,7 @@ msgstr "Schimbă modelul"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Schimbă modelul"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20519,8 +20477,7 @@ msgstr "Sync & Backup activat!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
+msgstr "Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20648,7 +20605,7 @@ msgstr "Dispozitive sincronizate"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Sincronizat la %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20686,7 +20643,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabel"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20755,8 +20712,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți Duck."
-"ai."
+"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21011,8 +20968,7 @@ msgstr "Fișierele atașate depășesc limita totală de %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
+msgstr "Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21200,8 +21156,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
+msgstr "Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21277,7 +21232,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Acest dispozitiv"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21288,20 +21243,21 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Acest dispozitiv nu va mai putea accesa datele tale sincronizate pe alte "
+"dispozitive. Ultimele %1$s chaturi vor rămâne în continuare disponibile în "
+"memoria locală."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
+msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
+msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21382,7 +21338,7 @@ msgstr "Aceste informații nu sunt utile"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Aceasta este o copie a unui chat partajat."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21451,8 +21407,7 @@ msgstr "Această pagină necesită JavaScript pentru a funcționa."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
+msgstr "Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21504,13 +21459,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Acest chat partajat nu a putut fi deschis. Linkul poate fi incomplet."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Acest link de chat partajat nu mai este disponibil."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21567,8 +21522,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
+msgstr "Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21704,8 +21658,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Pentru a tipări indicații de orientare:%1$sîntoarce-te la hartă."
-"%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
+"Pentru a tipări indicații de orientare:%1$sîntoarce-te la "
+"hartă.%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
 "pictograma de tipărire.%4$s"
 
 # smartling.placeholder_format=C
@@ -21927,8 +21881,7 @@ msgstr "Instrumente de urmărire blocate în ultima oră"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
+msgstr "Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22164,7 +22117,7 @@ msgstr "Încearcă gratuit"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Încearcă gratuit!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22287,7 +22240,7 @@ msgstr "Încearcă gratuit"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Încearcă gratuit!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22315,8 +22268,7 @@ msgstr "Încearcă gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
+msgstr "Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22355,8 +22307,7 @@ msgstr "Încearcă browserul nostru"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
+msgstr "Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22538,7 +22489,7 @@ msgstr "Turkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Oprește"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22556,7 +22507,7 @@ msgstr "Oprește Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Dorești să oprești Sync & Backup și să ștergi datele de pe server?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22627,8 +22578,7 @@ msgstr "Activează %1$sLocație precisă%2$s pentru rezultate mai precise"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
+msgstr "Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22845,14 +22795,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
+msgstr "Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
+msgstr "Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22862,8 +22810,7 @@ msgstr "Sub %1$sSetări de căutare%2$s selectează %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
+msgstr "Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -22877,15 +22824,13 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
+msgstr "Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
+msgstr "Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23046,7 +22991,7 @@ msgstr "Reactivează microfonul"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Chat fără titlu"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23089,7 +23034,7 @@ msgstr "Actualizează browserul"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Actualizează Duck.ai pentru a vedea acest chat distribuit."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23359,9 +23304,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. Protejează-"
-"ți chaturile împotriva hackerilor, a escrocilor și a companiilor. Păstrează "
-"informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
+"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. "
+"Protejează-ți chaturile împotriva hackerilor, a escrocilor și a companiilor. "
+"Păstrează informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23914,8 +23859,7 @@ msgstr "Anonimizăm"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
+msgstr "Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24062,8 +24006,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
+msgstr "Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24077,8 +24020,7 @@ msgstr ""
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr ""
-"Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
+msgstr "Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
@@ -24087,6 +24029,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Găsim și eliminăm informațiile tale personale de pe site-urile brokerilor de "
+"date. În plus, obții un VPN și multe altele."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24142,6 +24086,9 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Scanăm regulat site-urile brokerilor de date pentru informațiile tale "
+"personale și îți prezentăm progresul într-un tabel cu indicatori ușor de "
+"utilizat."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24154,8 +24101,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
+msgstr "Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24189,6 +24135,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Vom scana site-urile brokerilor de date pentru a căuta e-mailul, numele, "
+"adresa ta și multe altele și vom lucra pentru a elimina tot ce găsim despre "
+"tine."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24458,8 +24407,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea Duck."
-"ai. Încearcă să reîncarci pagina."
+"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea "
+"Duck.ai. Încearcă să reîncarci pagina."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24513,7 +24462,7 @@ msgstr "Care sunt câteva argumente pro și contra pentru anuități?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Care sunt beneficiile Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24528,10 +24477,10 @@ msgid ""
 msgstr ""
 "Care sunt beneficiile descărcării browserului DuckDuckGo pentru tine, dacă "
 "vrei să folosești Duck.ai? Citește doar surse oficiale DuckDuckGo. Împarte "
-"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările Duck."
-"ai și pe protecția confidențialității. Păstrează-l destul de scurt, simplu "
-"și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau în "
-"domeniul tehnic."
+"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările "
+"Duck.ai și pe protecția confidențialității. Păstrează-l destul de scurt, "
+"simplu și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau "
+"în domeniul tehnic."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24597,8 +24546,7 @@ msgstr "Care sunt principalele lucruri pe care le voi învăța din acest curs?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
-"Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
+msgstr "Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -24770,8 +24718,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de bookmarklet-"
-"ul cu parametri URL?"
+"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de "
+"bookmarklet-ul cu parametri URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24880,8 +24828,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
+msgstr "Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24899,8 +24846,7 @@ msgstr "Unde să urmărești <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
+msgstr "Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25097,6 +25043,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Funcționează direct de pe dispozitivul tău pentru a-ți elimina adresa de "
+"e-mail, numele, adresa și multe altele de pe site-urile brokerilor de date."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25602,7 +25550,7 @@ msgstr "Mai ai la dispoziție 1 încercare."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Nu ai linkuri de chat distribuite."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25752,8 +25700,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
+msgstr "Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25780,8 +25727,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile Duck."
-"ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
+"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile "
+"Duck.ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
 "sincronizarea. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
@@ -25832,13 +25779,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Cele mai recente %1$s chaturi ale tale vor fi disponibile în memoria locală "
+"pe aceste browsere:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Chaturile tale Duck.ai sunt sincronizate cu criptare de la un capăt la altul."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25870,6 +25819,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Copia de rezervă va fi ștearsă de pe serverul DuckDuckGo. Toate "
+"dispozitivele vor fi deconectate de la sincronizare."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26021,8 +25972,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
+msgstr "Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26069,8 +26019,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
+msgstr "Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26244,15 +26193,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
+msgstr "Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
+msgstr "Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -41,6 +42,14 @@ msgstr "Процент полностью вакцинированных"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "Процент вакцинированных"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -247,7 +256,8 @@ msgstr "Лайков: %1$s"
 #. Disclaimer text shown bellow chat input on mobile, avoid long text if possible. Example: 'GPT-3 may display inaccurate or offensive information.'
 msgctxt "Disclaimer bellow chat input - mobile"
 msgid "%s may display inaccurate or offensive information."
-msgstr "ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
+msgstr ""
+"ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
 
 # smartling.placeholder_format=C
 #. Label showing how many members a discussion has. To be displayed on a card about that discussion.
@@ -487,17 +497,26 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sКак мы сохраняем конфиденциальность вашего местоположения%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
+msgstr ""
+"%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
+msgstr ""
+"%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -775,6 +794,12 @@ msgid "2nd in Group %s"
 msgstr "2-е место в группе %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -982,8 +1007,8 @@ msgid ""
 msgstr ""
 "Функция AI Chat позволяет анонимно общаться с нашим чат-ботом на базе "
 "сторонних моделей ИИ. Если отключить эту функцию, она не будет отображаться "
-"в поиске DuckDuckGo Search, но останется доступной по ссылке "
-"%1$sduckduckgo.com/aichat%2$s."
+"в поиске DuckDuckGo Search, но останется доступной по ссылке %1$sduckduckgo."
+"com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1099,7 +1124,8 @@ msgstr "Не добавлять в браузер"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "ATB related (not displayed on settings page)"
-msgstr "Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
+msgstr ""
+"Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
 
 # smartling.placeholder_format=C
 #. Golf rankings column: average points
@@ -1457,6 +1483,12 @@ msgstr "Добавить в %1$s"
 #. Button that creates a shortcut to the current page on the home screen of the user's phone.
 msgid "Add to Home Screen"
 msgstr "Добавить на домашнюю страницу"
+
+# smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1821,6 +1853,13 @@ msgid "All types"
 msgstr "Все типы"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1869,8 +1908,8 @@ msgid ""
 msgstr ""
 "Позволяет %1$s выполнить поиск в Интернете, чтобы улучшить ответы на "
 "релевантные запросы. Отправляет в поисковую систему только сгенерированные "
-"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s "
-"по-прежнему имеют %3$sнулевую видимость провайдера%4$s."
+"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s по-"
+"прежнему имеют %3$sнулевую видимость провайдера%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2344,6 +2383,12 @@ msgid "Ask anything privately"
 msgstr "Задавайте любые вопросы, сохраняя конфиденциальность"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2404,9 +2449,10 @@ msgstr ""
 "интеллекта. Вы можете самостоятельно проконтролировать, как часто будут "
 "появляться ответы Assist: «никогда» (интерфейс Assist полностью исключается "
 "из поисковых запросов), «по запросу» (ответы ИИ отображаются при нажатии "
-"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или «часто» "
-"(чаще и в отношении более широкого спектра запросов). Пока что ответы на "
-"базе ИИ предоставляются только на территории США (на английском языке)."
+"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или "
+"«часто» (чаще и в отношении более широкого спектра запросов). Пока что "
+"ответы на базе ИИ предоставляются только на территории США (на английском "
+"языке)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2962,7 +3008,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Список блокировки не является исчерпывающим и может содержать неточности."
+msgstr ""
+"Список блокировки не является исчерпывающим и может содержать неточности."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3860,11 +3907,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними "
-"чат-моделями на базе ИИ от OpenAI, Anthropic и других компаний. При "
-"отключении этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка "
-"«Чат» и ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, "
-"посетив его страницу напрямую: %1$shttps://duck.ai%2$s."
+"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними чат-"
+"моделями на базе ИИ от OpenAI, Anthropic и других компаний. При отключении "
+"этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка «Чат» и "
+"ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, посетив "
+"его страницу напрямую: %1$shttps://duck.ai%2$s."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4103,7 +4150,8 @@ msgstr "Проверьте орфографию"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
+msgstr ""
+"Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4541,7 +4589,8 @@ msgstr "Нажмите %1$sНастройки%2$s в выпадающем мен
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
+msgstr ""
+"Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5290,6 +5339,12 @@ msgid "Copy"
 msgstr "Копировать"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5298,7 +5353,8 @@ msgstr "Копировать"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
+msgstr ""
+"Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5329,6 +5385,28 @@ msgstr "Скопируйте или сохраните этот код"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Скопировать код восстановления"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5437,7 +5515,8 @@ msgstr "Создать ссылку для доступа"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr "Создай список покупок с указанием количества ингредиентов из этого рецепта."
+msgstr ""
+"Создай список покупок с указанием количества ингредиентов из этого рецепта."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -6012,6 +6091,14 @@ msgid "Delete recent chats?"
 msgstr "Удалить недавние чаты?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6022,6 +6109,14 @@ msgstr "Удалить этот чат?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Удаленные чаты"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6117,7 +6212,8 @@ msgstr "Диктовка в Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
+msgstr ""
+"Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6275,6 +6371,13 @@ msgstr "Отклонить"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Закрыть"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6607,7 +6710,8 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr "Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
+msgstr ""
+"Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6629,7 +6733,8 @@ msgstr "Подготовь пост для соцсетей"
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Drag %sThis Button%s on top of the home icon:"
-msgstr "Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
+msgstr ""
+"Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
 
 # smartling.placeholder_format=C
 #. Indicates this is the number of draws for this team in e.g. soccer
@@ -6850,8 +6955,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai позволяет вести приватные беседы с популярными ИИ-моделями. При "
-"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы "
-"по-прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
+"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы по-"
+"прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
 "напрямую."
 
 # smartling.placeholder_format=C
@@ -6935,8 +7040,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, приватный чат-бот, бесплатный чат с ИИ, анонимный "
-"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, "
-"ИИ-модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
+"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, ИИ-"
+"модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7112,7 +7217,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
+msgstr ""
+"Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7139,6 +7245,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Браузер DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7419,8 +7532,8 @@ msgid ""
 msgstr ""
 "Каждый раз, когда вы просите нас порекомендовать парольную фразу, мы "
 "запрашиваем с серверов DuckDuckGo длинный список случайных слов. Затем в "
-"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум "
-"18–20 символов."
+"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум 18–"
+"20 символов."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7977,10 +8090,25 @@ msgstr ""
 "пустой звук."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Срок действия истек"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -9355,6 +9483,14 @@ msgstr ""
 "устройством»%4$s. Или отсканируйте QR-код в PDF-файле для восстановления."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -9465,6 +9601,12 @@ msgstr "Понятно"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Понятно"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9900,7 +10042,8 @@ msgstr "Ответ пригодился"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr "Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
+msgstr ""
+"Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -10619,7 +10762,8 @@ msgstr "Изображения по запросу «%1$s»"
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for images has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Images for %s blocked by safe search"
-msgstr "Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr ""
+"Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the image results for a certain query, ex. Images for <b>beach</b>
@@ -11447,6 +11591,12 @@ msgid "Learn %sMore%s"
 msgstr "Узнать %1$sБольше%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11503,7 +11653,8 @@ msgstr "Подробнее об активной защите конфиденц
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr "Получайте рекомендации о защите персональных данных на электронную почту."
+msgstr ""
+"Получайте рекомендации о защите персональных данных на электронную почту."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11557,7 +11708,8 @@ msgstr "Подробнее о работе этой функции"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
+msgstr ""
+"Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -12082,6 +12234,13 @@ msgid "Manage"
 msgstr "Настроить"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12331,6 +12490,12 @@ msgstr "Меню"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Меню"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12703,6 +12868,12 @@ msgid "More about Duck.ai"
 msgstr "Подробнее о Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Больше на"
@@ -12895,6 +13066,12 @@ msgstr "Микрофон отключен"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Приглушённый красный"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13923,7 +14100,8 @@ msgstr "Оман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
+msgstr ""
+"Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13963,6 +14141,30 @@ msgid ""
 msgstr ""
 "На Mac %1$sвыберите Maxthon > Настройки%2$s, на Windows %3$sнажмите на %4$s "
 "иконку > Настройки%5$s"
+
+# smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14088,7 +14290,8 @@ msgstr "Открыть сайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
+msgstr ""
+"Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14257,7 +14460,8 @@ msgstr "Открыть панель «Как работает Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
+msgstr ""
+"Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14714,6 +14918,12 @@ msgid "Past year"
 msgstr "За прошлый год"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14724,6 +14934,12 @@ msgstr "Вставить"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Вставить код синхронизации"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14777,6 +14993,20 @@ msgstr "Не работает/закрыто"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Персидский"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15754,7 +15984,8 @@ msgstr "Приватные чаты без сохранения"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr "Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
+msgstr ""
+"Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -16044,6 +16275,12 @@ msgid "Reading website…"
 msgstr "Чтение сайта…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16077,19 +16314,22 @@ msgstr "Аналитическая ИИ-модель со средним уро�
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr "Рассуждения позволяют получить более обдуманные ответы на сложные вопросы."
+msgstr ""
+"Рассуждения позволяют получить более обдуманные ответы на сложные вопросы."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Более глубокие рассуждения, но лимиты достигаются в 2–5 раз быстрее. %1$s"
+msgstr ""
+"Более глубокие рассуждения, но лимиты достигаются в 2–5 раз быстрее. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Более глубокие рассуждения, но лимиты расходуются в 2–5 раз быстрее. %1$s"
+msgstr ""
+"Более глубокие рассуждения, но лимиты расходуются в 2–5 раз быстрее. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16231,6 +16471,12 @@ msgstr "Восстановление данных"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Код восстановления"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16484,6 +16730,12 @@ msgid "Remove %s"
 msgstr "Удалить %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16524,6 +16776,18 @@ msgstr "Удалить выбранный текст"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Уберите лишние знаки препинания"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17219,6 +17483,12 @@ msgid "Say hello to Duck.ai"
 msgstr "Встречайте: Duck.ai"
 
 # smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai!"
@@ -17762,7 +18032,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
+msgstr ""
+"Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17946,7 +18217,8 @@ msgstr "Выберите %1$sDuckDuckGo%2$s и нажмите %3$sУстанов
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
+msgstr ""
+"Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17966,7 +18238,8 @@ msgstr "Выберите %1$sDuckDuckGo%2$s в списке поисковых �
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
+msgstr ""
+"Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18051,7 +18324,8 @@ msgstr "Выберите %1$sНастройки%2$s, затем %3$sДополн
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
+msgstr ""
+"Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18147,7 +18421,8 @@ msgstr "Выбранный текст со страницы %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
+msgstr ""
+"Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18213,6 +18488,13 @@ msgstr "Сербский (кириллица)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Сербский (латиница)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18369,6 +18651,14 @@ msgid "Share"
 msgstr "Поделиться"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18383,7 +18673,8 @@ msgstr "Поделиться"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
+msgstr ""
+"Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18516,6 +18807,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Что вы думаете о нашем поисковом поле?"
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18962,7 +19265,8 @@ msgstr "Показывает поисковые подсказки при вво
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
+msgstr ""
+"Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19056,7 +19360,8 @@ msgstr "Поиск по сайту временно недоступен. Мы �
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
+msgstr ""
+"Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19200,10 +19505,17 @@ msgid "Something went wrong"
 msgstr "Что-то пошло не так"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
+msgstr ""
+"Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19305,7 +19617,8 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
+msgstr ""
+"При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -20042,6 +20355,12 @@ msgid "Switch model"
 msgstr "Выбрать другую модель"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20301,6 +20620,13 @@ msgid "Synced Devices"
 msgstr "Синхронизированные устройства"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Сирия"
 
@@ -20331,6 +20657,12 @@ msgstr "Уточняется"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "ТВ"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20364,8 +20696,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с "
-"ИИ-помощником прямо в нашем бесплатном приложении — где бы вы ни находились."
+"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с ИИ-"
+"помощником прямо в нашем бесплатном приложении — где бы вы ни находились."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20374,8 +20706,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с "
-"ИИ-помощником прямо в нашем бесплатном браузере — где бы вы ни находились."
+"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с ИИ-"
+"помощником прямо в нашем бесплатном браузере — где бы вы ни находились."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20686,7 +21018,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
+msgstr ""
+"Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20821,7 +21154,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
+msgstr ""
+"Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20911,6 +21245,22 @@ msgstr ""
 "смотрите %4$s)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20988,12 +21338,19 @@ msgstr ""
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
+msgstr ""
+"Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Эта информация бесполезна"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21061,7 +21418,8 @@ msgstr "Для нормальной работы данной странице �
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
+msgstr ""
+"Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21111,6 +21469,18 @@ msgstr ""
 "страница %1$s, где никогда не отображаются ответы ИИ."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21137,7 +21507,8 @@ msgstr "Здесь это видео пока недоступно. Его мо�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
+msgstr ""
+"Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21284,7 +21655,8 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr "Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
+msgstr ""
+"Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -21707,11 +22079,13 @@ msgstr "Чтобы не получать подобные сообщения, п
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
+msgstr ""
+"Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr "Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
+msgstr ""
+"Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -21753,6 +22127,12 @@ msgstr "Попробовать бесплатно"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Попробовать бесплатно"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21842,14 +22222,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Для более точных результатов попробуйте использовать анонимную геопозицию."
+msgstr ""
+"Для более точных результатов попробуйте использовать анонимную геопозицию."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
+msgstr ""
+"Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21868,6 +22250,12 @@ msgstr "Попробовать бесплатно"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Попробовать бесплатно"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22031,7 +22419,8 @@ msgstr "Новинки платформы: ИИ-модели с открытым
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Попробуйте начать с готовых запросов или введите собственный вариант ниже."
+msgstr ""
+"Попробуйте начать с готовых запросов или введите собственный вариант ниже."
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22115,6 +22504,12 @@ msgid "Turkmenistan"
 msgstr "Туркменистан"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22125,6 +22520,12 @@ msgstr "Отключить Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Отключить Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22209,7 +22610,8 @@ msgstr "Активировать переключатель Duck.ai"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
-msgstr "Для получения более точных результатов выберите вариант «Точная геопозиция»."
+msgstr ""
+"Для получения более точных результатов выберите вариант «Точная геопозиция»."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -22416,14 +22818,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
+msgstr ""
+"Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"В меню %1$sПри запуске > Домашняя страница%2$s введите: "
-"https://duckduckgo.com"
+"В меню %1$sПри запуске > Домашняя страница%2$s введите: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22433,15 +22836,16 @@ msgstr "В меню %1$sНастройки поиска%2$s выберите %3$
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
+msgstr ""
+"В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми "
-"системами...%4$s"
+"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми системами..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22455,7 +22859,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
+msgstr ""
+"В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22611,6 +23016,12 @@ msgid "Unmute"
 msgstr "Включить микрофон"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22646,6 +23057,12 @@ msgstr "Обновить"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Обновить браузер"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22684,8 +23101,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми "
-"ИИ-моделями, обновите браузер DuckDuckGo."
+"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми ИИ-"
+"моделями, обновите браузер DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22927,7 +23344,8 @@ msgstr "Используйте DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
+msgstr ""
+"Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23061,7 +23479,8 @@ msgstr "Видеоролики заблокированы в рамках без
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for videos has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Videos for %s blocked by safe search"
-msgstr "Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr ""
+"Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the video results for a certain query, ex. Videos for <b>japan</b>
@@ -23580,7 +23999,8 @@ msgstr "Мы не отслеживаем вас. Никогда."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
+msgstr ""
+"Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23621,13 +24041,22 @@ msgstr "Мы не следим за вами, ни в режиме приват�
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
+msgstr ""
+"Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Чат завершен из-за отсутствия активности. Хотите повторить попытку?"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23676,6 +24105,14 @@ msgstr ""
 "Вы всегда можете изменить эту настройку позже."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23707,7 +24144,16 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
+msgstr ""
+"Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24016,6 +24462,12 @@ msgid "What are some pros and cons of annuities?"
 msgstr "В чем плюсы и минусы пенсионных аннуитетов?"
 
 # smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
 msgctxt "User prompt seeded by Learn More CTA"
 msgid ""
@@ -24097,7 +24549,8 @@ msgstr "Чему я научусь на этом курсе?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr "Каковы основные контраргументы или критические замечания по этому поводу?"
+msgstr ""
+"Каковы основные контраргументы или критические замечания по этому поводу?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -24375,7 +24828,8 @@ msgstr "На какие бренды обратить внимание нови�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
+msgstr ""
+"При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24581,6 +25035,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Без нулевой видимости для поставщика"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24890,7 +25352,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
+msgstr ""
+"Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -24919,7 +25382,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
+msgstr ""
+"Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -24964,7 +25428,8 @@ msgstr "Вы можете продолжить чат, используя сво
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
+msgstr ""
+"Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24982,25 +25447,29 @@ msgstr "Число файлов, прикрепляемых к одной бес
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time"
-msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time."
-msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation"
-msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
-msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
@@ -25078,6 +25547,13 @@ msgstr "Осталось попыток: %1$s."
 msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Осталась 1 попытка."
+
+# smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25246,7 +25722,8 @@ msgstr "Вы исчерпали голосовой лимит на сегодн�
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Вы достигли лимита использования функции диктовки. Повторите попытку позже."
+msgstr ""
+"Вы достигли лимита использования функции диктовки. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25298,6 +25775,23 @@ msgid "YouTube Standard"
 msgstr "Стандартная лицензия YouTube"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Ваша история поиска в DuckDuckGo — только ваша"
@@ -25319,6 +25813,14 @@ msgstr "Ваше фактическое местоположение сохра�
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Ваше фактическое местоположение сохраняется в тайне."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25407,7 +25909,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
+msgstr ""
+"Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25429,8 +25932,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения "
-"ИИ-моделей."
+"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения ИИ-"
+"моделей."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25464,8 +25967,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в "
-"Duck.ai."
+"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -49,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (это устройство)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -256,8 +255,7 @@ msgstr "Лайков: %1$s"
 #. Disclaimer text shown bellow chat input on mobile, avoid long text if possible. Example: 'GPT-3 may display inaccurate or offensive information.'
 msgctxt "Disclaimer bellow chat input - mobile"
 msgid "%s may display inaccurate or offensive information."
-msgstr ""
-"ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
+msgstr "ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
 
 # smartling.placeholder_format=C
 #. Label showing how many members a discussion has. To be displayed on a card about that discussion.
@@ -501,22 +499,20 @@ msgstr "%1$sКак мы сохраняем конфиденциальность 
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sПодробнее%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
+msgstr "%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
+msgstr "%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -797,7 +793,7 @@ msgstr "2-е место в группе %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "Второе мнение"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1007,8 +1003,8 @@ msgid ""
 msgstr ""
 "Функция AI Chat позволяет анонимно общаться с нашим чат-ботом на базе "
 "сторонних моделей ИИ. Если отключить эту функцию, она не будет отображаться "
-"в поиске DuckDuckGo Search, но останется доступной по ссылке %1$sduckduckgo."
-"com/aichat%2$s."
+"в поиске DuckDuckGo Search, но останется доступной по ссылке "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1124,8 +1120,7 @@ msgstr "Не добавлять в браузер"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "ATB related (not displayed on settings page)"
-msgstr ""
-"Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
+msgstr "Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
 
 # smartling.placeholder_format=C
 #. Golf rankings column: average points
@@ -1488,7 +1483,7 @@ msgstr "Добавить на домашнюю страницу"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Добавить в «Мои чаты»"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1857,7 +1852,7 @@ msgstr "Все типы"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Все ваши устройства отключены от синхронизации."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1908,8 +1903,8 @@ msgid ""
 msgstr ""
 "Позволяет %1$s выполнить поиск в Интернете, чтобы улучшить ответы на "
 "релевантные запросы. Отправляет в поисковую систему только сгенерированные "
-"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s по-"
-"прежнему имеют %3$sнулевую видимость провайдера%4$s."
+"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s "
+"по-прежнему имеют %3$sнулевую видимость провайдера%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2386,7 +2381,7 @@ msgstr "Задавайте любые вопросы, сохраняя конф�
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Задавайте любые вопросы, сохраняя конфиденциальность"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2449,10 +2444,9 @@ msgstr ""
 "интеллекта. Вы можете самостоятельно проконтролировать, как часто будут "
 "появляться ответы Assist: «никогда» (интерфейс Assist полностью исключается "
 "из поисковых запросов), «по запросу» (ответы ИИ отображаются при нажатии "
-"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или "
-"«часто» (чаще и в отношении более широкого спектра запросов). Пока что "
-"ответы на базе ИИ предоставляются только на территории США (на английском "
-"языке)."
+"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или «часто» "
+"(чаще и в отношении более широкого спектра запросов). Пока что ответы на "
+"базе ИИ предоставляются только на территории США (на английском языке)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -3008,8 +3002,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Список блокировки не является исчерпывающим и может содержать неточности."
+msgstr "Список блокировки не является исчерпывающим и может содержать неточности."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3907,11 +3900,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними чат-"
-"моделями на базе ИИ от OpenAI, Anthropic и других компаний. При отключении "
-"этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка «Чат» и "
-"ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, посетив "
-"его страницу напрямую: %1$shttps://duck.ai%2$s."
+"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними "
+"чат-моделями на базе ИИ от OpenAI, Anthropic и других компаний. При "
+"отключении этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка "
+"«Чат» и ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, "
+"посетив его страницу напрямую: %1$shttps://duck.ai%2$s."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4150,8 +4143,7 @@ msgstr "Проверьте орфографию"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
+msgstr "Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4589,8 +4581,7 @@ msgstr "Нажмите %1$sНастройки%2$s в выпадающем мен
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
+msgstr "Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5342,7 +5333,7 @@ msgstr "Копировать"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Копировать"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5353,8 +5344,7 @@ msgstr "Копировать"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
+msgstr "Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5392,13 +5382,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Копировать ссылку общего доступа"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Скопируйте код с другого устройства"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5407,6 +5397,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Скопируйте код с другого устройства. Перейдите в раздел %1$sНастройки "
+"Duck.ai › Чаты › Sync & Backup › Синхронизировать с другим устройством%2$s и "
+"повторите попытку."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5515,8 +5508,7 @@ msgstr "Создать ссылку для доступа"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
-"Создай список покупок с указанием количества ингредиентов из этого рецепта."
+msgstr "Создай список покупок с указанием количества ингредиентов из этого рецепта."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -6096,7 +6088,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Удалить ссылку общего доступа"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6117,6 +6109,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Если удалить ссылку, она перестанет работать. Те, кто открыл её и добавил "
+"беседу в свои чаты, сохранят свою копию."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6212,8 +6206,7 @@ msgstr "Диктовка в Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
+msgstr "Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6377,7 +6370,7 @@ msgstr "Закрыть"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Закрыть"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6710,8 +6703,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
+msgstr "Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6733,8 +6725,7 @@ msgstr "Подготовь пост для соцсетей"
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Drag %sThis Button%s on top of the home icon:"
-msgstr ""
-"Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
+msgstr "Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
 
 # smartling.placeholder_format=C
 #. Indicates this is the number of draws for this team in e.g. soccer
@@ -6955,8 +6946,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai позволяет вести приватные беседы с популярными ИИ-моделями. При "
-"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы по-"
-"прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
+"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы "
+"по-прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
 "напрямую."
 
 # smartling.placeholder_format=C
@@ -7040,8 +7031,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, приватный чат-бот, бесплатный чат с ИИ, анонимный "
-"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, ИИ-"
-"модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
+"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, "
+"ИИ-модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7217,8 +7208,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
+msgstr "Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7251,7 +7241,7 @@ msgstr "Браузер DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Страницы справки DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7532,8 +7522,8 @@ msgid ""
 msgstr ""
 "Каждый раз, когда вы просите нас порекомендовать парольную фразу, мы "
 "запрашиваем с серверов DuckDuckGo длинный список случайных слов. Затем в "
-"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум 18–"
-"20 символов."
+"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум "
+"18–20 символов."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -8094,7 +8084,7 @@ msgstr ""
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Срок действия истек"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8108,7 +8098,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Истекает %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -9489,6 +9479,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Перейдите в раздел %1$sНастройки Duck.ai%2$s › %3$sЧаты › Sync & Backup › "
+"Синхронизировать с другим устройством%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9606,7 +9598,7 @@ msgstr "Понятно"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Понятно"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10042,8 +10034,7 @@ msgstr "Ответ пригодился"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr ""
-"Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
+msgstr "Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -10762,8 +10753,7 @@ msgstr "Изображения по запросу «%1$s»"
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for images has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Images for %s blocked by safe search"
-msgstr ""
-"Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr "Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the image results for a certain query, ex. Images for <b>beach</b>
@@ -11594,7 +11584,7 @@ msgstr "Узнать %1$sБольше%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Узнать больше"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11653,8 +11643,7 @@ msgstr "Подробнее об активной защите конфиденц
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Получайте рекомендации о защите персональных данных на электронную почту."
+msgstr "Получайте рекомендации о защите персональных данных на электронную почту."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11708,8 +11697,7 @@ msgstr "Подробнее о работе этой функции"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
+msgstr "Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -12238,7 +12226,7 @@ msgstr "Настроить"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Управление"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12495,7 +12483,7 @@ msgstr "Меню"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Сообщения ниже видны только вам."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12871,7 +12859,7 @@ msgstr "Подробнее о Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Дополнительные действия"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13071,7 +13059,7 @@ msgstr "Приглушённый красный"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Мои устройства"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14100,8 +14088,7 @@ msgstr "Оман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
+msgstr "Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14149,6 +14136,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"На другом устройстве перейдите в раздел %1$sНастройки Duck.ai%2$s › %3$sЧаты "
+"› Sync & Backup › Синхронизировать с другим устройством%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14157,6 +14146,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"На другом устройстве перейдите в раздел %1$sНастройки Duck.ai%2$s › %3$sЧаты "
+"› Sync & Backup › Синхронизировать с другим устройством%4$s и отсканируйте "
+"этот код:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14165,6 +14157,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"На другом устройстве перейдите в раздел %1$sНастройки Duck.ai%2$s › %3$sЧаты "
+"› Sync & Backup › Синхронизировать с другим устройством%4$s. Или "
+"отсканируйте QR-код в PDF-файле для восстановления."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14290,8 +14285,7 @@ msgstr "Открыть сайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
+msgstr "Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14460,8 +14454,7 @@ msgstr "Открыть панель «Как работает Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
+msgstr "Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14921,7 +14914,7 @@ msgstr "За прошлый год"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Вставить"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14939,7 +14932,7 @@ msgstr "Вставить код синхронизации"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Вставьте его ниже"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14998,7 +14991,7 @@ msgstr "Персидский"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -15007,6 +15000,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal находит вашу информацию на сайтах брокеров "
+"данных, которые продают её. Затем мы добиваемся её удаления."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15984,8 +15979,7 @@ msgstr "Приватные чаты без сохранения"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr ""
-"Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
+msgstr "Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -16278,7 +16272,7 @@ msgstr "Чтение сайта…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Готовы к солнечному затмению?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16314,22 +16308,19 @@ msgstr "Аналитическая ИИ-модель со средним уро�
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
-"Рассуждения позволяют получить более обдуманные ответы на сложные вопросы."
+msgstr "Рассуждения позволяют получить более обдуманные ответы на сложные вопросы."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Более глубокие рассуждения, но лимиты достигаются в 2–5 раз быстрее. %1$s"
+msgstr "Более глубокие рассуждения, но лимиты достигаются в 2–5 раз быстрее. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Более глубокие рассуждения, но лимиты расходуются в 2–5 раз быстрее. %1$s"
+msgstr "Более глубокие рассуждения, но лимиты расходуются в 2–5 раз быстрее. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16476,7 +16467,7 @@ msgstr "Код восстановления"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Код восстановления"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16733,7 +16724,7 @@ msgstr "Удалить %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Удалить устройство"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16781,13 +16772,13 @@ msgstr "Уберите лишние знаки препинания"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Удалите свои данные из интернета"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Удалите свои данные из интернета"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17486,7 +17477,7 @@ msgstr "Встречайте: Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Встречайте Duck.ai — бесплатный, приватный ИИ-чат от DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -18032,8 +18023,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
+msgstr "Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18217,8 +18207,7 @@ msgstr "Выберите %1$sDuckDuckGo%2$s и нажмите %3$sУстанов
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
+msgstr "Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18238,8 +18227,7 @@ msgstr "Выберите %1$sDuckDuckGo%2$s в списке поисковых �
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
+msgstr "Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18324,8 +18312,7 @@ msgstr "Выберите %1$sНастройки%2$s, затем %3$sДополн
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
+msgstr "Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18421,8 +18408,7 @@ msgstr "Выбранный текст со страницы %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
+msgstr "Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18494,7 +18480,7 @@ msgstr "Сербский (латиница)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Данные сервера удалены"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18656,7 +18642,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Поделиться"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18673,8 +18659,7 @@ msgstr "Поделиться"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
+msgstr "Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18812,13 +18797,13 @@ msgstr "Что вы думаете о нашем поисковом поле?"
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Ссылки для общего доступа к чатам"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Ссылки для общего доступа к чатам"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19265,8 +19250,7 @@ msgstr "Показывает поисковые подсказки при вво
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
+msgstr "Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19360,8 +19344,7 @@ msgstr "Поиск по сайту временно недоступен. Мы �
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
+msgstr "Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19508,14 +19491,13 @@ msgstr "Что-то пошло не так"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Произошла ошибка при загрузке этого общего чата."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
+msgstr "Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19617,8 +19599,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
+msgstr "При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -20358,7 +20339,7 @@ msgstr "Выбрать другую модель"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Выбрать другую модель"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20624,7 +20605,7 @@ msgstr "Синхронизированные устройства"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Синхронизировано %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20662,7 +20643,7 @@ msgstr "ТВ"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Таблица"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20696,8 +20677,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с ИИ-"
-"помощником прямо в нашем бесплатном приложении — где бы вы ни находились."
+"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с "
+"ИИ-помощником прямо в нашем бесплатном приложении — где бы вы ни находились."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20706,8 +20687,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с ИИ-"
-"помощником прямо в нашем бесплатном браузере — где бы вы ни находились."
+"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с "
+"ИИ-помощником прямо в нашем бесплатном браузере — где бы вы ни находились."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -21018,8 +20999,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
+msgstr "Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21154,8 +21134,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
+msgstr "Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21248,7 +21227,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Это устройство"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21259,6 +21238,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Это устройство больше не сможет получать доступ к данным, синхронизированным "
+"на других устройствах. Последние %1$s чатов по-прежнему будут доступны в "
+"локальном хранилище."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21338,8 +21320,7 @@ msgstr ""
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
+msgstr "Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21350,7 +21331,7 @@ msgstr "Эта информация бесполезна"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Это копия чата с общим доступом."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21418,8 +21399,7 @@ msgstr "Для нормальной работы данной странице �
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
+msgstr "Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21472,13 +21452,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Не удалось открыть этот общий чат. Возможно, ссылка неполная."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Ссылка на этот общий чат больше недоступна."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21507,8 +21487,7 @@ msgstr "Здесь это видео пока недоступно. Его мо�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
+msgstr "Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21655,8 +21634,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
+msgstr "Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -22079,13 +22057,11 @@ msgstr "Чтобы не получать подобные сообщения, п
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
+msgstr "Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
+msgstr "Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -22132,7 +22108,7 @@ msgstr "Попробовать бесплатно"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Попробовать бесплатно!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22222,16 +22198,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Для более точных результатов попробуйте использовать анонимную геопозицию."
+msgstr "Для более точных результатов попробуйте использовать анонимную геопозицию."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
+msgstr "Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22255,7 +22229,7 @@ msgstr "Попробовать бесплатно"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Попробовать бесплатно!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22419,8 +22393,7 @@ msgstr "Новинки платформы: ИИ-модели с открытым
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Попробуйте начать с готовых запросов или введите собственный вариант ниже."
+msgstr "Попробуйте начать с готовых запросов или введите собственный вариант ниже."
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22507,7 +22480,7 @@ msgstr "Туркменистан"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Отключить"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22525,7 +22498,7 @@ msgstr "Отключить Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Отключить Sync & Backup и удалить данные с сервера?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22610,8 +22583,7 @@ msgstr "Активировать переключатель Duck.ai"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
-msgstr ""
-"Для получения более точных результатов выберите вариант «Точная геопозиция»."
+msgstr "Для получения более точных результатов выберите вариант «Точная геопозиция»."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -22818,15 +22790,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
+msgstr "Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"В меню %1$sПри запуске > Домашняя страница%2$s введите: https://duckduckgo."
-"com"
+"В меню %1$sПри запуске > Домашняя страница%2$s введите: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22836,16 +22807,15 @@ msgstr "В меню %1$sНастройки поиска%2$s выберите %3$
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
+msgstr "В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми системами..."
-"%4$s"
+"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми "
+"системами...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22859,8 +22829,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
+msgstr "В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23019,7 +22988,7 @@ msgstr "Включить микрофон"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Чат без названия"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23062,7 +23031,7 @@ msgstr "Обновить браузер"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Обновите Duck.ai, чтобы просмотреть этот чат с общим доступом."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23101,8 +23070,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми ИИ-"
-"моделями, обновите браузер DuckDuckGo."
+"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми "
+"ИИ-моделями, обновите браузер DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23344,8 +23313,7 @@ msgstr "Используйте DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
+msgstr "Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23479,8 +23447,7 @@ msgstr "Видеоролики заблокированы в рамках без
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for videos has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Videos for %s blocked by safe search"
-msgstr ""
-"Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr "Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the video results for a certain query, ex. Videos for <b>japan</b>
@@ -23999,8 +23966,7 @@ msgstr "Мы не отслеживаем вас. Никогда."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
+msgstr "Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24041,8 +24007,7 @@ msgstr "Мы не следим за вами, ни в режиме приват�
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
+msgstr "Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24057,6 +24022,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Мы находим и удаляем вашу личную информацию с сайтов брокеров данных. Кроме "
+"того, вы получите VPN и другие функции защиты."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24111,6 +24078,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Мы регулярно проверяем сайты брокеров данных на наличие вашей личной "
+"информации и показываем ход работы в удобной панели."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24144,8 +24113,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
+msgstr "Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24154,6 +24122,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Мы проверим сайты брокеров данных на наличие вашего адреса электронной "
+"почты, имени, адреса и других данных и постараемся удалить всю найденную "
+"информацию о вас."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24465,7 +24436,7 @@ msgstr "В чем плюсы и минусы пенсионных аннуите
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "В чем преимущества Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24549,8 +24520,7 @@ msgstr "Чему я научусь на этом курсе?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
-"Каковы основные контраргументы или критические замечания по этому поводу?"
+msgstr "Каковы основные контраргументы или критические замечания по этому поводу?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -24828,8 +24798,7 @@ msgstr "На какие бренды обратить внимание нови�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
+msgstr "При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25043,6 +25012,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Работает прямо на вашем устройстве и удаляет ваш адрес электронной почты, "
+"имя, адрес и другие данные с сайтов брокеров данных."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25352,8 +25323,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
+msgstr "Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -25382,8 +25352,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
+msgstr "Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25428,8 +25397,7 @@ msgstr "Вы можете продолжить чат, используя сво
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
+msgstr "Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25447,29 +25415,25 @@ msgstr "Число файлов, прикрепляемых к одной бес
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time"
-msgstr ""
-"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time."
-msgstr ""
-"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation"
-msgstr ""
-"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
-msgstr ""
-"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
@@ -25553,7 +25517,7 @@ msgstr "Осталась 1 попытка."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "На этом устройстве нет ссылок общего доступа к чатам."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25722,8 +25686,7 @@ msgstr "Вы исчерпали голосовой лимит на сегодн�
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Вы достигли лимита использования функции диктовки. Повторите попытку позже."
+msgstr "Вы достигли лимита использования функции диктовки. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25783,13 +25746,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Ваши последние %1$s чатов будут доступны в локальном хранилище следующих "
+"браузеров:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Ваши чаты Duck.ai синхронизируются с использованием сквозного шифрования."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25821,6 +25786,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Ваша резервная копия будет удалена с сервера DuckDuckGo. Все устройства "
+"будут отключены от синхронизации."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25909,8 +25876,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
+msgstr "Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25932,8 +25898,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения ИИ-"
-"моделей."
+"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения "
+"ИИ-моделей."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25967,8 +25933,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в Duck."
-"ai."
+"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/sc_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/sc_IT/LC_MESSAGES/duckduckgo.po
@@ -35,6 +35,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% vatzinos"
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -393,6 +400,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%sImpara comente tenimus sa positzione in anònimu%s."
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -628,6 +641,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1185,6 +1203,11 @@ msgstr "Agiunghe a %s"
 msgid "Add to Home Screen"
 msgstr "Agiunghe a sa pàgina initziale"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Cumplementos"
@@ -1479,6 +1502,12 @@ msgstr "Totu is mannàrias"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Totu is tipos"
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
@@ -1893,6 +1922,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4270,6 +4304,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4303,6 +4342,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4863,6 +4921,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4871,6 +4936,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5077,6 +5149,12 @@ msgstr "Iscarta"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5727,6 +5805,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6412,9 +6496,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7513,6 +7610,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7599,6 +7703,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9228,6 +9337,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "%sÀteras informatziones%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9750,6 +9864,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9956,6 +10076,11 @@ msgstr "Menù"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menù"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10258,6 +10383,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Àteru in"
@@ -10415,6 +10545,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Ruju iscuru"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11295,6 +11430,27 @@ msgstr ""
 "In Mac, %sincarca Maxthon > Preferèntzias%s, in Windows, %sincarca s'%sicona "
 "> Cunfiguratziones%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11916,6 +12072,11 @@ msgstr "S'ùrtima chida"
 msgid "Past year"
 msgstr "S'ùrtimu annu"
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11924,6 +12085,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11969,6 +12135,18 @@ msgstr ""
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persianu"
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
 msgctxt "Assistant role option label for Personal trainer"
@@ -12988,6 +13166,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13137,6 +13320,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13346,6 +13534,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13379,6 +13572,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13930,6 +14133,11 @@ msgstr "Sarva is cunfiguratziones tuas in manera anònima in sa nue"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14742,6 +14950,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Serbu (latinu)"
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14868,6 +15082,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14989,6 +15210,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15550,6 +15781,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16239,6 +16475,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16436,6 +16677,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16461,6 +16708,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "TV"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16923,6 +17175,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16991,6 +17257,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -17074,6 +17345,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17593,6 +17874,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17686,6 +17972,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17886,6 +18177,11 @@ msgstr "Turcu"
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17894,6 +18190,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18286,6 +18587,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18313,6 +18619,11 @@ msgstr "Atualiza"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -19091,6 +19402,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -19127,6 +19445,13 @@ msgstr ""
 "Imperamus isceti sa positzione anònima tua pro frunire resurtados prus "
 "bonos, acanta de tue. Podes semper mudare idea."
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -19159,6 +19484,13 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Amus a blocare is sighidores chi regollant is datos tuos durante sa "
 "navigatzione."
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
 msgctxt "noresults"
@@ -19402,6 +19734,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19867,6 +20204,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20275,6 +20619,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "T'abarrat unu tentativu."
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20447,6 +20797,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Lissèntzia istandard de YouTube"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Sa cronologia de chirca tua in DuckDuckGo est segura"
@@ -20464,6 +20829,13 @@ msgstr "Sa positzione atuale tua abarrat privada"
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/si_LK/LC_MESSAGES/duckduckgo.po
+++ b/locales/si_LK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: si_LK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "සම්පූර්ණයෙන්ම එන්නත් කර ඇත
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "එන්නත් කර ඇති ප්‍රතිශතය %"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -183,8 +191,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
-"ප්‍රකාරයකට මාරු වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
+"වන්න."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -195,8 +203,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
-"ප්‍රකාරයකට මාරු වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
+"වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -213,8 +221,7 @@ msgid ""
 "model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ DuckDuckGo දායකත්වයක් සමඟ පමණි. චැට් දිගටම කරගෙන යාමට මෙම "
-"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු "
-"වන්න."
+"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -223,8 +230,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව "
-"නැවත උත්සාහ කරන්න."
+"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -321,9 +328,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් "
-"අදහස් කරන්නේ ආකෘති සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ "
-"මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට නොහැකි බවයි."
+"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් අදහස් කරන්නේ ආකෘති "
+"සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට "
+"නොහැකි බවයි."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -409,8 +416,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම "
-"කරගෙන යාමට ආකෘති මාරු කළ හැකි ය."
+"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
+"යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -421,8 +428,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
-"යාමට ආකෘති මාරු කළ හැකි ය."
+"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන යාමට "
+"ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -435,8 +442,8 @@ msgstr "%1$s වචන"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව "
-"%6$sහරි%7$sක්ලික් කරන්න"
+"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව %6$sහරි%7$sක්ලික් "
+"කරන්න"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -444,8 +451,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි "
-"ලකුණ දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
+"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි ලකුණ "
+"දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -465,8 +472,7 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට "
-"%1$sමෙතන ක්ලික් කරන්න%2$s."
+"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට %1$sමෙතන ක්ලික් කරන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -487,13 +493,19 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sඅපි ඔබේ ස්ථානය පුද්ගලිකව තබා ගන්නේ කෙසේදැයි ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර "
-"ඉගෙන ගන්න."
+"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර ඉගෙන ගන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -512,8 +524,8 @@ msgstr "මුල් තිරයේ ඇති DuckDuckGo යෙදුම් න
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s "
-"සහ නැවත උත්සාහ කරන්න."
+"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s සහ නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -777,6 +789,12 @@ msgid "2nd in Group %s"
 msgstr "%1$s කණ්ඩායමේ 2 වැනියා"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -859,8 +877,7 @@ msgstr "පැය 6ක පරිශීලන සීමාවට ළඟා වී
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
-"හැක."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -868,8 +885,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට "
-"ම කතාබස් කළ හැකි ය."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට ම කතාබස් කළ "
+"හැකි ය."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -923,8 +940,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. "
-"කරුණාකර ඔබේ සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
+"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. කරුණාකර ඔබේ "
+"සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -932,8 +949,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
 msgstr ""
-"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
-"නැවත නැවුම් කරන්න."
+"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -941,8 +958,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
 msgstr ""
-"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
-"නැවත නැවුම් කරන්න."
+"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -986,10 +1003,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. "
-"මෙය ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. "
-"මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI "
-"Chat වෙත ප්‍රවේශ විය හැකිය."
+"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. මෙය "
+"ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. මෙම සැකසුම ක්‍රියා "
+"විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI Chat වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1050,10 +1066,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ "
-"වෙතත්, අපි පසු විපරම් ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය "
-"වෙත සබැඳෙමු, එය OpenAI සහ Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය "
-"දක්වන අපගේ පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ වෙතත්, අපි පසු විපරම් "
+"ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය වෙත සබැඳෙමු, එය OpenAI සහ "
+"Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය දක්වන අපගේ පෞද්ගලික AI බලයෙන් "
+"ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1238,8 +1254,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් "
-"නොමිලේ ආකෘතියකට මාරු වන්න."
+"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට "
+"මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1275,8 +1291,8 @@ msgstr "දැන්වීම"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය "
-"මගින් වන අතර ඒවා ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
+"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය මගින් වන අතර ඒවා "
+"ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1284,8 +1300,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය "
-"විසිනි, ඒවා ඔබව පැතිකඩ කිරීමට භාවිතා නොකෙරේ."
+"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය විසිනි, ඒවා ඔබව පැතිකඩ "
+"කිරීමට භාවිතා නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1336,8 +1352,7 @@ msgstr "DuckDuckGo දිගුව එක් කරන්න"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් "
-"කරන්න:"
+"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් කරන්න:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1464,6 +1479,12 @@ msgid "Add to Home Screen"
 msgstr "මුල් පිටුවට එකතු කරන්න"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "ඇඩෝන"
@@ -1565,8 +1586,7 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2–5 ගුණයක් වේගයෙන් පරිශීලන සීමාවලට ළඟා විය "
-"හැක. %1$s"
+"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2–5 ගුණයක් වේගයෙන් පරිශීලන සීමාවලට ළඟා විය හැක. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1574,9 +1594,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2-5 ගුණයකින් වේගයෙන් සීමාවන් භාවිතා කළ හැක. "
-"%1$s"
+msgstr "උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2-5 ගුණයකින් වේගයෙන් සීමාවන් භාවිතා කළ හැක. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1754,8 +1772,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo "
-"හෝ ආකෘති සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
+"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo හෝ ආකෘති "
+"සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1802,8 +1820,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, "
-"ඔබගේ IP ලිපිනය) ඉවත් කරනු ලැබේ."
+"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, ඔබගේ IP ලිපිනය) "
+"ඉවත් කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1824,6 +1842,13 @@ msgid "All types"
 msgstr "සියලු වර්ග"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1835,8 +1860,7 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය "
-"ලබා දෙන්න."
+"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය ලබා දෙන්න."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1868,10 +1892,9 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ "
-"දෙයි. සීමිත දත්ත රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් "
-"පමණක් යවයි. %2$s සහිත විමසීම් සහ ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ "
-"දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
+"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ දෙයි. සීමිත දත්ත "
+"රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් පමණක් යවයි. %2$s සහිත විමසීම් සහ "
+"ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1879,8 +1902,7 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට "
-"අවශ්‍ය වේ)"
+"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2018,8 +2040,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
-"නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2028,8 +2049,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
-"නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2043,9 +2063,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. "
-"එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම "
-"අක්‍රිය කරන්න."
+"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. එය කොපමණ වාර ගණනක් "
+"පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම අක්‍රිය කරන්න."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2092,8 +2111,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම "
-"විටම කරුණු මට කියන්න"
+"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම විටම කරුණු "
+"මට කියන්න"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2213,8 +2232,7 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, "
-"සියලුම කතා මකා දමනු ඇත."
+"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, සියලුම කතා මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2223,8 +2241,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද "
-"ඕනෑම මෑත කාලීන කතාබස් ද මකා දමනු ඇත."
+"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද ඕනෑම මෑත "
+"කාලීන කතාබස් ද මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2262,9 +2280,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම "
-"රැස්කර හෝ හුවමාරුකර නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු "
-"වේ."
+"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම රැස්කර හෝ හුවමාරුකර "
+"නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු වේ."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2345,6 +2362,12 @@ msgid "Ask anything privately"
 msgstr "පෞද්ගලිකව ඕනෑම දෙයක් අසන්න"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2400,14 +2423,12 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා "
-"AI-සහය සහිත පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් "
-"Assist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් "
-"ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම මත (ඔබ Assist "
-"බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
-"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක "
-"සෙවුම් මත නිතර පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් "
-"ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
+"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා AI-සහය සහිත "
+"පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් Assist පෙනී සිටීමට අවශ්‍ය දැ යි "
+"ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම "
+"මත (ඔබ Assist බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
+"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
+"පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2419,12 +2440,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට "
-"නිර්නාමික ව සෙවුම් විමසුම් සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු "
-"කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ "
-"තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා "
-"තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
-"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් විමසුම් "
+"සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා "
+"වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-"
+"බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව "
+"ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2450,8 +2470,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"DuckDuckGo VPN මගින් අවන්හලක, ගුවන් තොටුපළක හෝ හෝටලයක දී, ඔබේ සම්බන්ධතාවය "
-"ගුප්ත කේතනය කර Wi-Fi මත ඔබේ IP ලිපිනය සඟවයි."
+"DuckDuckGo VPN මගින් අවන්හලක, ගුවන් තොටුපළක හෝ හෝටලයක දී, ඔබේ සම්බන්ධතාවය ගුප්ත කේතනය "
+"කර Wi-Fi මත ඔබේ IP ලිපිනය සඟවයි."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2572,9 +2592,7 @@ msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදන
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් "
-"තිබිය හැක."
+msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් තිබිය හැක."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2599,9 +2617,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර "
-"සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist "
-"ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර "
+"වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල "
+"පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2610,17 +2628,15 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව "
-"සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, "
-"DuckAssist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව සමහර සෙවීම් "
+"වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, DuckAssist ලබා ගත "
+"හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව "
-"ධාවනය කරන්න."
+msgstr "ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව ධාවනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2820,8 +2836,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත "
-"හැකි පාරදත්ත වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
+"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත හැකි පාරදත්ත "
+"වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2951,8 +2967,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"හානිකර වෙබ් අඩවි අවහිර කරන්න, ඔබේ IP ලිපිනය සඟවන්න, තව ද අපගේ ග්‍රාහකත්වය "
-"සමඟ තවත් වාරික ආරක්ෂණ ලබා ගන්න."
+"හානිකර වෙබ් අඩවි අවහිර කරන්න, ඔබේ IP ලිපිනය සඟවන්න, තව ද අපගේ ග්‍රාහකත්වය සමඟ තවත් වාරික "
+"ආරක්ෂණ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3212,18 +3228,16 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ "
-"සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s "
-"දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
+"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
+"අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් "
-"යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s "
-"දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
+"අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3231,9 +3245,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන "
-"බ්‍රවුසර්%2$s සඳහා පුද්ගලික සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය "
-"යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන බ්‍රවුසර්%2$s සඳහා පුද්ගලික "
+"සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3340,11 +3353,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ "
-"බ්‍රව්සරයේ). ඔබේ සැකසීම් වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික "
-"Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත "
-"හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි විටෙකත් ඔබගේ "
-"බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ බ්‍රව්සරයේ). ඔබේ සැකසීම් "
+"වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති "
+"දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි "
+"විටෙකත් ඔබගේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3352,8 +3364,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ "
-"දත්ත OpenAI වෙත යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ දත්ත OpenAI වෙත "
+"යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3362,8 +3374,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත "
-"OpenAI වෙත යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත OpenAI වෙත "
+"යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3398,9 +3410,7 @@ msgstr "කැමරූන්"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ "
-"හැකිද?"
+msgstr "කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ හැකිද?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3849,11 +3859,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික "
-"සංවාද කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. "
-"මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු "
-"ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් "
-"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත ප්‍රවේශ විය හැකිය."
+"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික සංවාද "
+"කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. මෙම සැකසුම අක්‍රිය "
+"කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම "
+"ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත "
+"ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3909,8 +3919,7 @@ msgstr "පෞද්ගලිකව චැට් කරන්න"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ "
-"යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3918,8 +3927,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක "
-"පුද්ගලිකව කතාබහේ යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක පුද්ගලිකව කතාබහේ "
+"යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3988,8 +3997,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් "
-"ගබඩා කර ඇත. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
+"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් ගබඩා කර ඇත. "
+"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4001,11 +4010,10 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
-"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
-"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. "
-"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ "
-"ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් "
+"නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
+"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ "
+"කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4028,9 +4036,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන "
-"සියලුම ගොනු %2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව "
-"සමාලෝචනය කරනු ලැබේ."
+"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන සියලුම ගොනු "
+"%2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව සමාලෝචනය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4038,8 +4045,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට "
-"ගබඩාවේ ඉඩ නිදහස් කරගන්න."
+"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට ගබඩාවේ ඉඩ නිදහස් "
+"කරගන්න."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4195,8 +4202,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"හානිකර අඩවි සහ වංචා අවහිර කිරීමට උපකාරී වන ලොව පුරා පවතින සේවාදායක ස්ථාන "
-"40කට වඩා වැඩි ගණනකින් තෝරා ගන්න."
+"හානිකර අඩවි සහ වංචා අවහිර කිරීමට උපකාරී වන ලොව පුරා පවතින සේවාදායක ස්ථාන 40කට වඩා වැඩි "
+"ගණනකින් තෝරා ගන්න."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4213,9 +4220,7 @@ msgstr "සේවාවක් තෝරන්න"
 msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
-msgstr ""
-"ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම "
-"තෝරන්න"
+msgstr "ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම තෝරන්න"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4396,9 +4401,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන "
-"කතාබස් කාලය නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා "
-"ස්වයංක්‍රීයව මකා දැමිය හැකි ය."
+"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන කතාබස් කාලය "
+"නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා ස්වයංක්‍රීයව මකා දැමිය හැකි "
+"ය."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4408,9 +4413,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, "
-"ඔබේ බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ "
-"ස්වයංක්‍රීයව මකා දැමිය හැකිය."
+"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, ඔබේ "
+"බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ ස්වයංක්‍රීයව මකා දැමිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4419,8 +4423,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ "
-"අවහිර ලැයිස්තුව අපගේ ගාස්තු රහිත බ්‍රවුසරයේ"
+"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ අවහිර ලැයිස්තුව අපගේ "
+"ගාස්තු රහිත බ්‍රවුසරයේ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4429,9 +4433,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ "
-"%1$sDuck.ai%2$s හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ "
-"ආයතනවලින් චැට් ආකෘතිවලට සහය දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
+"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ %1$sDuck.ai%2$s "
+"හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ ආයතනවලින් චැට් ආකෘතිවලට සහය "
+"දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4505,8 +4509,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ "
-"දකුණු පස %3$sgears icon%4$s මත ක්ලික් කරන්න)"
+"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ දකුණු පස "
+"%3$sgears icon%4$s මත ක්ලික් කරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4536,8 +4540,7 @@ msgstr "%1$sYes%2$s කලික් කරන්න"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් "
-"කරන්න."
+"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් කරන්න."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4599,9 +4602,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
-"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
-"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
+"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4612,9 +4614,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
-"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
-"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
+"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4683,8 +4684,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් "
-"මෙනුව ක්ලික් කර %3$sDuckDuckGo%4$s තෝරන්න."
+"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් මෙනුව ක්ලික් කර "
+"%3$sDuckDuckGo%4$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4692,8 +4693,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ "
-"ඉහළ දකුණු කෙළවරේ තියෙනවා."
+"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ ඉහළ දකුණු කෙළවරේ "
+"තියෙනවා."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4894,8 +4895,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු "
-"කිරීමට හැකියාව Cloud Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
+"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු කිරීමට හැකියාව Cloud "
+"Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5167,8 +5168,8 @@ msgstr "දැන්වීම් අවහිර කිරීම දිගටම
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
-"මෑත කාලීන කතාබස් මෙතැනින් දිගටම කරගෙන යන්න. නැතහොත් Fire Button භාවිතයෙන් "
-"ඒවා මකා දමන්න."
+"මෑත කාලීන කතාබස් මෙතැනින් දිගටම කරගෙන යන්න. නැතහොත් Fire Button භාවිතයෙන් ඒවා මකා "
+"දමන්න."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5272,6 +5273,12 @@ msgid "Copy"
 msgstr "පිටපත් කරන්න"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5311,6 +5318,28 @@ msgstr "මෙම කේතය පිටපත් කරන්න, නැතහ�
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "ප්‍රතිසාධන කේතය පිටපත් කරගන්න"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5363,8 +5392,7 @@ msgstr "කොස්ටාරිකාව"
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
 msgstr ""
-"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ "
-"කරන්න."
+"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5465,8 +5493,7 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
-"සබැඳියක් සෑදීමෙන් කතාබස්හි පිටපතක් සෑදෙන අතර, එය විවෘත කරන ඕනෑම අයෙකුට එය "
-"බැලිය හැකිය."
+"සබැඳියක් සෑදීමෙන් කතාබස්හි පිටපතක් සෑදෙන අතර, එය විවෘත කරන ඕනෑම අයෙකුට එය බැලිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5706,8 +5733,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් "
-"කරගෙන යා හැකිය."
+"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් කරගෙන යා හැකිය."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5992,6 +6018,14 @@ msgid "Delete recent chats?"
 msgstr "මෑත කාලීන කතාබස් මකන්නද?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6002,6 +6036,14 @@ msgstr "මේ කතාබස් මකන්න ද?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "මකා දැමූ කතාබස්"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6098,8 +6140,8 @@ msgstr "Duck.ai අසා ලිවීම"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට "
-"කිසිවිටෙකත් භාවිතා කරනු නොලැබේ."
+"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට කිසිවිටෙකත් භාවිතා කරනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6117,8 +6159,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා "
-"කරන බැවින්, ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
+"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා කරන බැවින්, "
+"ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6257,6 +6299,13 @@ msgstr "නැති කරන්න"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "ඉවත ලන්න"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6430,8 +6479,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන "
-"අතර AI-ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන අතර AI-"
+"ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6440,8 +6489,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ "
-"AI රූප පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ AI රූප "
+"පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6557,8 +6606,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින "
-"විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
+"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6567,8 +6616,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට "
-"සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
+"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6589,8 +6638,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප "
-"කිහිපයක් කෙටුම්පත් කරන්න."
+"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප කිහිපයක් කෙටුම්පත් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6599,8 +6648,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් "
-"සඳහා විකල්ප කිහිපයක් කෙටුම්පත් කරන්න."
+"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් සඳහා විකල්ප "
+"කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6732,9 +6781,8 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. "
-"සැකසුම් තුළ පිටු ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය "
-"ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
+"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. සැකසුම් තුළ පිටු "
+"ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6744,9 +6792,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ "
-"බ්‍රවුසර සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය "
-"කර නැවත උත්සාහ කරන්න."
+"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ බ්‍රවුසර "
+"සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6755,8 +6802,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම "
-"කතාබස් දිගටම කරගෙන යන්න."
+"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම "
+"කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -6772,9 +6819,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය "
-"නැවතත් සියතට ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන "
-"ස්වාධීන සමාගමක් ලෙස අපි කටයුතු කරමු."
+"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය නැවතත් සියතට "
+"ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන ස්වාධීන සමාගමක් ලෙස අපි "
+"කටයුතු කරමු."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6789,8 +6836,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් "
-"පිටුවක් සමගින් අන්තර්ජාලයේ: https://duck.ai"
+"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් පිටුවක් සමගින් "
+"අන්තර්ජාලයේ: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6805,8 +6852,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s "
-"නිර්නාමික කේතය %2$s වෙත ඊමේල් කරන්න"
+"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s නිර්නාමික "
+"කේතය %2$s වෙත ඊමේල් කරන්න"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6827,9 +6874,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. "
-"එය අක්‍රිය කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව "
-"ම %1$sduck.ai%2$s වෙත පිවිසිය හැකි ය."
+"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. එය අක්‍රිය "
+"කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව ම %1$sduck.ai%2$s වෙත "
+"පිවිසිය හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6840,11 +6887,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI "
-"චැට් ආකෘති සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය "
-"කිරීමෙන් DuckDuckGo Search හි Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, "
-"මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට %1$shttps://duck.ai%2$s වෙත "
-"පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
+"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI චැට් ආකෘති "
+"සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි "
+"Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට "
+"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6859,8 +6905,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai "
-"භාවිතා කරන්න පුළුවන්."
+"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai භාවිතා "
+"කරන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6874,8 +6920,7 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා "
-"පරීක්ෂා කර නැත."
+"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා පරීක්ෂා කර නැත."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -6909,10 +6954,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI "
-"කතාබහ, ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, "
-"විවෘත මූලාශ්‍ර AI ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI "
-"කතාබස්"
+"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI කතාබහ, "
+"ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, විවෘත මූලාශ්‍ර AI "
+"ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI කතාබස්"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6940,13 +6984,12 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා "
-"සාරාංශගත කළ හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා "
-"ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම "
-"ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට "
-"(ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
-"නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ "
-"පමණි."
+"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ "
+"හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් "
+"(සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම "
+"ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට (ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් "
+"පරාසයක සෙවුම් මත නිතර නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද "
+"(ඉංග්‍රීසි) කලාපයේ පමණි."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6955,10 +6998,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
-"%1$sDuckDuckGo AI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
-"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
-"සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි %1$sDuckDuckGo AI "
+"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
+"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6967,10 +7009,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
-"DuckDuckGo %1$sAI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
-"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
-"සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි DuckDuckGo %1$sAI "
+"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
+"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6982,12 +7023,11 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
-"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
-"එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම "
-"තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් ක්‍රියාත්මක වන ස්වාභාවික භාෂා "
-"තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ අන්තර්ගතයන් මත "
-"පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
+"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව "
+"සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් "
+"ක්‍රියාත්මක වන ස්වාභාවික භාෂා තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ "
+"අන්තර්ගතයන් මත පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7001,15 +7041,13 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
-"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
-"එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත "
-"පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත "
-"කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට සෘජුවම සම්බන්ධ වන "
-"අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
-"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් "
-"ස්වයංක්රීයව ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම "
-"වැදගත්ය."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
+"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් "
+"කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති "
+"ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට "
+"සෘජුවම සම්බන්ධ වන අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
+"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
+"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7017,8 +7055,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර "
-"නිරවද්‍යතාව සඳහා පරීක්‍ෂා කර නොමැත."
+"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර නිරවද්‍යතාව සඳහා "
+"පරීක්‍ෂා කර නොමැත."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7027,8 +7065,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට "
-"මෙම කතාබස් දිගටම කරගෙන යන්න."
+"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට මෙම "
+"කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7037,8 +7075,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
-"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
+"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7047,8 +7085,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
-"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
+"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7074,9 +7112,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ "
-"කරන්න."
+msgstr "DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7109,6 +7145,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo බ්‍රවුසරය %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7225,8 +7268,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත "
-"වැනි PII ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
+"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත වැනි PII "
+"ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7234,8 +7277,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai "
-"%2$s වෙත එකඟ වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai %2$s වෙත එකඟ "
+"වෙයි."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7244,8 +7287,7 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s "
-"වෙත එකඟ වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7254,9 +7296,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල "
-"DuckDuckGo ට්‍රැකර් අවහිර කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය "
-"කිරීමට උත්සාහ කරයි."
+"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල DuckDuckGo ට්‍රැකර් අවහිර "
+"කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය කිරීමට උත්සාහ කරයි."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7268,11 +7309,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය "
-"උපාංගයේ පමණක් ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ "
-"ප්‍රතිඵල වැඩි දියුණු කිරීම සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන "
-"පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම "
-"තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන ගන්න%2$s."
+"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය උපාංගයේ පමණක් "
+"ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ ප්‍රතිඵල වැඩි දියුණු කිරීම "
+"සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ "
+"පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන "
+"ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7292,8 +7333,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල "
-"ලබා දීමට අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
+"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල ලබා දීමට "
+"අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7385,9 +7426,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු "
-"අහඹු වචන ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 "
-"ක් තෝරා ගනිමු, මුරපදය අවම වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
+"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු අහඹු වචන "
+"ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 ක් තෝරා ගනිමු, මුරපදය අවම "
+"වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7457,9 +7498,7 @@ msgstr "රූපය සංස්කරණය කෙරේ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය "
-"කරයි."
+msgstr "ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය කරයි."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7597,8 +7636,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම "
-"විටම ඔබේ අදහස වෙනස් කළ හැකිය."
+"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම විටම ඔබේ අදහස වෙනස් "
+"කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7609,9 +7648,7 @@ msgstr "Duck.ai මත අසා ලිවීම සක් රීය කරන�
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය "
-"කරන්න"
+msgstr "නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7643,8 +7680,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් "
-"තවමත් ඔබේ සෙවුම් සහ නිශ්චිත ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
+"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් තවමත් ඔබේ සෙවුම් සහ නිශ්චිත "
+"ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7806,8 +7843,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ "
-"නව මුරදය යටතේ ඔබගේ දත්ත සුරකිනු ඇත."
+"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ නව මුරදය යටතේ "
+"ඔබගේ දත්ත සුරකිනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7934,15 +7971,28 @@ msgstr "සිතියම පුළුල් කරන්න"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
+msgstr "පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද නිෂ්පාදන."
+
+# smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
 msgstr ""
-"පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද "
-"නිෂ්පාදන."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "කල් ඉකුත් වී ඇත"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8009,9 +8059,7 @@ msgstr "මෙය සරලව පැහැදිලි කරන්න"
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
-"මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි "
-"කරන්න."
+msgstr "මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි කරන්න."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -8206,9 +8254,7 @@ msgstr "ප්‍රතිපෝෂණය සාර්ථකව යවන ලද
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු "
-"කිරීම් බලපායි."
+msgstr "ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් බලපායි."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8217,18 +8263,15 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් "
-"සෘජුවම බලපායි. ඔබ බෙදාගත් ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම "
-"බලාපොරොත්තු වෙමි."
+"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් සෘජුවම බලපායි. ඔබ බෙදාගත් "
+"ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම බලාපොරොත්තු වෙමි."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් "
-"කරන්න."
+msgstr "පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් කරන්න."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8318,8 +8361,7 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. "
-"%1$sවැඩිදුර දැනගන්න%2$s"
+"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. %1$sවැඩිදුර දැනගන්න%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8397,9 +8439,7 @@ msgstr "ඔබට සමීප ප්‍රතිඵල සොයා ගන්�
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව "
-"පවතී."
+msgstr "ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව පවතී."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8463,8 +8503,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට "
-"මෙනු විකල්පයක් තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
+"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට මෙනු විකල්පයක් "
+"තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8693,8 +8733,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac හි යෙදුම් මෙනු තීරුවෙන්, <strong>DuckDuckGo</strong> තෝරන්න &gt; "
-"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන "
-"ස්ථාපනය කරන්න</strong> තෝරන්න."
+"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන ස්ථාපනය "
+"කරන්න</strong> තෝරන්න."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8980,8 +9020,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN, උසස් Duck.ai ලබා ගන්න පුද්ගලික තොරතුරු ඉවත් කිරීම සහ "
-"Identity Theft Restoration."
+"DuckDuckGo VPN, උසස් Duck.ai ලබා ගන්න පුද්ගලික තොරතුරු ඉවත් කිරීම සහ Identity Theft "
+"Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9067,8 +9107,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"වේගවත්, ලොග් වීම අනවශ්‍ය VPN, විකල්ප උසස් AI කතාබහ, Personal info Removal, "
-"සහ Identity Theft Restoration ලබා ගන්න."
+"වේගවත්, ලොග් වීම අනවශ්‍ය VPN, විකල්ප උසස් AI කතාබහ, Personal info Removal, සහ "
+"Identity Theft Restoration ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9077,8 +9117,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"වේගවත්, ලොග් වීම අනවශ්‍ය VPN එකක්, විකල්ප උසස් AI චැට් එකක් සහ Identity "
-"Theft Restoration ලබා ගන්න."
+"වේගවත්, ලොග් වීම අනවශ්‍ය VPN එකක්, විකල්ප උසස් AI චැට් එකක් සහ Identity Theft "
+"Restoration ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9087,8 +9127,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත "
-"දායක වීමෙන් Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත දායක වීමෙන් Duck."
+"ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9099,8 +9139,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo "
-"දායකත්වයක් සමඟ Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo දායකත්වයක් සමඟ "
+"Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9144,8 +9184,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN එක, ඉහළ චැට් සීමාවන් සහිත උසස් AI මාදිලි "
-"සඳහා විකල්ප ප්‍රවේශය සහ තවත් ප්‍රිමියම් ආරක්ෂණ ලබා ගන්න."
+"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN එක, ඉහළ චැට් සීමාවන් සහිත උසස් AI මාදිලි සඳහා විකල්ප "
+"ප්‍රවේශය සහ තවත් ප්‍රිමියම් ආරක්ෂණ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9154,8 +9194,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai ලබා ගන්න, Personal "
-"Information Removal සහ Identity Theft Restoration."
+"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai ලබා ගන්න, Personal Information "
+"Removal සහ Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9163,8 +9203,8 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai, සහ Identity Theft "
-"Restoration ලබා ගන්න."
+"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai, සහ Identity Theft Restoration ලබා "
+"ගන්න."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9205,9 +9245,7 @@ msgstr "යෙදුම ලබා ගන්න"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"YouTube මත දැන්වීම් අවහිර කිරීමට %1$sනොමිලේ DuckDuckGo බ්‍රවුසරය ලබා "
-"ගන්න.%2$s"
+msgstr "YouTube මත දැන්වීම් අවහිර කිරීමට %1$sනොමිලේ DuckDuckGo බ්‍රවුසරය ලබා ගන්න.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9266,9 +9304,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
-"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
-"කරන්න › පාඨමය කේතය පිටපත් කරන්න%4$sවෙත යන්න"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
+"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න › පාඨමය කේතය "
+"පිටපත් කරන්න%4$sවෙත යන්න"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9277,9 +9315,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත "
-"යන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත ගොස් "
+"%3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9289,9 +9326,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
-"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
-"කරන්න%4$s වෙත ගොස් මෙම කේතය ස්කෑන් කරන්න:"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
+"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත ගොස් මෙම "
+"කේතය ස්කෑන් කරන්න:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9301,10 +9338,17 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
-"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
-"කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් "
-"කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
+"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. "
+"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් කරන්න."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9319,8 +9363,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන "
-"සේවා\" සක්‍රිය කර ඇති බවට වග බලා ගන්න."
+"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන සේවා\" සක්‍රිය කර "
+"ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9329,8 +9373,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් "
-"%3$sDuckDuckGo%4$s වෙත පහළට අනුචලනය කරන්න."
+"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් %3$sDuckDuckGo%4$s "
+"වෙත පහළට අනුචලනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9415,6 +9459,12 @@ msgstr "වැටහුණා"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "වැටහුණි"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10013,8 +10063,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist "
-"පිළිතුරුවල ප්‍රධාන කරුණු ඉස්මතු කරයි."
+"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist පිළිතුරුවල ප්‍රධාන "
+"කරුණු ඉස්මතු කරයි."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10041,8 +10091,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ "
-"සුරකින්න.%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
+"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ සුරකින්න."
+"%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10056,8 +10106,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ "
-"රහස්‍යතා ආරක්ෂාව අහිමි වේ."
+"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ රහස්‍යතා ආරක්ෂාව "
+"අහිමි වේ."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10107,8 +10157,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය "
-"කරනු ලබන අතර ඔබව පැතිකඩ කිරීමට භාවිත නොකෙරේ."
+"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය කරනු ලබන අතර ඔබව "
+"පැතිකඩ කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10250,8 +10300,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ "
-"කෙසේද සහ මා කුමක් කිව යුතුද?"
+"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ කෙසේද සහ මා කුමක් "
+"කිව යුතුද?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10373,8 +10423,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම "
-"කැමති මොනවාද සහ ඇයි?"
+"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම කැමති මොනවාද "
+"සහ ඇයි?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10409,8 +10459,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > "
-"'පිහිටීම හා රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > 'පිහිටීම හා "
+"රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10420,9 +10470,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > "
-"සැකසුම් > අඩවි සැකසුම් > පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා "
-"අවසර දී ඇති ද යන්න දැනගන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > සැකසුම් > අඩවි සැකසුම් > "
+"පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා අවසර දී ඇති ද යන්න දැනගන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10437,8 +10486,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther "
-"Search Engines%4$s ලැයිස්තුවට එකතු කරන්න"
+"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther Search "
+"Engines%4$s ලැයිස්තුවට එකතු කරන්න"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10447,8 +10496,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් "
-"ඇත්නම්, ඔබට කෙලින්ම %1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
+"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් ඇත්නම්, ඔබට කෙලින්ම "
+"%1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10457,17 +10506,14 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා "
-"ගැනීමට මෙම කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස "
-"සුරැකිය හැකි ය."
+"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා ගැනීමට මෙම "
+"කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස සුරැකිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු "
-"කරන්න%2$s"
+msgstr "ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු කරන්න%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10477,17 +10523,15 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ "
-"%1$s හෝ %2$s යන පිටපත් භාවිතා කරන්න."
+"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ %1$s හෝ %2$s "
+"යන පිටපත් භාවිතා කරන්න."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත "
-"කරන්න)."
+msgstr "ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත කරන්න)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10616,8 +10660,7 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය "
-"වැඩි දියුණු කරයි"
+"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය වැඩි දියුණු කරයි"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10630,8 +10673,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් "
-"කිරීම් අපගේ සර්වරය හරහා හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
+"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් කිරීම් අපගේ සර්වරය හරහා "
+"හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10642,8 +10685,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් "
-"උපාංගයක් සමග සමමුහුර්ත කරන්න” වෙත යන්න."
+"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් උපාංගයක් සමග "
+"සමමුහුර්ත කරන්න” වෙත යන්න."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10658,8 +10701,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන "
-"ගැනීමට හැකියි අප ගබඩා කරන්නේ කුමන දත්තද කියා."
+"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන ගැනීමට හැකියි අප "
+"ගබඩා කරන්නේ කුමන දත්තද කියා."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10670,8 +10713,8 @@ msgstr "ඉහළ ඇති මෙනුවෙන් %1$sTools%2$s > %3$sSetting
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
 msgstr ""
-"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි "
-"සලකුණ යොදන්න"
+"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි සලකුණ "
+"යොදන්න"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10998,8 +11041,7 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය "
-"සාරාංශගත කරන්න."
+"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11068,10 +11110,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි "
-"දැන්වීම් ජාලය හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ "
-"පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු "
-"නොකෙරේ."
+"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි දැන්වීම් ජාලය "
+"හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් "
+"නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11080,8 +11121,7 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත "
-"වේ."
+"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත වේ."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11153,9 +11193,7 @@ msgstr "උපාංග දෙකෙහිම Sync & Backup විවෘතව �
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr ""
-"එකවර උපාංග 5ක් දක්වා ඔබගේ සියලුම යෙදුම් සහ මාර්ගගත ක්‍රියාකාරකම් පුද්ගලිකව "
-"තබා ගන්න."
+msgstr "එකවර උපාංග 5ක් දක්වා ඔබගේ සියලුම යෙදුම් සහ මාර්ගගත ක්‍රියාකාරකම් පුද්ගලිකව තබා ගන්න."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11387,6 +11425,12 @@ msgstr "%1$sතවත්%2$s ඉගෙන ගන්න"
 msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "%1$sතවත්%2$s ඉගෙන ගන්න"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11764,9 +11808,7 @@ msgstr "අනුචලනය කරන විට තවත් පින්ත�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය "
-"කරයි"
+msgstr "අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය කරයි"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11952,7 +11994,8 @@ msgstr "සියළුම වචන වල අක්ෂර වින්‍ය�
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
+msgstr ""
+"%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12018,6 +12061,13 @@ msgstr "අනිෂ්ට මෘදුකාංග"
 #. Text for generic link to send the user to a page to manage their settings.
 msgid "Manage"
 msgstr "කළමනාකරණය කරන්න"
+
+# smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12271,6 +12321,12 @@ msgid "Menu"
 msgstr "මෙනුව"
 
 # smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
 msgstr "ප්‍රමිතික (කිලෝග්‍රෑම්, මීටර්, සෙල්සියස්)"
@@ -12298,9 +12354,7 @@ msgstr "මයික්රොනීසියාව"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත "
-"උත්සාහ කරන්න."
+msgstr "මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12531,9 +12585,7 @@ msgstr "මාසික සීමාවට ළඟා විය"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
-"හැක."
+msgstr "මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12639,6 +12691,12 @@ msgstr "නෙරපුම් පිළිබඳ තවත්!"
 msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr "Duck.ai ගැන වැඩි විස්තර"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12833,6 +12891,12 @@ msgstr "නිශ්ක්රීය"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "ලා රතු"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13074,10 +13138,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම "
-"සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo "
-"සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් "
-"මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව "
+"විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු "
+"ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර "
+"තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13899,8 +13963,32 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the "
-"%4$s icon > Settings%5$s"
+"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the %4$s "
+"icon > Settings%5$s"
+
+# smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13928,8 +14016,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. "
-"පිටු %1$s ක් හෝ ඊට අඩු පිටු ඇති ගොනු උඩුගත කරන්න."
+"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. පිටු %1$s ක් හෝ ඊට අඩු "
+"පිටු ඇති ගොනු උඩුගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13955,9 +14043,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව "
-"දක්වා ඇත."
+msgstr "ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව දක්වා ඇත."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13972,8 +14058,7 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත "
-"උත්සාහ කරන්න."
+"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14296,8 +14381,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් "
-"නිරීක්ෂණය කරයි. අපි ඔබව කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
+"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් නිරීක්ෂණය කරයි. අපි ඔබව "
+"කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14311,8 +14396,8 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN, ඉහළ සීමාවන් සහිත වඩා සුහුරු AI චැට් සහ "
-"තවත් ප්‍රිමියම් ආරක්ෂණ සමඟින් පැමිණේ.‍ සියල්ල ඇතුළත් එකම ග්‍රාහකත්වයක්."
+"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN, ඉහළ සීමාවන් සහිත වඩා සුහුරු AI චැට් සහ තවත් ප්‍රිමියම් "
+"ආරක්ෂණ සමඟින් පැමිණේ.‍ සියල්ල ඇතුළත් එකම ග්‍රාහකත්වයක්."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14320,8 +14405,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු "
-"කරන්නේ හෝ බෙදා හරින්නේ නැත."
+"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු කරන්නේ හෝ බෙදා "
+"හරින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14329,9 +14414,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරකාරකය, ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & "
-"Android%2$sහි ලද හැක."
+"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය, "
+"ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & Android%2$sහි ලද හැක."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14584,8 +14668,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ "
-"සම්බන්ධ නොකරන බැවින් මුරපද යථාවත් කර ගත නොහැක."
+"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ සම්බන්ධ නොකරන බැවින් මුරපද "
+"යථාවත් කර ගත නොහැක."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14652,6 +14736,12 @@ msgid "Past year"
 msgstr "පසුගිය අවුරුද්ද"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14662,6 +14752,12 @@ msgstr "අලවන්න"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "සමමුහුර්ත කේතය අලවන්න"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14715,6 +14811,20 @@ msgstr "ස්ථිරව වසා ඇත"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "පර්සියානු"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14785,10 +14895,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත "
-"පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. "
-"ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s "
-"වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ "
+"ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම "
+"සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14797,10 +14906,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
-"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. "
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය ක්‍රියා විරහිත "
-"කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
+"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් "
+"කිරීමට හෝ එය ක්‍රියා විරහිත කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14810,10 +14918,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
-"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය "
-"නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට %1$sDuckAssist සැකසුම්%2$s වෙත "
-"පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
+"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට "
+"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14846,8 +14953,7 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් "
-"කිරීමට තෝරන්න."
+"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් කිරීමට තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14856,8 +14962,7 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI "
-"එකක් තෝරන්න."
+"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් තෝරන්න."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14878,8 +14983,8 @@ msgstr "විශේෂ වූ ප්‍රශ්නයක් තෝරා ග�
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් "
-"අනුගමනය කරන්න."
+"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් අනුගමනය "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14967,9 +15072,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
-"සම්පූර්ණ කරන්න."
+msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14977,25 +15080,19 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
-"සම්පූර්ණ කරන්න."
+msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
-"(විකල්ප)"
+msgstr "කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
-"(විකල්ප)"
+msgstr "කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15016,8 +15113,7 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය "
-"මකා දමනු ඇත."
+"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15026,8 +15122,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
-"අලවා අන්තර්ගතය හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
+"හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15036,8 +15132,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
-"අලවා අන්තර්ගතය නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
+"නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15251,9 +15347,7 @@ msgstr "දුර්වල ආකෘතිකරණය"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
-"ජනප්‍රිය AI ආකෘති ලබා ගත හැක. ගිණුමක් අවශ්‍ය නොවේ. කතාබස් අප විසින් "
-"නිර්නාමික කර ඇත."
+msgstr "ජනප්‍රිය AI ආකෘති ලබා ගත හැක. ගිණුමක් අවශ්‍ය නොවේ. කතාබස් අප විසින් නිර්නාමික කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15805,8 +15899,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම "
-"පෙළ මෙහි ඇතුලත් කරන්න.]"
+"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම පෙළ මෙහි "
+"ඇතුලත් කරන්න.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15978,6 +16072,12 @@ msgid "Reading website…"
 msgstr "වෙබ් අඩවිය කියවීම…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16017,9 +16117,7 @@ msgstr "තර්කනය මඟින් සංකීර්ණ ප්‍රශ
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"තර්කනය වඩාත් සවිස්තරාත්මකයි, නමුත් 2-5 ගුණයක් වේගයෙන් පරිශීලන සීමාවන්ට ළඟා "
-"වේ. %1$s"
+msgstr "තර්කනය වඩාත් සවිස්තරාත්මකයි, නමුත් 2-5 ගුණයක් වේගයෙන් පරිශීලන සීමාවන්ට ළඟා වේ. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16075,8 +16173,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
-"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
+"උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16085,8 +16183,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
-"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
+"උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16096,9 +16194,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
-"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
-"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
+"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් "
+"කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
+"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16169,6 +16267,12 @@ msgid "Recovery Code"
 msgstr "ප්‍රතිසාධන කේතය"
 
 # smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Red"
 msgstr "රතු"
@@ -16233,9 +16337,7 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr ""
-"ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු "
-"කරයි"
+msgstr "ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු කරයි"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16376,8 +16478,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ "
-"&quot;Reload&quot; බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
+"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ &quot;Reload&quot; "
+"බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16418,6 +16520,12 @@ msgstr "%1$s ඉවත් කරන්න"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "%1$s ඉවත් කරන්න"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16462,13 +16570,25 @@ msgid "Remove unnecessary punctuation"
 msgstr "අනවශ්‍ය විරාම ලකුණු ඉවත් කරන්න"
 
 # smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" "
-"බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" බොත්තම ඉවත් කරයි. "
+"හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16476,9 +16596,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි "
-"\"Generate\" බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව "
-"දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Generate\" බොත්තම ඉවත් "
+"කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16536,9 +16655,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට "
-"DuckDuckGo වෙත යවනු ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු "
-"කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු ලැබේ."
+"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට DuckDuckGo වෙත යවනු "
+"ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු "
+"ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16546,8 +16665,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු "
-"පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත "
+"හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16556,9 +16675,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට "
-"ඉල්ලා ඇති සියලු පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ "
-"කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට ඉල්ලා ඇති සියලු "
+"පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි "
+"තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16650,9 +16769,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
-"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා "
-"කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
+"උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16661,9 +16779,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
-"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා "
-"කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
+"උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16673,10 +16790,9 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
-"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය "
-"කර ඇති අතර සාවද්‍යතා අඩංගු විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s "
-"යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
+"උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය කර ඇති අතර සාවද්‍යතා අඩංගු "
+"විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17101,8 +17217,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ "
-"මෑත කාලීන කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
+"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ මෑත කාලීන "
+"කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17146,6 +17262,12 @@ msgstr "ඔබගේ සැකසුම් නිර්ණාමිකව ක්
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Duck.ai වෙත හෙලෝ කියන්න"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17263,8 +17385,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු "
-"%3$sChange%4$s ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
+"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු %3$sChange%4$s "
+"ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17273,8 +17395,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත "
-"ක්ලික් කරන්න (හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
+"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත ක්ලික් කරන්න "
+"(හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17352,13 +17474,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන "
-"විශේෂාංගයකි. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන "
-"අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි. ඔබට එය කොපමණ වාර "
-"ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, ඉල්ලූ-විට (Assist "
-"ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන "
-"කලාපවල උප කණ්ඩායමක පමණි."
+"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන විශේෂාංගයකි. මෙය සිදු කිරීම "
+"සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI "
+"භාවිත කරයි. ඔබට එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, "
+"ඉල්ලූ-විට (Assist ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
+"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන කලාපවල උප "
+"කණ්ඩායමක පමණි."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17366,8 +17487,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක "
-"තොරතුරු සොයාගැනීමට Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
+"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක තොරතුරු සොයාගැනීමට "
+"Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17376,10 +17497,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප "
-"විශේෂාංගයකි. %1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් "
-"කර පසුව සොයාගත් තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත "
-"කරයි."
+"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප විශේෂාංගයකි. "
+"%1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් කර පසුව සොයාගත් තොරතුරු "
+"මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17500,8 +17620,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ "
-"“ducks” සෘජුවම සොයාගත හැක."
+"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ “ducks” සෘජුවම "
+"සොයාගත හැක."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17520,8 +17640,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් "
-"සෙවුම එක් කරන්න, නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
+"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් සෙවුම එක් කරන්න, "
+"නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17529,8 +17649,7 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් "
-"භාවිතා කරනු ඇත)"
+"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් භාවිතා කරනු ඇත)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17542,11 +17661,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර "
-"ගබඩා තුළ ගබඩා කර ඇත, නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ "
-"සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු "
-"ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් ඔබේ බ්‍රව්සරයෙන් ඉවත් "
-"නොවේ."
+"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර ගබඩා තුළ ගබඩා කර ඇත, "
+"නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත "
+"කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් "
+"ඔබේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17649,8 +17767,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
-"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
+"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17659,8 +17777,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
-"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
+"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17669,8 +17787,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
-"ආරක්ෂිතව ගබඩා කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
+"කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17679,8 +17797,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා කර, "
+"ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17695,8 +17813,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට "
-"හැර වෙන කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
+"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට හැර වෙන "
+"කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -17920,8 +18038,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් "
-"වල) තෝරන්න"
+"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් වල) "
+"තෝරන්න"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17986,8 +18104,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් "
-"අනෙකුත් විකල්ප වලින් එකක් තෝරන්න)"
+"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් අනෙකුත් "
+"විකල්ප වලින් එකක් තෝරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18109,8 +18227,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත "
-"විමසුමක් යවයි. මෙම උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
+"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත විමසුමක් යවයි. මෙම "
+"උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18131,6 +18249,13 @@ msgstr "සර්බියානු (සිරිලික්)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "සර්බියානු (ලතින්)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18226,8 +18351,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක "
-"කිරීමෙන් පසු Sync & Backup පිහිටුුවන්න."
+"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක කිරීමෙන් පසු Sync & "
+"Backup පිහිටුුවන්න."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18285,6 +18410,14 @@ msgid "Share"
 msgstr "බෙදා ගන්න"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18326,8 +18459,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. "
-"Duck.ai කිසි විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
+"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. Duck.ai කිසි "
+"විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18423,8 +18556,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ "
-"හානිකර වාර්තා සඳහා අවශ්‍ය වේ)"
+"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ හානිකර වාර්තා "
+"සඳහා අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18433,15 +18566,26 @@ msgid "Share your thoughts on the search box."
 msgstr "සෙවුම් කොටුව පිළිබඳ ඔබේ අදහස් බෙදා ගන්න."
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"අපගේ ලොග් වීම අනවශ්‍ය, වේගවත් VPN සමඟ ඔබේ අන්තර්ජාල ක්‍රියාකාරකම් ආරක්ෂා "
-"කරගන්න. සැකසීමට සරල වන අතර ඕනෑම වේලාවක ක්‍රියාත්මක කිරීමට සහ අක්‍රිය කිරීමට "
-"පහසුය."
+"අපගේ ලොග් වීම අනවශ්‍ය, වේගවත් VPN සමඟ ඔබේ අන්තර්ජාල ක්‍රියාකාරකම් ආරක්ෂා කරගන්න. සැකසීමට "
+"සරල වන අතර ඕනෑම වේලාවක ක්‍රියාත්මක කිරීමට සහ අක්‍රිය කිරීමට පහසුය."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18562,8 +18706,7 @@ msgstr "DuckAssist <sup>BETA</sup> පෙන්වන්න"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත "
-"කිරීමටද%2$s හැකිය.)"
+"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත කිරීමටද%2$s හැකිය.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18801,8 +18944,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
-"කිරීම මතක් කිරීම සඟවයි සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවයි "
+"සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18810,8 +18953,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
-"කිරීම මතක් කිරීම සඟවන අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවන "
+"අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18849,8 +18992,7 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන "
-"පණිවුඩ පෙන්වන්න"
+"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන පණිවුඩ පෙන්වන්න"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19107,6 +19249,12 @@ msgid "Something went wrong"
 msgstr "කුමක් හෝ වැරැද්දක් සිදු විය"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19185,8 +19333,7 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් "
-"උත්සාහ කරන්න."
+"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19195,16 +19342,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර "
-"ඇති බවට වග බලා ගන්න."
+"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර ඇති බවට වග "
+"බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට "
-"Duck.ai එකෙන් අහන්න උත්සාහ කළ හැක."
+"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට Duck.ai එකෙන් අහන්න "
+"උත්සාහ කළ හැක."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19213,16 +19360,15 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ "
-"කිරීමට%1$sමෙහි ක්ලික් කරන්න%2$s ."
+"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ කිරීමට%1$sමෙහි ක්ලික් "
+"කරන්න%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත "
-"උත්සාහ කරන්න."
+"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19626,8 +19772,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය "
-"ලබාගන්න, නැතහොත් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය ලබාගන්න, නැතහොත් "
+"තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19695,9 +19841,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා "
-"කරනවාද?"
+msgstr "සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා කරනවාද?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19951,6 +20095,12 @@ msgid "Switch model"
 msgstr "ආකෘතිය මාරු කරන්න"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20027,9 +20177,7 @@ msgstr "%1$sවෙත මාරු විය"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට "
-"යවනු ඇත"
+msgstr "ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට යවනු ඇත"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20084,8 +20232,7 @@ msgstr "Sync & Backup සක්‍රිය කරන ලදී!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය "
-"කළ නොහැක."
+"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20134,9 +20281,9 @@ msgid ""
 msgstr ""
 "ප්‍රතිසාධන කේතය සමමුහුර්ත කරන්න\n"
 "\n"
-"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් "
-"උපාංග කිහිපයක් අතර සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි "
-"වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය කර ගනී.\n"
+"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් උපාංග කිහිපයක් අතර "
+"සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
+"කර ගනී.\n"
 "\n"
 "මෙම තොරතුරු ආරක්ෂිතව තබා ගන්න.\n"
 "මෙම කේතයට ප්‍රවේශය ඇති ඕනෑම අයෙකුට ඔබේ සමමුහුර්ත දත්ත වෙත ප්‍රවේශ විය හැක.\n"
@@ -20145,14 +20292,12 @@ msgstr ""
 "\n"
 "මෙම කේතය ක්‍රියා කරන්නේ කෙසේ ද?\n"
 "1. ඔබේ බ්‍රවුසරයෙන් Duck.ai වෙත ගොස් Duck.ai සැකසුම් විවෘත කරන්න.\n"
-"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
-"කරන්න\" තෝරන්න\n"
-"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන "
-"ස්ථානයේ අලවන්න\n"
+"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය කරන්න\" තෝරන්න\n"
+"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන ස්ථානයේ "
+"අලවන්න\n"
 "\n"
-"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි "
-"කාලයක් භාවිතා නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය "
-"කළ නොහැක."
+"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි කාලයක් භාවිතා "
+"නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20209,6 +20354,13 @@ msgid "Synced Devices"
 msgstr "සමමුහුර්ත කළ උපාංග"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "සිරියාව"
 
@@ -20239,6 +20391,12 @@ msgstr "TBD"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "රූපවාහිනිය"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20272,8 +20430,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිටියත්, වඩාත් වේගවත් "
-"ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ යෙදුම තුළම ලබා ගන්න."
+"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිටියත්, වඩාත් වේගවත් ප්‍රවේශයක් සඳහා "
+"එය අපගේ නොමිලේ යෙදුම තුළම ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20282,8 +20440,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිට බ්‍රවුස් කළ ද වඩාත් "
-"වේගවත් ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ ලබා දෙන බ්‍රවුසරය තුළට ඇතුළත් කරගන්න."
+"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිට බ්‍රවුස් කළ ද වඩාත් වේගවත් "
+"ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ ලබා දෙන බ්‍රවුසරය තුළට ඇතුළත් කරගන්න."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20307,8 +20465,7 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික "
-"සමීක්ෂණයට සහභාගි වන්න."
+"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික සමීක්ෂණයට සහභාගි වන්න."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20529,9 +20686,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද "
-"තොරතුරු තෙවන පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ "
-"අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට ඇතුළත් වේ."
+"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද තොරතුරු තෙවන "
+"පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට "
+"ඇතුළත් වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20540,8 +20697,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් "
-"Cloud Save කුඩා පිටු සලකුණු මඟින් ඉඩ දෙයි."
+"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් Cloud Save කුඩා පිටු "
+"සලකුණු මඟින් ඉඩ දෙයි."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20571,8 +20728,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය "
-"හැක්කේ ඔබට පමණි."
+"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය හැක්කේ ඔබට "
+"පමණි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -20593,9 +20750,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල "
-"සුරකින්නේ නැත."
+msgstr "ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල සුරකින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20654,8 +20809,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය "
-"කර ඇති බවට වග බලා ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
+"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය කර ඇති බවට වග බලා "
+"ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20670,8 +20825,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර "
-"කරුණාකර මිනිත්තු කිහිපයක් රැඳී සිටින්න."
+"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර කරුණාකර මිනිත්තු කිහිපයක් "
+"රැඳී සිටින්න."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20690,9 +20845,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් "
-"සහ DuckDuckGo ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් "
-"අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම බ්‍රව්සර් අවසර භාවිතා කරයි."
+"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් සහ DuckDuckGo "
+"ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම "
+"බ්‍රව්සර් අවසර භාවිතා කරයි."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20730,8 +20885,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ "
-"කිරීමට උත්සාහ කරන්න."
+"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ කිරීමට උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20740,8 +20895,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව "
-"කතාබහක් ආරම්භ කරන්න."
+"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව කතාබහක් "
+"ආරම්භ කරන්න."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20780,9 +20935,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත "
-"කරමිනි. AI කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි "
-"විස්තර සඳහා %4$s බලන්න)."
+"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත කරමිනි. AI "
+"කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20792,8 +20946,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI "
-"කතාබස් සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
+"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI කතාබස් "
+"සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20802,8 +20956,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ "
-"අහිතකර තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
+"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ අහිතකර "
+"තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20814,8 +20968,24 @@ msgid ""
 "more info)."
 msgstr ""
 "මෙම සංවාදය DuckDuckGo AI Chat (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sහි %3$s ආකෘතිය "
-"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය "
-"(වැඩි විස්තර සඳහා %4$s බලන්න)."
+"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා "
+"%4$s බලන්න)."
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20901,14 +21071,20 @@ msgid "This information isn’t useful"
 msgstr "මෙම තොරතුරු ප්‍රයෝජනවත් නොවේ"
 
 # smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එහි මෙනුව (තිත් තුන) විවෘත කර, එය ඔබේ "
-"කතාබස්වල ඉහළින්ම තබා ගැනීමට පින් කරන්න තෝරන්න!"
+"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එහි මෙනුව (තිත් තුන) විවෘත කර, එය ඔබේ කතාබස්වල ඉහළින්ම තබා "
+"ගැනීමට පින් කරන්න තෝරන්න!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20917,8 +21093,7 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එය මකා දැමීමට පැති මෙනුවේ ඇති Fire Button "
-"භාවිතා කරන්න!"
+"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එය මකා දැමීමට පැති මෙනුවේ ඇති Fire Button භාවිතා කරන්න!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20939,8 +21114,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. "
-"අනෙකුත් ආකෘති සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. අනෙකුත් ආකෘති "
+"සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20949,8 +21124,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. "
-"අනෙකුත් ආකෘති සපයන්නන් සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. අනෙකුත් ආකෘති සපයන්නන් "
+"සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20987,8 +21162,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය "
-"සමඟ සුරකින අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
+"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ සුරකින "
+"අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20997,8 +21172,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
-"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
+"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21008,9 +21183,21 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
-"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ "
-"වෙතත්, අපට %1$s හි AI-සහය සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
+"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ වෙතත්, අපට %1$s හි AI-සහය "
+"සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21049,9 +21236,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup "
-"විසන්ධි කරයි. Sync & Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට "
-"තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට හැකි වනු ඇත."
+"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup විසන්ධි කරයි. Sync "
+"& Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට "
+"හැකි වනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21060,8 +21247,7 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු "
-"හැරවිය නොහැක."
+"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු හැරවිය නොහැක."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21199,8 +21385,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට "
-"අවශ්‍ය මාර්ගය තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
+"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට අවශ්‍ය මාර්ගය "
+"තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21210,9 +21396,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත "
-"කිරීම සැකසීමේ දී සුරකින ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් "
-"වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
+"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත කිරීම සැකසීමේ දී සුරකින "
+"ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ "
+"PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21221,8 +21407,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය "
-"නවතම අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
+"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය නවතම "
+"අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21230,8 +21416,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ "
-"වීමට ඔබේ බ්‍රවුසරයට ඉඩ දෙන්න."
+"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ වීමට ඔබේ බ්‍රවුසරයට ඉඩ "
+"දෙන්න."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21254,8 +21440,8 @@ msgstr "අද"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"පුද්ගලික AI කතාබස් උත්සාහ කිරීමට ටොගල් කරන්න, නැතහොත් %1$s %2$s මෙනුව තුළින් "
-"එය අක්‍රිය කරන්න.%3$s"
+"පුද්ගලික AI කතාබස් උත්සාහ කිරීමට ටොගල් කරන්න, නැතහොත් %1$s %2$s මෙනුව තුළින් එය අක්‍රිය කරන්න."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21429,8 +21615,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ "
-"ප්‍රමාණයක් අවහිර කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
+"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ ප්‍රමාණයක් අවහිර "
+"කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21478,8 +21664,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
-"ශාලාවට යන්නේ කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
+"කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21488,8 +21674,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
-"ශාලාවට යන්නේ කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
+"කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21651,6 +21837,12 @@ msgid "Try Free"
 msgstr "නොමිලේ අත්හදා බලන්න"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21730,9 +21922,7 @@ msgstr "වෙනත් වචන සමග උත්සාහ කරන්න."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ "
-"කරන්න."
+msgstr "තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21745,9 +21935,7 @@ msgstr "වඩාත් නිවැරදි ප්‍රතිඵල සඳහ
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා "
-"දෙනු ඇත."
+msgstr "එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා දෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21766,6 +21954,12 @@ msgstr "නොමිලේ අත්හදා බලන්න"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "නොමිලේ අත්හදා බලන්න"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21959,8 +22153,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට "
-"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
+"No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21969,8 +22163,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට "
-"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
+"No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22009,6 +22203,12 @@ msgid "Turkmenistan"
 msgstr "තුර්ක්මනිස්තාන්"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22019,6 +22219,12 @@ msgstr "Sync & Backup අක්‍රීය කරන්න"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Sync & Backup අක්‍රීය කරන්න"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22159,8 +22365,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත "
-"කිරීමෙන් සෙවීමක් සහ ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
+"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත කිරීමෙන් සෙවීමක් සහ "
+"ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22290,8 +22496,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර "
-"%5$sSet Pages%6$s මත ක්ලික් කරන්න."
+"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර %5$sSet "
+"Pages%6$s මත ක්ලික් කරන්න."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22299,8 +22505,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: "
-"https://duckduckgo.com"
+"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22416,8 +22622,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා "
-"2 ගුණයක් ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
+"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා 2 ගුණයක් "
+"ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22492,6 +22698,12 @@ msgid "Unmute"
 msgstr "නිශ්ශබ්දතාවය ඉවත්"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22525,6 +22737,12 @@ msgstr "යාවත්කාලීන කරන්න"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "බ්‍රව්සරය යාවත්කාලීන කරන්න"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22563,8 +22781,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට "
-"DuckDuckGo බ්‍රවුසරය යාවත්කාලීන කරන්න"
+"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට DuckDuckGo බ්‍රවුසරය "
+"යාවත්කාලීන කරන්න"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22689,16 +22907,15 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත "
-"කරන්න, නැත්නම් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න, නැත්නම් තවත් "
+"රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත "
-"උත්ශ්‍රේණිගත කරන්න"
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22794,9 +23011,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, "
-"වංචාකරුවන් සහ සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා "
-"ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය නොවේ."
+"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, වංචාකරුවන් සහ "
+"සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය "
+"නොවේ."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22851,8 +23068,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය "
-"භාවිතා කරන්න. එය ආරක්ෂිතව තබා ගන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා කරන්න. එය "
+"ආරක්ෂිතව තබා ගන්න."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -22860,8 +23077,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට "
-"මේ කේතය භාවිතා කරන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23011,8 +23228,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
-"කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු "
+"ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23021,8 +23238,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
-"කිරීම් TripAdvisor හි දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් TripAdvisor හි "
+"දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23034,8 +23251,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist "
-"සැකසුම්%2$s වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist සැකසුම්%2$s "
+"වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23044,8 +23261,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට "
-"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sDuckAssist "
+"සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23054,8 +23271,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති "
-"උපදෙස් පිළිපදින්න."
+"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති උපදෙස් "
+"පිළිපදින්න."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23070,9 +23287,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync "
-"& Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ "
-"සමමුහුර්ත කරන්න%8$s තෝරන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync & "
+"Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ සමමුහුර්ත "
+"කරන්න%8$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23082,9 +23299,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn "
-"On” තෝරන්න Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. "
-"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF එකේ QR ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn On” තෝරන්න "
+"Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන "
+"PDF එකේ QR ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23106,10 +23323,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai "
-"සැකසුම් විවෘත කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් "
-"උපාංගයක් සමග සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR "
-"කේතය ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත "
+"කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් උපාංගයක් සමග සමමුහුර්ත කරන්න” "
+"තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23162,8 +23378,7 @@ msgstr "හඬ කතාබහ අවසන්"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් "
-"භාවිතා කරන්නේ නැහැ."
+"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් භාවිතා කරන්නේ නැහැ."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23307,8 +23522,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට "
-"බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
+"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ "
+"ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23328,10 +23543,9 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට "
-"ඔබව නිරීක්ෂණය කළ හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ "
-"යුතු වීමයි. DuckDuckGo යනු ස්වාධීන සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන "
-"සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
+"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට ඔබව නිරීක්ෂණය කළ "
+"හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ යුතු වීමයි. DuckDuckGo යනු ස්වාධීන "
+"සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23343,9 +23557,7 @@ msgstr "අපි නිර්නාමික කරමු"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ "
-"හැකිය."
+msgstr "ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23357,9 +23569,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
-"වාර්තා කිරීමට, කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව "
-"විමර්ශනය කර විසඳා ගත හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
+"කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23371,17 +23583,15 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
-"වාර්තා කිරීමට, කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට "
-"ගැටලුව විමර්ශනය කර විසඳා ගත හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
+"කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ "
-"හැකිය."
+msgstr "ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -23389,8 +23599,7 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා "
-"කියවිය නොහැක."
+"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා කියවිය නොහැක."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23406,9 +23615,7 @@ msgstr "අපි පරිශීලක නාම හෝ පුද්ගලි�
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද "
-"නැත."
+msgstr "කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද නැත."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23420,8 +23627,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට "
-"පත් නොකරන්නෙමු. අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
+"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට පත් නොකරන්නෙමු. "
+"අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23435,8 +23642,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි "
-"පැවසුවහොත් එය අපට උපකාරී වීමට හැක:"
+"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි පැවසුවහොත් එය "
+"අපට උපකාරී වීමට හැක:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23445,8 +23652,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ "
-"අපට පැවසීමට ඔබගේ උදව් භාවිතා කළ හැකිය:"
+"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ අපට පැවසීමට "
+"ඔබගේ උදව් භාවිතා කළ හැකිය:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23486,8 +23693,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම "
-"වලට විකිණීමට කිසිවක් නැත."
+"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම වලට විකිණීමට "
+"කිසිවක් නැත."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23507,14 +23714,22 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "අකර්මණ්‍යව පැවතීම හේතුවෙන් අපි කතාබහ අවසන් කළ‍ෙමු. ආයෙත් උත්සාහ කරන්න ඕනද?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ "
-"ගිවිසුම් ඇති කරගෙන ඇත්තෙමු."
+"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ ගිවිසුම් ඇති කරගෙන "
+"ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23539,8 +23754,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ "
-"දත්ත සූරාකෑමෙන් නොවේ."
+"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ දත්ත සූරාකෑමෙන් "
+"නොවේ."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23549,16 +23764,23 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික "
-"පිහිටීම භාවිතා කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
+"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික පිහිටීම භාවිතා "
+"කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත "
-"රඳා සිටිමු."
+"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත රඳා සිටිමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23579,15 +23801,21 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි "
-"අභිමතය පරිදි යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
+"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි අභිමතය පරිදි "
+"යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr "ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර කරන්නෙමු."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
-"ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර "
-"කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23596,8 +23824,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට "
-"මෙම දෝෂය දිගටම පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට මෙම දෝෂය දිගටම "
+"පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23606,8 +23834,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර "
-"විට ඔබගේ බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර විට ඔබගේ "
+"බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23622,8 +23850,7 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි "
-"මහන්සි වෙමින් සිටිමු."
+"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි මහන්සි වෙමින් සිටිමු."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23632,8 +23859,7 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත "
-"පූරණය කළ යුතුය."
+"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත පූරණය කළ යුතුය."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23742,8 +23968,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම "
-"කතාබහේ යෙදිය හැකි ය."
+"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම කතාබහේ යෙදිය "
+"හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23757,8 +23983,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප "
-"විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර "
+"ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23767,9 +23993,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් "
-"පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් "
+"නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23779,17 +24004,15 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ "
-"%1$sගේ %2$s විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් "
-"DuckDuckGo විසින් ගබඩා කර හෝ AI ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ %1$sගේ %2$s "
+"විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් DuckDuckGo විසින් ගබඩා කර හෝ AI "
+"ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න "
-"පුළුවන්."
+msgstr "නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23857,8 +24080,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. "
-"පිටුව නැවත ප්‍රවේශනය කර උත්සාහ කරන්න."
+"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. පිටුව නැවත "
+"ප්‍රවේශනය කර උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23873,8 +24096,7 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ "
-"ප්‍රතිවිරෝධතා මොනවාද?"
+"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ ප්‍රතිවිරෝධතා මොනවාද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -23895,14 +24117,20 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර "
-"විකල්ප මොනවාද."
+"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර විකල්ප "
+"මොනවාද."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "වාරිකවල සමහර වාසි සහ අවාසි මොනවාද?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -23915,11 +24143,10 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ "
-"ප්‍රතිලාභ මොනවා ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ "
-"කිරීම් සහ රහස්‍යතා ආරක්ෂණ කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත "
-"පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් "
-"කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
+"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ ප්‍රතිලාභ මොනවා "
+"ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ කිරීම් සහ රහස්‍යතා ආරක්ෂණ "
+"කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික "
+"අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24155,8 +24382,7 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් "
-"වන්නේ කෙසේද?"
+"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් වන්නේ කෙසේද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24257,8 +24483,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම "
-"නිෂ්පාදන වෙළඳ නාම මොනවාද?"
+"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම නිෂ්පාදන වෙළඳ නාම "
+"මොනවාද?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24459,15 +24685,22 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai සමඟින්, ඔබගේ කතාබස් නිර්නාමික කර ඇති අතර ඒවා කිසි විටෙකත් AI පුහුණු "
-"කිරීමට භාවිත නොකෙරේ. '%1$s' මෙනුව තුළ ඕනෑම වේලාවක එය සක්‍රිය හෝ අක්‍රිය "
-"කරන්න."
+"Duck.ai සමඟින්, ඔබගේ කතාබස් නිර්නාමික කර ඇති අතර ඒවා කිසි විටෙකත් AI පුහුණු කිරීමට භාවිත "
+"නොකෙරේ. '%1$s' මෙනුව තුළ ඕනෑම වේලාවක එය සක්‍රිය හෝ අක්‍රිය කරන්න."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "සැපයුම්කරුගේ දෘශ්‍යතාව නොමැතිව"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24734,9 +24967,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
-"හැකිය."
+msgstr "ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24745,8 +24976,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර "
-"මත කඍජුව %1$s හෝ සෙවිය හැකිය."
+"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර මත කඍජුව %1$s හෝ "
+"සෙවිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24760,8 +24991,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s "
-"තුළ එය අක්‍රිය කළ හැකිය."
+"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s තුළ එය "
+"අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24770,22 +25001,21 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් "
-"කිරීමට හෝ එය අක්‍රිය කිරීමට හැකිය."
+"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය "
+"අක්‍රිය කිරීමට හැකිය."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ "
-"හැකිය."
+"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ හැකිය."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s "
-"ද භාාවිත කළ හැකිය."
+"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s ද භාාවිත "
+"කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -24799,8 +25029,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, "
-"එය සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
+"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, එය "
+"සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24821,8 +25051,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස "
-"පළමු සමූහය මකනවා."
+"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස පළමු සමූහය "
+"මකනවා."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24915,8 +25145,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම "
-"වෙනත් වෙබ් අඩවියක් අහිතකර කිරීමට අවශ්ය වේ."
+"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම වෙනත් වෙබ් අඩවියක් "
+"අහිතකර කිරීමට අවශ්ය වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24967,14 +25197,21 @@ msgid "You have 1 attempt left."
 msgstr "ඔබට උත්සාහයන් 1ක් ඉතිරිව ඇත."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් "
-"පුළුල් පරිශීලන සීමාවන් ඇත."
+"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් පුළුල් පරිශීලන "
+"සීමාවන් ඇත."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24983,8 +25220,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ "
-"අනෙකුත් DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
+"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ අනෙකුත් "
+"DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25006,9 +25243,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
-"වනු ඇත. අවසාන කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
-"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
+"කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25018,9 +25255,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
-"වනු ඇත. අවසාන කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
-"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
+"කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25033,9 +25270,7 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr ""
-"ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන "
-"ලැබෙනු ඇත."
+msgstr "ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන ලැබෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -25050,8 +25285,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome "
-"වෙනුවට අපගේ යෙදුම භාවිතා කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome වෙනුවට අපගේ යෙදුම භාවිතා "
+"කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25064,8 +25299,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර "
-"ගැනීමට ඉඟි ලබා ගන්න."
+"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර ගැනීමට ඉඟි ලබා "
+"ගන්න."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25141,9 +25376,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත "
-"කිරීම නැවත ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
-"නොලැබේ."
+"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
+"ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25153,9 +25387,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
-"ආරම්භ කිරීමට ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
-"නොලැබේ."
+"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත ආරම්භ කිරීමට "
+"ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25169,9 +25402,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. "
-"ඒ වගේම, Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා "
-"කිරීමකට ලක් වෙන්න පුළුවන්."
+"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. ඒ වගේම, "
+"Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා කිරීමකට ලක් වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25183,6 +25415,23 @@ msgstr "YouTube පෞද්ගලිකත්වය සම්බන්ධ අ�
 msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube සම්මතය"
+
+# smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25208,6 +25457,14 @@ msgid "Your actual location remains private."
 msgstr "ඔබගේ සැබෑ ස්ථානය පුද්ගලිකව පවතී."
 
 # smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
 msgctxt "Body copy for the Delete Server Data confirmation modal"
 msgid ""
@@ -25215,9 +25472,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
-"විසන්ධි වනු ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා "
-"ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
+"ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25227,9 +25483,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
-"විසන්ධි වනු ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත "
-"හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
+"ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25254,8 +25509,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත "
-"කිසිවිටෙක මෙම දත්ත වෙත ප්‍රවේශය නොමැත."
+"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත කිසිවිටෙක මෙම දත්ත "
+"වෙත ප්‍රවේශය නොමැත."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25263,8 +25518,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට "
-"කවදාවත් අවසරයක් නැහැ ඒ දත්ත වලට."
+"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට කවදාවත් අවසරයක් "
+"නැහැ ඒ දත්ත වලට."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25272,9 +25527,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
-"හැකිය."
+msgstr "%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25287,8 +25540,7 @@ msgstr "ඔබගේ කතාබස් දැන් සුරැකෙමින
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ "
-"භාවිත නොකෙරේ"
+"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ භාවිත නොකෙරේ"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25302,8 +25554,7 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
-"කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25311,8 +25562,7 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
-"කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25320,8 +25570,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
-"පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25329,8 +25579,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
-"පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25345,9 +25595,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා "
-"කෘත්‍රිම බුද්ධි ආකෘති පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා "
-"ගැනීමට මේ පියවර අනුගමනය කරන්න."
+"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා කෘත්‍රිම බුද්ධි ආකෘති "
+"පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා ගැනීමට මේ පියවර අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25387,8 +25636,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ "
-"සම්බන්ධ කිරීමක් සිදු නොවේ. [%2$sඋදාහරණ පණිවිඩය%3$s]"
+"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ සම්බන්ධ කිරීමක් සිදු නොවේ. "
+"[%2$sඋදාහරණ පණිවිඩය%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25431,10 +25680,9 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ "
-"මුරපදය 512-bit යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත "
-"සැකසුම් ගොනුව පමණි. යතුර නම ලෙස භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. "
-"DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
+"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ මුරපදය 512-bit "
+"යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත සැකසුම් ගොනුව පමණි. යතුර නම ලෙස "
+"භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25449,9 +25697,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත "
-"හැකි පාර-දත්ත ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත "
-"සම්බන්ධ කළ නොහැක."
+"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත හැකි පාර-දත්ත "
+"ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත සම්බන්ධ කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25465,8 +25712,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම "
-"වේලාවක ඒවා ඉවත් කළ හැකි ය."
+"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම වේලාවක "
+"ඒවා ඉවත් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25498,8 +25745,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය "
-"ස්ථිර කර ගැනීමට %1$sDuckDuckGo No AI%2$s දිගුව සක්‍රීය කරන්න."
+"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය ස්ථිර කර ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s දිගුව සක්‍රීය කරන්න."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25508,9 +25755,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය "
-"ස්ථිර කර ගැනීමට %1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර "
-"දැනගන්න%4$s"
+"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය ස්ථිර කර ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25530,8 +25776,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට "
-"අපේ බ්‍රවුසරය භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට අපේ බ්‍රවුසරය "
+"භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25540,8 +25786,7 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ "
-"කරන්න."
+"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25550,8 +25795,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button "
-"සමඟ මෙම සංවාදය ඉවත් කරන්න."
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button සමඟ "
+"මෙම සංවාදය ඉවත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25559,9 +25804,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ "
-"ගන්න."
+msgstr "ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ ගන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25576,8 +25819,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් "
-"දිගටම කරගෙන යන්න."
+"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම කරගෙන "
+"යන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.

--- a/locales/si_LK/LC_MESSAGES/duckduckgo.po
+++ b/locales/si_LK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: si_LK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (මෙම උපාංගය)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -191,8 +191,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
-"වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
+"ප්‍රකාරයකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -203,8 +203,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
-"වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
+"ප්‍රකාරයකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -221,7 +221,8 @@ msgid ""
 "model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ DuckDuckGo දායකත්වයක් සමඟ පමණි. චැට් දිගටම කරගෙන යාමට මෙම "
-"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු වන්න."
+"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු "
+"වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -230,8 +231,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව නැවත උත්සාහ "
-"කරන්න."
+"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව "
+"නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -328,9 +329,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් අදහස් කරන්නේ ආකෘති "
-"සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට "
-"නොහැකි බවයි."
+"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් "
+"අදහස් කරන්නේ ආකෘති සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ "
+"මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට නොහැකි බවයි."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -416,8 +417,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
-"යාමට ආකෘති මාරු කළ හැකි ය."
+"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම "
+"කරගෙන යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -428,8 +429,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන යාමට "
-"ආකෘති මාරු කළ හැකි ය."
+"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
+"යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -442,8 +443,8 @@ msgstr "%1$s වචන"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව %6$sහරි%7$sක්ලික් "
-"කරන්න"
+"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව "
+"%6$sහරි%7$sක්ලික් කරන්න"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -451,8 +452,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි ලකුණ "
-"දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
+"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි "
+"ලකුණ දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -472,7 +473,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට %1$sමෙතන ක්ලික් කරන්න%2$s."
+"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට "
+"%1$sමෙතන ක්ලික් කරන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -497,7 +499,7 @@ msgstr "%1$sඅපි ඔබේ ස්ථානය පුද්ගලිකව �
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sවැඩි විස්තර දැනගන්න%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -505,7 +507,8 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර ඉගෙන ගන්න."
+"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර "
+"ඉගෙන ගන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -524,8 +527,8 @@ msgstr "මුල් තිරයේ ඇති DuckDuckGo යෙදුම් න
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s සහ නැවත "
-"උත්සාහ කරන්න."
+"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s "
+"සහ නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -792,7 +795,7 @@ msgstr "%1$s කණ්ඩායමේ 2 වැනියා"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2 වැනි මතය"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -877,7 +880,8 @@ msgstr "පැය 6ක පරිශීලන සීමාවට ළඟා වී
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
+"හැක."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -885,8 +889,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට ම කතාබස් කළ "
-"හැකි ය."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට "
+"ම කතාබස් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -940,8 +944,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. කරුණාකර ඔබේ "
-"සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
+"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. "
+"කරුණාකර ඔබේ සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -949,8 +953,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
 msgstr ""
-"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
-"කරන්න."
+"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
+"නැවත නැවුම් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -958,8 +962,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
 msgstr ""
-"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
-"කරන්න."
+"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
+"නැවත නැවුම් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1003,9 +1007,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. මෙය "
-"ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. මෙම සැකසුම ක්‍රියා "
-"විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI Chat වෙත ප්‍රවේශ විය හැකිය."
+"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. "
+"මෙය ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. "
+"මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI "
+"Chat වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1066,10 +1071,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ වෙතත්, අපි පසු විපරම් "
-"ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය වෙත සබැඳෙමු, එය OpenAI සහ "
-"Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය දක්වන අපගේ පෞද්ගලික AI බලයෙන් "
-"ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ "
+"වෙතත්, අපි පසු විපරම් ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය "
+"වෙත සබැඳෙමු, එය OpenAI සහ Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය "
+"දක්වන අපගේ පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1254,8 +1259,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට "
-"මාරු වන්න."
+"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් "
+"නොමිලේ ආකෘතියකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1291,8 +1296,8 @@ msgstr "දැන්වීම"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය මගින් වන අතර ඒවා "
-"ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
+"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය "
+"මගින් වන අතර ඒවා ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1300,8 +1305,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය විසිනි, ඒවා ඔබව පැතිකඩ "
-"කිරීමට භාවිතා නොකෙරේ."
+"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය "
+"විසිනි, ඒවා ඔබව පැතිකඩ කිරීමට භාවිතා නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1352,7 +1357,8 @@ msgstr "DuckDuckGo දිගුව එක් කරන්න"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් කරන්න:"
+"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් "
+"කරන්න:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1482,7 +1488,7 @@ msgstr "මුල් පිටුවට එකතු කරන්න"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "මගේ කතාබස් වෙත එක් කරන්න"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1586,7 +1592,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2–5 ගුණයක් වේගයෙන් පරිශීලන සීමාවලට ළඟා විය හැක. %1$s"
+"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2–5 ගුණයක් වේගයෙන් පරිශීලන සීමාවලට ළඟා විය "
+"හැක. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1594,7 +1601,9 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2-5 ගුණයකින් වේගයෙන් සීමාවන් භාවිතා කළ හැක. %1$s"
+msgstr ""
+"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2-5 ගුණයකින් වේගයෙන් සීමාවන් භාවිතා කළ හැක. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1772,8 +1781,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo හෝ ආකෘති "
-"සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
+"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo "
+"හෝ ආකෘති සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1820,8 +1829,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, ඔබගේ IP ලිපිනය) "
-"ඉවත් කරනු ලැබේ."
+"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, "
+"ඔබගේ IP ලිපිනය) ඉවත් කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1846,7 +1855,7 @@ msgstr "සියලු වර්ග"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "ඔබගේ සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි කර ඇත."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1860,7 +1869,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය ලබා දෙන්න."
+"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය "
+"ලබා දෙන්න."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1892,9 +1902,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ දෙයි. සීමිත දත්ත "
-"රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් පමණක් යවයි. %2$s සහිත විමසීම් සහ "
-"ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
+"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ "
+"දෙයි. සීමිත දත්ත රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් "
+"පමණක් යවයි. %2$s සහිත විමසීම් සහ ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ "
+"දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1902,7 +1913,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට අවශ්‍ය වේ)"
+"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට "
+"අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2040,7 +2052,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
+"නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2049,7 +2062,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
+"නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2063,8 +2077,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. එය කොපමණ වාර ගණනක් "
-"පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම අක්‍රිය කරන්න."
+"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. "
+"එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම "
+"අක්‍රිය කරන්න."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2111,8 +2126,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම විටම කරුණු "
-"මට කියන්න"
+"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම "
+"විටම කරුණු මට කියන්න"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2232,7 +2247,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, සියලුම කතා මකා දමනු ඇත."
+"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, "
+"සියලුම කතා මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2241,8 +2257,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද ඕනෑම මෑත "
-"කාලීන කතාබස් ද මකා දමනු ඇත."
+"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද "
+"ඕනෑම මෑත කාලීන කතාබස් ද මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2280,8 +2296,9 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම රැස්කර හෝ හුවමාරුකර "
-"නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු වේ."
+"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම "
+"රැස්කර හෝ හුවමාරුකර නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු "
+"වේ."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2365,7 +2382,7 @@ msgstr "පෞද්ගලිකව ඕනෑම දෙයක් අසන්න
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "පෞද්ගලිකව ඕනෑම දෙයක් අසන්න"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2423,12 +2440,14 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා AI-සහය සහිත "
-"පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් Assist පෙනී සිටීමට අවශ්‍ය දැ යි "
-"ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම "
-"මත (ඔබ Assist බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
-"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
-"පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
+"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා "
+"AI-සහය සහිත පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් "
+"Assist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් "
+"ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම මත (ඔබ Assist "
+"බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
+"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක "
+"සෙවුම් මත නිතර පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් "
+"ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2440,11 +2459,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් විමසුම් "
-"සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා "
-"වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-"
-"බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව "
-"ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු "
+"කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ "
+"තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා "
+"තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
+"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2470,8 +2490,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"DuckDuckGo VPN මගින් අවන්හලක, ගුවන් තොටුපළක හෝ හෝටලයක දී, ඔබේ සම්බන්ධතාවය ගුප්ත කේතනය "
-"කර Wi-Fi මත ඔබේ IP ලිපිනය සඟවයි."
+"DuckDuckGo VPN මගින් අවන්හලක, ගුවන් තොටුපළක හෝ හෝටලයක දී, ඔබේ සම්බන්ධතාවය "
+"ගුප්ත කේතනය කර Wi-Fi මත ඔබේ IP ලිපිනය සඟවයි."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2592,7 +2612,9 @@ msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදන
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් තිබිය හැක."
+msgstr ""
+"ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් "
+"තිබිය හැක."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2617,9 +2639,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර "
-"වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල "
-"පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර "
+"සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist "
+"ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2628,15 +2650,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව සමහර සෙවීම් "
-"වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, DuckAssist ලබා ගත "
-"හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව "
+"සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, "
+"DuckAssist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව ධාවනය කරන්න."
+msgstr ""
+"ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව "
+"ධාවනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2836,8 +2860,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත හැකි පාරදත්ත "
-"වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
+"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත "
+"හැකි පාරදත්ත වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2967,8 +2991,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"හානිකර වෙබ් අඩවි අවහිර කරන්න, ඔබේ IP ලිපිනය සඟවන්න, තව ද අපගේ ග්‍රාහකත්වය සමඟ තවත් වාරික "
-"ආරක්ෂණ ලබා ගන්න."
+"හානිකර වෙබ් අඩවි අවහිර කරන්න, ඔබේ IP ලිපිනය සඟවන්න, තව ද අපගේ ග්‍රාහකත්වය "
+"සමඟ තවත් වාරික ආරක්ෂණ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3228,16 +3252,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
+"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ "
+"සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s "
+"දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් "
+"යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s "
+"දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3245,8 +3271,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන බ්‍රවුසර්%2$s සඳහා පුද්ගලික "
-"සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන "
+"බ්‍රවුසර්%2$s සඳහා පුද්ගලික සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය "
+"යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3353,10 +3380,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ බ්‍රව්සරයේ). ඔබේ සැකසීම් "
-"වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති "
-"දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි "
-"විටෙකත් ඔබගේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ "
+"බ්‍රව්සරයේ). ඔබේ සැකසීම් වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික "
+"Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත "
+"හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි විටෙකත් ඔබගේ "
+"බ්‍රව්සරයෙන් ඉවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3364,8 +3392,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ දත්ත OpenAI වෙත "
-"යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ "
+"දත්ත OpenAI වෙත යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3374,8 +3402,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත OpenAI වෙත "
-"යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත "
+"OpenAI වෙත යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3410,7 +3438,9 @@ msgstr "කැමරූන්"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ හැකිද?"
+msgstr ""
+"කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ "
+"හැකිද?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3859,11 +3889,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික සංවාද "
-"කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. මෙම සැකසුම අක්‍රිය "
-"කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම "
-"ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත "
-"ප්‍රවේශ විය හැකිය."
+"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික "
+"සංවාද කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. "
+"මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු "
+"ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් "
+"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3919,7 +3949,8 @@ msgstr "පෞද්ගලිකව චැට් කරන්න"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ "
+"යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3927,8 +3958,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක පුද්ගලිකව කතාබහේ "
-"යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක "
+"පුද්ගලිකව කතාබහේ යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3997,8 +4028,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් ගබඩා කර ඇත. "
-"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
+"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් "
+"ගබඩා කර ඇත. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4010,10 +4041,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් "
-"නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
-"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ "
-"කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
+"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
+"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. "
+"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ "
+"ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4036,8 +4068,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන සියලුම ගොනු "
-"%2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව සමාලෝචනය කරනු ලැබේ."
+"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන "
+"සියලුම ගොනු %2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව "
+"සමාලෝචනය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4045,8 +4078,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට ගබඩාවේ ඉඩ නිදහස් "
-"කරගන්න."
+"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට "
+"ගබඩාවේ ඉඩ නිදහස් කරගන්න."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4202,8 +4235,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"හානිකර අඩවි සහ වංචා අවහිර කිරීමට උපකාරී වන ලොව පුරා පවතින සේවාදායක ස්ථාන 40කට වඩා වැඩි "
-"ගණනකින් තෝරා ගන්න."
+"හානිකර අඩවි සහ වංචා අවහිර කිරීමට උපකාරී වන ලොව පුරා පවතින සේවාදායක ස්ථාන "
+"40කට වඩා වැඩි ගණනකින් තෝරා ගන්න."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4220,7 +4253,9 @@ msgstr "සේවාවක් තෝරන්න"
 msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
-msgstr "ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම තෝරන්න"
+msgstr ""
+"ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම "
+"තෝරන්න"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4401,9 +4436,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන කතාබස් කාලය "
-"නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා ස්වයංක්‍රීයව මකා දැමිය හැකි "
-"ය."
+"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන "
+"කතාබස් කාලය නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා "
+"ස්වයංක්‍රීයව මකා දැමිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4413,8 +4448,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, ඔබේ "
-"බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ ස්වයංක්‍රීයව මකා දැමිය හැකිය."
+"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, "
+"ඔබේ බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ "
+"ස්වයංක්‍රීයව මකා දැමිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4423,8 +4459,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ අවහිර ලැයිස්තුව අපගේ "
-"ගාස්තු රහිත බ්‍රවුසරයේ"
+"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ "
+"අවහිර ලැයිස්තුව අපගේ ගාස්තු රහිත බ්‍රවුසරයේ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4433,9 +4469,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ %1$sDuck.ai%2$s "
-"හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ ආයතනවලින් චැට් ආකෘතිවලට සහය "
-"දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
+"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ "
+"%1$sDuck.ai%2$s හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ "
+"ආයතනවලින් චැට් ආකෘතිවලට සහය දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4509,8 +4545,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ දකුණු පස "
-"%3$sgears icon%4$s මත ක්ලික් කරන්න)"
+"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ "
+"දකුණු පස %3$sgears icon%4$s මත ක්ලික් කරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4540,7 +4576,8 @@ msgstr "%1$sYes%2$s කලික් කරන්න"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් කරන්න."
+"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් "
+"කරන්න."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4602,8 +4639,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
-"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
+"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
+"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4614,8 +4652,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
-"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
+"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
+"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4684,8 +4723,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් මෙනුව ක්ලික් කර "
-"%3$sDuckDuckGo%4$s තෝරන්න."
+"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් "
+"මෙනුව ක්ලික් කර %3$sDuckDuckGo%4$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4693,8 +4732,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ ඉහළ දකුණු කෙළවරේ "
-"තියෙනවා."
+"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ "
+"ඉහළ දකුණු කෙළවරේ තියෙනවා."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4895,8 +4934,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු කිරීමට හැකියාව Cloud "
-"Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
+"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු "
+"කිරීමට හැකියාව Cloud Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5168,8 +5207,8 @@ msgstr "දැන්වීම් අවහිර කිරීම දිගටම
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
-"මෑත කාලීන කතාබස් මෙතැනින් දිගටම කරගෙන යන්න. නැතහොත් Fire Button භාවිතයෙන් ඒවා මකා "
-"දමන්න."
+"මෑත කාලීන කතාබස් මෙතැනින් දිගටම කරගෙන යන්න. නැතහොත් Fire Button භාවිතයෙන් "
+"ඒවා මකා දමන්න."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5276,7 +5315,7 @@ msgstr "පිටපත් කරන්න"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "පිටපත් කරන්න"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5325,13 +5364,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "බෙදාගත් සබැඳිය පිටපත් කරන්න"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "වෙනත් උපාංගයකින් කේතය පිටපත් කරගන්න"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5340,6 +5379,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"වෙනත් උපාංගයකින් කේතය පිටපත් කරගන්න. %1$sDuck.ai සැකසුම් › කතාබස් › Sync & "
+"Backup › වෙනත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න%2$s වෙත ගොස් නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5392,7 +5433,8 @@ msgstr "කොස්ටාරිකාව"
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
 msgstr ""
-"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ කරන්න."
+"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5493,7 +5535,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
-"සබැඳියක් සෑදීමෙන් කතාබස්හි පිටපතක් සෑදෙන අතර, එය විවෘත කරන ඕනෑම අයෙකුට එය බැලිය හැකිය."
+"සබැඳියක් සෑදීමෙන් කතාබස්හි පිටපතක් සෑදෙන අතර, එය විවෘත කරන ඕනෑම අයෙකුට එය "
+"බැලිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5733,7 +5776,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් කරගෙන යා හැකිය."
+"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් "
+"කරගෙන යා හැකිය."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6023,7 +6067,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "බෙදාගත් සබැඳිය මකන්න"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6044,6 +6088,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"සබැඳියක් මකා දැමීමෙන් එය ක්‍රියා කිරීම නවත්වයි. සංවාදය විවෘත කර ඔවුන්ගේ "
+"කතාබස් වෙත එක් කර ඇති පුද්ගලයින් ඔවුන්ගේම පිටපතක් තබා ගනු ඇත."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6140,8 +6186,8 @@ msgstr "Duck.ai අසා ලිවීම"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට කිසිවිටෙකත් භාවිතා කරනු "
-"නොලැබේ."
+"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට "
+"කිසිවිටෙකත් භාවිතා කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6159,8 +6205,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා කරන බැවින්, "
-"ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
+"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා "
+"කරන බැවින්, ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6305,7 +6351,7 @@ msgstr "ඉවත ලන්න"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "ඉවත ලන්න"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6479,8 +6525,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන අතර AI-"
-"ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන "
+"අතර AI-ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6489,8 +6535,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ AI රූප "
-"පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ "
+"AI රූප පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6606,8 +6652,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
-"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින "
+"විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6616,8 +6662,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
-"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට "
+"සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6638,8 +6684,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප කිහිපයක් කෙටුම්පත් "
-"කරන්න."
+"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප "
+"කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6648,8 +6694,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් සඳහා විකල්ප "
-"කිහිපයක් කෙටුම්පත් කරන්න."
+"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් "
+"සඳහා විකල්ප කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6781,8 +6827,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. සැකසුම් තුළ පිටු "
-"ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
+"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. "
+"සැකසුම් තුළ පිටු ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය "
+"ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6792,8 +6839,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ බ්‍රවුසර "
-"සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය කර නැවත උත්සාහ කරන්න."
+"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ "
+"බ්‍රවුසර සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය "
+"කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6802,8 +6850,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම "
-"කරගෙන යන්න."
+"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම "
+"කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -6819,9 +6867,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය නැවතත් සියතට "
-"ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන ස්වාධීන සමාගමක් ලෙස අපි "
-"කටයුතු කරමු."
+"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය "
+"නැවතත් සියතට ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන "
+"ස්වාධීන සමාගමක් ලෙස අපි කටයුතු කරමු."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6836,8 +6884,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් පිටුවක් සමගින් "
-"අන්තර්ජාලයේ: https://duck.ai"
+"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් "
+"පිටුවක් සමගින් අන්තර්ජාලයේ: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6852,8 +6900,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s නිර්නාමික "
-"කේතය %2$s වෙත ඊමේල් කරන්න"
+"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s "
+"නිර්නාමික කේතය %2$s වෙත ඊමේල් කරන්න"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6874,9 +6922,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. එය අක්‍රිය "
-"කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව ම %1$sduck.ai%2$s වෙත "
-"පිවිසිය හැකි ය."
+"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. "
+"එය අක්‍රිය කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව "
+"ම %1$sduck.ai%2$s වෙත පිවිසිය හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6887,10 +6935,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI චැට් ආකෘති "
-"සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි "
-"Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට "
-"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
+"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI "
+"චැට් ආකෘති සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය "
+"කිරීමෙන් DuckDuckGo Search හි Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, "
+"මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට %1$shttps://duck.ai%2$s වෙත "
+"පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6905,8 +6954,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai භාවිතා "
-"කරන්න පුළුවන්."
+"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai "
+"භාවිතා කරන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6920,7 +6969,8 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා පරීක්ෂා කර නැත."
+"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා "
+"පරීක්ෂා කර නැත."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -6954,9 +7004,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI කතාබහ, "
-"ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, විවෘත මූලාශ්‍ර AI "
-"ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI කතාබස්"
+"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI "
+"කතාබහ, ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, "
+"විවෘත මූලාශ්‍ර AI ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI "
+"කතාබස්"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6984,12 +7035,13 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ "
-"හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් "
-"(සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම "
-"ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට (ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත නිතර නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද "
-"(ඉංග්‍රීසි) කලාපයේ පමණි."
+"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා "
+"සාරාංශගත කළ හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා "
+"ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම "
+"ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට "
+"(ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
+"නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ "
+"පමණි."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6998,9 +7050,10 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි %1$sDuckDuckGo AI "
-"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
-"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
+"%1$sDuckDuckGo AI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
+"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
+"සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7009,9 +7062,10 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි DuckDuckGo %1$sAI "
-"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
-"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
+"DuckDuckGo %1$sAI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
+"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
+"සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7023,11 +7077,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
-"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව "
-"සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් "
-"ක්‍රියාත්මක වන ස්වාභාවික භාෂා තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ "
-"අන්තර්ගතයන් මත පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
+"එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම "
+"තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් ක්‍රියාත්මක වන ස්වාභාවික භාෂා "
+"තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ අන්තර්ගතයන් මත "
+"පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7041,13 +7096,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
-"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් "
-"කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති "
-"ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට "
-"සෘජුවම සම්බන්ධ වන අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
-"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
-"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
+"එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත "
+"පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත "
+"කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට සෘජුවම සම්බන්ධ වන "
+"අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
+"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් "
+"ස්වයංක්රීයව ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම "
+"වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7055,8 +7112,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර නිරවද්‍යතාව සඳහා "
-"පරීක්‍ෂා කර නොමැත."
+"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර "
+"නිරවද්‍යතාව සඳහා පරීක්‍ෂා කර නොමැත."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7065,8 +7122,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට මෙම "
-"කතාබස් දිගටම කරගෙන යන්න."
+"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට "
+"මෙම කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7075,8 +7132,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
-"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
+"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7085,8 +7142,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
-"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
+"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7112,7 +7169,9 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ කරන්න."
+msgstr ""
+"DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7151,7 +7210,7 @@ msgstr "DuckDuckGo බ්‍රවුසරය %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo උදවු පිටු"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7268,8 +7327,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත වැනි PII "
-"ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
+"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත "
+"වැනි PII ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7277,8 +7336,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai %2$s වෙත එකඟ "
-"වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai "
+"%2$s වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7287,7 +7346,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s වෙත එකඟ වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s "
+"වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7296,8 +7356,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල DuckDuckGo ට්‍රැකර් අවහිර "
-"කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය කිරීමට උත්සාහ කරයි."
+"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල "
+"DuckDuckGo ට්‍රැකර් අවහිර කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය "
+"කිරීමට උත්සාහ කරයි."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7309,11 +7370,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය උපාංගයේ පමණක් "
-"ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ ප්‍රතිඵල වැඩි දියුණු කිරීම "
-"සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ "
-"පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන "
-"ගන්න%2$s."
+"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය "
+"උපාංගයේ පමණක් ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ "
+"ප්‍රතිඵල වැඩි දියුණු කිරීම සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන "
+"පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම "
+"තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7333,8 +7394,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල ලබා දීමට "
-"අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
+"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල "
+"ලබා දීමට අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7426,9 +7487,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු අහඹු වචන "
-"ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 ක් තෝරා ගනිමු, මුරපදය අවම "
-"වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
+"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු "
+"අහඹු වචන ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 "
+"ක් තෝරා ගනිමු, මුරපදය අවම වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7498,7 +7559,9 @@ msgstr "රූපය සංස්කරණය කෙරේ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය කරයි."
+msgstr ""
+"ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය "
+"කරයි."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7636,8 +7699,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම විටම ඔබේ අදහස වෙනස් "
-"කළ හැකිය."
+"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම "
+"විටම ඔබේ අදහස වෙනස් කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7648,7 +7711,9 @@ msgstr "Duck.ai මත අසා ලිවීම සක් රීය කරන�
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය කරන්න"
+msgstr ""
+"නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය "
+"කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7680,8 +7745,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් තවමත් ඔබේ සෙවුම් සහ නිශ්චිත "
-"ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
+"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් "
+"තවමත් ඔබේ සෙවුම් සහ නිශ්චිත ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7843,8 +7908,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ නව මුරදය යටතේ "
-"ඔබගේ දත්ත සුරකිනු ඇත."
+"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ "
+"නව මුරදය යටතේ ඔබගේ දත්ත සුරකිනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7971,14 +8036,16 @@ msgstr "සිතියම පුළුල් කරන්න"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද නිෂ්පාදන."
+msgstr ""
+"පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද "
+"නිෂ්පාදන."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "කල් ඉකුත් වී ඇත"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7992,7 +8059,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "%1$s දින කල් ඉකුත් වේ"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8059,7 +8126,9 @@ msgstr "මෙය සරලව පැහැදිලි කරන්න"
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr "මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි කරන්න."
+msgstr ""
+"මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -8254,7 +8323,9 @@ msgstr "ප්‍රතිපෝෂණය සාර්ථකව යවන ලද
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් බලපායි."
+msgstr ""
+"ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු "
+"කිරීම් බලපායි."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8263,15 +8334,18 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් සෘජුවම බලපායි. ඔබ බෙදාගත් "
-"ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම බලාපොරොත්තු වෙමි."
+"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් "
+"සෘජුවම බලපායි. ඔබ බෙදාගත් ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම "
+"බලාපොරොත්තු වෙමි."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් කරන්න."
+msgstr ""
+"පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8361,7 +8435,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. %1$sවැඩිදුර දැනගන්න%2$s"
+"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. "
+"%1$sවැඩිදුර දැනගන්න%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8439,7 +8514,9 @@ msgstr "ඔබට සමීප ප්‍රතිඵල සොයා ගන්�
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව පවතී."
+msgstr ""
+"ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව "
+"පවතී."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8503,8 +8580,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට මෙනු විකල්පයක් "
-"තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
+"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට "
+"මෙනු විකල්පයක් තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8733,8 +8810,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac හි යෙදුම් මෙනු තීරුවෙන්, <strong>DuckDuckGo</strong> තෝරන්න &gt; "
-"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන ස්ථාපනය "
-"කරන්න</strong> තෝරන්න."
+"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන "
+"ස්ථාපනය කරන්න</strong> තෝරන්න."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9020,8 +9097,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN, උසස් Duck.ai ලබා ගන්න පුද්ගලික තොරතුරු ඉවත් කිරීම සහ Identity Theft "
-"Restoration."
+"DuckDuckGo VPN, උසස් Duck.ai ලබා ගන්න පුද්ගලික තොරතුරු ඉවත් කිරීම සහ "
+"Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9107,8 +9184,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"වේගවත්, ලොග් වීම අනවශ්‍ය VPN, විකල්ප උසස් AI කතාබහ, Personal info Removal, සහ "
-"Identity Theft Restoration ලබා ගන්න."
+"වේගවත්, ලොග් වීම අනවශ්‍ය VPN, විකල්ප උසස් AI කතාබහ, Personal info Removal, "
+"සහ Identity Theft Restoration ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9117,8 +9194,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"වේගවත්, ලොග් වීම අනවශ්‍ය VPN එකක්, විකල්ප උසස් AI චැට් එකක් සහ Identity Theft "
-"Restoration ලබා ගන්න."
+"වේගවත්, ලොග් වීම අනවශ්‍ය VPN එකක්, විකල්ප උසස් AI චැට් එකක් සහ Identity "
+"Theft Restoration ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9127,8 +9204,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත දායක වීමෙන් Duck."
-"ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත "
+"දායක වීමෙන් Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9139,8 +9216,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo දායකත්වයක් සමඟ "
-"Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo "
+"දායකත්වයක් සමඟ Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9184,8 +9261,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN එක, ඉහළ චැට් සීමාවන් සහිත උසස් AI මාදිලි සඳහා විකල්ප "
-"ප්‍රවේශය සහ තවත් ප්‍රිමියම් ආරක්ෂණ ලබා ගන්න."
+"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN එක, ඉහළ චැට් සීමාවන් සහිත උසස් AI මාදිලි "
+"සඳහා විකල්ප ප්‍රවේශය සහ තවත් ප්‍රිමියම් ආරක්ෂණ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9194,8 +9271,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai ලබා ගන්න, Personal Information "
-"Removal සහ Identity Theft Restoration."
+"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai ලබා ගන්න, Personal "
+"Information Removal සහ Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9203,8 +9280,8 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai, සහ Identity Theft Restoration ලබා "
-"ගන්න."
+"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai, සහ Identity Theft "
+"Restoration ලබා ගන්න."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9245,7 +9322,9 @@ msgstr "යෙදුම ලබා ගන්න"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "YouTube මත දැන්වීම් අවහිර කිරීමට %1$sනොමිලේ DuckDuckGo බ්‍රවුසරය ලබා ගන්න.%2$s"
+msgstr ""
+"YouTube මත දැන්වීම් අවහිර කිරීමට %1$sනොමිලේ DuckDuckGo බ්‍රවුසරය ලබා "
+"ගන්න.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9304,9 +9383,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න › පාඨමය කේතය "
-"පිටපත් කරන්න%4$sවෙත යන්න"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
+"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
+"කරන්න › පාඨමය කේතය පිටපත් කරන්න%4$sවෙත යන්න"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9315,8 +9394,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත ගොස් "
-"%3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත යන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත "
+"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත "
+"යන්න."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9326,9 +9406,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත ගොස් මෙම "
-"කේතය ස්කෑන් කරන්න:"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
+"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
+"කරන්න%4$s වෙත ගොස් මෙම කේතය ස්කෑන් කරන්න:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9338,9 +9418,10 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. "
-"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
+"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
+"කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9349,6 +9430,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"%1$sDuck.ai සැකසුම්%2$s › %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග "
+"සමමුහුර්ත කරන්න%4$s වෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9363,8 +9446,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන සේවා\" සක්‍රිය කර "
-"ඇති බවට වග බලා ගන්න."
+"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන "
+"සේවා\" සක්‍රිය කර ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9373,8 +9456,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් %3$sDuckDuckGo%4$s "
-"වෙත පහළට අනුචලනය කරන්න."
+"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් "
+"%3$sDuckDuckGo%4$s වෙත පහළට අනුචලනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9464,7 +9547,7 @@ msgstr "වැටහුණි"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "වැටහුණා"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10063,8 +10146,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist පිළිතුරුවල ප්‍රධාන "
-"කරුණු ඉස්මතු කරයි."
+"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist "
+"පිළිතුරුවල ප්‍රධාන කරුණු ඉස්මතු කරයි."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10091,8 +10174,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ සුරකින්න."
-"%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
+"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ "
+"සුරකින්න.%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10106,8 +10189,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ රහස්‍යතා ආරක්ෂාව "
-"අහිමි වේ."
+"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ "
+"රහස්‍යතා ආරක්ෂාව අහිමි වේ."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10157,8 +10240,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය කරනු ලබන අතර ඔබව "
-"පැතිකඩ කිරීමට භාවිත නොකෙරේ."
+"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය "
+"කරනු ලබන අතර ඔබව පැතිකඩ කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10300,8 +10383,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ කෙසේද සහ මා කුමක් "
-"කිව යුතුද?"
+"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ "
+"කෙසේද සහ මා කුමක් කිව යුතුද?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10423,8 +10506,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම කැමති මොනවාද "
-"සහ ඇයි?"
+"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම "
+"කැමති මොනවාද සහ ඇයි?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10459,8 +10542,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > 'පිහිටීම හා "
-"රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > "
+"'පිහිටීම හා රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10470,8 +10553,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > සැකසුම් > අඩවි සැකසුම් > "
-"පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා අවසර දී ඇති ද යන්න දැනගන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > "
+"සැකසුම් > අඩවි සැකසුම් > පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා "
+"අවසර දී ඇති ද යන්න දැනගන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10486,8 +10570,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther Search "
-"Engines%4$s ලැයිස්තුවට එකතු කරන්න"
+"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther "
+"Search Engines%4$s ලැයිස්තුවට එකතු කරන්න"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10496,8 +10580,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් ඇත්නම්, ඔබට කෙලින්ම "
-"%1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
+"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් "
+"ඇත්නම්, ඔබට කෙලින්ම %1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10506,14 +10590,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා ගැනීමට මෙම "
-"කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස සුරැකිය හැකි ය."
+"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා "
+"ගැනීමට මෙම කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස "
+"සුරැකිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු කරන්න%2$s"
+msgstr ""
+"ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු "
+"කරන්න%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10523,15 +10610,17 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ %1$s හෝ %2$s "
-"යන පිටපත් භාවිතා කරන්න."
+"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ "
+"%1$s හෝ %2$s යන පිටපත් භාවිතා කරන්න."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත කරන්න)."
+msgstr ""
+"ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත "
+"කරන්න)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10660,7 +10749,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය වැඩි දියුණු කරයි"
+"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය "
+"වැඩි දියුණු කරයි"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10673,8 +10763,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් කිරීම් අපගේ සර්වරය හරහා "
-"හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
+"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් "
+"කිරීම් අපගේ සර්වරය හරහා හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10685,8 +10775,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් උපාංගයක් සමග "
-"සමමුහුර්ත කරන්න” වෙත යන්න."
+"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් "
+"උපාංගයක් සමග සමමුහුර්ත කරන්න” වෙත යන්න."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10701,8 +10791,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන ගැනීමට හැකියි අප "
-"ගබඩා කරන්නේ කුමන දත්තද කියා."
+"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන "
+"ගැනීමට හැකියි අප ගබඩා කරන්නේ කුමන දත්තද කියා."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10713,8 +10803,8 @@ msgstr "ඉහළ ඇති මෙනුවෙන් %1$sTools%2$s > %3$sSetting
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
 msgstr ""
-"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි සලකුණ "
-"යොදන්න"
+"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි "
+"සලකුණ යොදන්න"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11041,7 +11131,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය සාරාංශගත කරන්න."
+"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය "
+"සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11110,9 +11201,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි දැන්වීම් ජාලය "
-"හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් "
-"නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු නොකෙරේ."
+"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි "
+"දැන්වීම් ජාලය හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ "
+"පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11121,7 +11213,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත වේ."
+"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත "
+"වේ."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11193,7 +11286,9 @@ msgstr "උපාංග දෙකෙහිම Sync & Backup විවෘතව �
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr "එකවර උපාංග 5ක් දක්වා ඔබගේ සියලුම යෙදුම් සහ මාර්ගගත ක්‍රියාකාරකම් පුද්ගලිකව තබා ගන්න."
+msgstr ""
+"එකවර උපාංග 5ක් දක්වා ඔබගේ සියලුම යෙදුම් සහ මාර්ගගත ක්‍රියාකාරකම් පුද්ගලිකව "
+"තබා ගන්න."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11430,7 +11525,7 @@ msgstr "%1$sතවත්%2$s ඉගෙන ගන්න"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "වැඩිදුර දැනගන්න"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11808,7 +11903,9 @@ msgstr "අනුචලනය කරන විට තවත් පින්ත�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය කරයි"
+msgstr ""
+"අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය "
+"කරයි"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11994,8 +12091,7 @@ msgstr "සියළුම වචන වල අක්ෂර වින්‍ය�
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
+msgstr "%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12067,7 +12163,7 @@ msgstr "කළමනාකරණය කරන්න"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "කළමනාකරණය කරන්න"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12324,7 +12420,7 @@ msgstr "මෙනුව"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "මෙතැනින් ඉදිරියට ඇති පණිවිඩ පෙනෙන්නේ ඔබට පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12354,7 +12450,9 @@ msgstr "මයික්රොනීසියාව"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත උත්සාහ කරන්න."
+msgstr ""
+"මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12585,7 +12683,9 @@ msgstr "මාසික සීමාවට ළඟා විය"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
+msgstr ""
+"මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
+"හැක."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12696,7 +12796,7 @@ msgstr "Duck.ai ගැන වැඩි විස්තර"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "තවත් ක්‍රියා"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12896,7 +12996,7 @@ msgstr "ලා රතු"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "මගේ උපාංග"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13138,10 +13238,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව "
-"විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු "
-"ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර "
-"තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම "
+"සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo "
+"සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් "
+"මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13963,8 +14063,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the %4$s "
-"icon > Settings%5$s"
+"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the "
+"%4$s icon > Settings%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -13973,6 +14073,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"වෙනත් උපාංගයක %1$sDuck.ai සැකසුම්%2$s › %3$sකතාබස් › Sync & Backup › වෙනත් "
+"උපාංගයක් සමඟ සමමුහුර්ත කරන්න%4$sවෙත යන්න"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -13981,6 +14083,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"වෙනත් උපාංගයක %1$sDuck.ai සැකසුම්%2$s › %3$sකතාබස් › Sync & Backup › වෙනත් "
+"උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත ගොස් මෙම කේතය ස්කෑන් කරන්න:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -13989,6 +14093,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"වෙනත් උපාංගයක %1$sDuck.ai සැකසුම්%2$s › %3$sකතාබස් › Sync & Backup › වෙනත් "
+"උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF "
+"ගොනුවේ ඇති QR කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14016,8 +14123,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. පිටු %1$s ක් හෝ ඊට අඩු "
-"පිටු ඇති ගොනු උඩුගත කරන්න."
+"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. "
+"පිටු %1$s ක් හෝ ඊට අඩු පිටු ඇති ගොනු උඩුගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14043,7 +14150,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව දක්වා ඇත."
+msgstr ""
+"ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව "
+"දක්වා ඇත."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14058,7 +14167,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
+"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14381,8 +14491,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් නිරීක්ෂණය කරයි. අපි ඔබව "
-"කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
+"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් "
+"නිරීක්ෂණය කරයි. අපි ඔබව කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14396,8 +14506,8 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN, ඉහළ සීමාවන් සහිත වඩා සුහුරු AI චැට් සහ තවත් ප්‍රිමියම් "
-"ආරක්ෂණ සමඟින් පැමිණේ.‍ සියල්ල ඇතුළත් එකම ග්‍රාහකත්වයක්."
+"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN, ඉහළ සීමාවන් සහිත වඩා සුහුරු AI චැට් සහ "
+"තවත් ප්‍රිමියම් ආරක්ෂණ සමඟින් පැමිණේ.‍ සියල්ල ඇතුළත් එකම ග්‍රාහකත්වයක්."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14405,8 +14515,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු කරන්නේ හෝ බෙදා "
-"හරින්නේ නැත."
+"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු "
+"කරන්නේ හෝ බෙදා හරින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14414,8 +14524,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය, "
-"ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & Android%2$sහි ලද හැක."
+"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
+"අවහිරකාරකය, ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & "
+"Android%2$sහි ලද හැක."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14668,8 +14779,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ සම්බන්ධ නොකරන බැවින් මුරපද "
-"යථාවත් කර ගත නොහැක."
+"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ "
+"සම්බන්ධ නොකරන බැවින් මුරපද යථාවත් කර ගත නොහැක."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14739,7 +14850,7 @@ msgstr "පසුගිය අවුරුද්ද"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "අලවන්න"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14757,7 +14868,7 @@ msgstr "සමමුහුර්ත කේතය අලවන්න"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "පහතින් එය අලවන්න"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14816,7 +14927,7 @@ msgstr "පර්සියානු"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14825,6 +14936,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal මගින් ඔබේ තොරතුරු ඒවා අලෙවි කරන දත්ත තැරැව්කාර "
+"අඩවිවලින් සොයා ගනියි. අනතුරුව අපි ඔබ වෙනුවෙන් ඒවා ඉවත් කර ගැනීමට කටයුතු "
+"කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14895,9 +15009,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ "
-"ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම "
-"සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත "
+"පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. "
+"ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s "
+"වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14906,9 +15021,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
-"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් "
-"කිරීමට හෝ එය ක්‍රියා විරහිත කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
+"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. "
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය ක්‍රියා විරහිත "
+"කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14918,9 +15034,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
-"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට "
-"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
+"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය "
+"නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට %1$sDuckAssist සැකසුම්%2$s වෙත "
+"පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14953,7 +15070,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් කිරීමට තෝරන්න."
+"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් "
+"කිරීමට තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14962,7 +15080,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් තෝරන්න."
+"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI "
+"එකක් තෝරන්න."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14983,8 +15102,8 @@ msgstr "විශේෂ වූ ප්‍රශ්නයක් තෝරා ග�
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් අනුගමනය "
-"කරන්න."
+"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් "
+"අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15072,7 +15191,9 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
+msgstr ""
+"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
+"සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15080,19 +15201,25 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
+msgstr ""
+"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
+"සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
+msgstr ""
+"කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
+"(විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
+msgstr ""
+"කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
+"(විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15113,7 +15240,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය මකා දමනු ඇත."
+"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය "
+"මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15122,8 +15250,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
-"හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
+"අලවා අන්තර්ගතය හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15132,8 +15260,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
-"නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
+"අලවා අන්තර්ගතය නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15347,7 +15475,9 @@ msgstr "දුර්වල ආකෘතිකරණය"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr "ජනප්‍රිය AI ආකෘති ලබා ගත හැක. ගිණුමක් අවශ්‍ය නොවේ. කතාබස් අප විසින් නිර්නාමික කර ඇත."
+msgstr ""
+"ජනප්‍රිය AI ආකෘති ලබා ගත හැක. ගිණුමක් අවශ්‍ය නොවේ. කතාබස් අප විසින් "
+"නිර්නාමික කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15899,8 +16029,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම පෙළ මෙහි "
-"ඇතුලත් කරන්න.]"
+"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම "
+"පෙළ මෙහි ඇතුලත් කරන්න.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16075,7 +16205,7 @@ msgstr "වෙබ් අඩවිය කියවීම…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "සූර්යග්‍රහණයට සූදානම් ද?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16117,7 +16247,9 @@ msgstr "තර්කනය මඟින් සංකීර්ණ ප්‍රශ
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "තර්කනය වඩාත් සවිස්තරාත්මකයි, නමුත් 2-5 ගුණයක් වේගයෙන් පරිශීලන සීමාවන්ට ළඟා වේ. %1$s"
+msgstr ""
+"තර්කනය වඩාත් සවිස්තරාත්මකයි, නමුත් 2-5 ගුණයක් වේගයෙන් පරිශීලන සීමාවන්ට ළඟා "
+"වේ. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16173,8 +16305,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
-"උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
+"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16183,8 +16315,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
-"උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
+"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16194,9 +16326,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් "
-"කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
-"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
+"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
+"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
+"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16270,7 +16402,7 @@ msgstr "ප්‍රතිසාධන කේතය"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "ප්‍රතිසාධන කේතය"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16337,7 +16469,9 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr "ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු කරයි"
+msgstr ""
+"ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු "
+"කරයි"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16478,8 +16612,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ &quot;Reload&quot; "
-"බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
+"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ "
+"&quot;Reload&quot; බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16525,7 +16659,7 @@ msgstr "%1$s ඉවත් කරන්න"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "උපකරණය ඉවත් කරන්න"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16573,13 +16707,13 @@ msgstr "අනවශ්‍ය විරාම ලකුණු ඉවත් ක�
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "ඔබේ තොරතුරු අන්තර්ජාලයෙන් ඉවත් කරන්න"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "ඔබේ තොරතුරු අන්තර්ජාලයෙන් ඉවත් කරන්න"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16587,8 +16721,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" බොත්තම ඉවත් කරයි. "
-"හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" "
+"බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16596,8 +16730,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Generate\" බොත්තම ඉවත් "
-"කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි "
+"\"Generate\" බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව "
+"දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16655,9 +16790,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට DuckDuckGo වෙත යවනු "
-"ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු "
-"ලැබේ."
+"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට "
+"DuckDuckGo වෙත යවනු ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු "
+"කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16665,8 +16800,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත "
-"හැකි තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු "
+"පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16675,9 +16810,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට ඉල්ලා ඇති සියලු "
-"පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි "
-"තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට "
+"ඉල්ලා ඇති සියලු පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ "
+"කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16769,8 +16904,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා "
+"කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16779,8 +16915,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා "
+"කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16790,9 +16927,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය කර ඇති අතර සාවද්‍යතා අඩංගු "
-"විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය "
+"කර ඇති අතර සාවද්‍යතා අඩංගු විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s "
+"යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17217,8 +17355,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ මෑත කාලීන "
-"කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
+"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ "
+"මෑත කාලීන කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17267,7 +17405,7 @@ msgstr "Duck.ai වෙත හෙලෝ කියන්න"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Duck.ai පිළිගන්න – DuckDuckGo වෙතින් නොමිලේ, පුද්ගලික AI කතාබස්."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17385,8 +17523,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු %3$sChange%4$s "
-"ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
+"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු "
+"%3$sChange%4$s ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17395,8 +17533,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත ක්ලික් කරන්න "
-"(හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
+"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත "
+"ක්ලික් කරන්න (හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17474,12 +17612,13 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන විශේෂාංගයකි. මෙය සිදු කිරීම "
-"සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI "
-"භාවිත කරයි. ඔබට එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, "
-"ඉල්ලූ-විට (Assist ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන කලාපවල උප "
-"කණ්ඩායමක පමණි."
+"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන "
+"විශේෂාංගයකි. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන "
+"අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි. ඔබට එය කොපමණ වාර "
+"ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, ඉල්ලූ-විට (Assist "
+"ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
+"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන "
+"කලාපවල උප කණ්ඩායමක පමණි."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17487,8 +17626,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක තොරතුරු සොයාගැනීමට "
-"Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
+"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක "
+"තොරතුරු සොයාගැනීමට Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17497,9 +17636,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප විශේෂාංගයකි. "
-"%1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් කර පසුව සොයාගත් තොරතුරු "
-"මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි."
+"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප "
+"විශේෂාංගයකි. %1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් "
+"කර පසුව සොයාගත් තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත "
+"කරයි."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17620,8 +17760,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ “ducks” සෘජුවම "
-"සොයාගත හැක."
+"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ "
+"“ducks” සෘජුවම සොයාගත හැක."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17640,8 +17780,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් සෙවුම එක් කරන්න, "
-"නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
+"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් "
+"සෙවුම එක් කරන්න, නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17649,7 +17789,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් භාවිතා කරනු ඇත)"
+"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් "
+"භාවිතා කරනු ඇත)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17661,10 +17802,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර ගබඩා තුළ ගබඩා කර ඇත, "
-"නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත "
-"කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් "
-"ඔබේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර "
+"ගබඩා තුළ ගබඩා කර ඇත, නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ "
+"සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු "
+"ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් ඔබේ බ්‍රව්සරයෙන් ඉවත් "
+"නොවේ."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17767,8 +17909,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17777,8 +17919,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17787,8 +17929,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17797,8 +17939,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා කර, "
-"ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා "
+"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17813,8 +17955,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට හැර වෙන "
-"කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
+"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට "
+"හැර වෙන කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18038,8 +18180,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් වල) "
-"තෝරන්න"
+"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් "
+"වල) තෝරන්න"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18104,8 +18246,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් අනෙකුත් "
-"විකල්ප වලින් එකක් තෝරන්න)"
+"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් "
+"අනෙකුත් විකල්ප වලින් එකක් තෝරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18227,8 +18369,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත විමසුමක් යවයි. මෙම "
-"උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
+"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත "
+"විමසුමක් යවයි. මෙම උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18255,7 +18397,7 @@ msgstr "සර්බියානු (ලතින්)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "සර්වර දත්ත මකා දමන ලදී"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18351,8 +18493,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක කිරීමෙන් පසු Sync & "
-"Backup පිහිටුුවන්න."
+"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක "
+"කිරීමෙන් පසු Sync & Backup පිහිටුුවන්න."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18415,7 +18557,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "බෙදා ගන්න"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18459,8 +18601,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. Duck.ai කිසි "
-"විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
+"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. "
+"Duck.ai කිසි විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18556,8 +18698,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ හානිකර වාර්තා "
-"සඳහා අවශ්‍ය වේ)"
+"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ "
+"හානිකර වාර්තා සඳහා අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18569,13 +18711,13 @@ msgstr "සෙවුම් කොටුව පිළිබඳ ඔබේ අද�
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "බෙදාගත් කතාබස් සබැඳි"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "බෙදාගත් කතාබස් සබැඳි"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18584,8 +18726,9 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"අපගේ ලොග් වීම අනවශ්‍ය, වේගවත් VPN සමඟ ඔබේ අන්තර්ජාල ක්‍රියාකාරකම් ආරක්ෂා කරගන්න. සැකසීමට "
-"සරල වන අතර ඕනෑම වේලාවක ක්‍රියාත්මක කිරීමට සහ අක්‍රිය කිරීමට පහසුය."
+"අපගේ ලොග් වීම අනවශ්‍ය, වේගවත් VPN සමඟ ඔබේ අන්තර්ජාල ක්‍රියාකාරකම් ආරක්ෂා "
+"කරගන්න. සැකසීමට සරල වන අතර ඕනෑම වේලාවක ක්‍රියාත්මක කිරීමට සහ අක්‍රිය කිරීමට "
+"පහසුය."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18706,7 +18849,8 @@ msgstr "DuckAssist <sup>BETA</sup> පෙන්වන්න"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත කිරීමටද%2$s හැකිය.)"
+"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත "
+"කිරීමටද%2$s හැකිය.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18944,8 +19088,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවයි "
-"සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
+"කිරීම මතක් කිරීම සඟවයි සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18953,8 +19097,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවන "
-"අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
+"කිරීම මතක් කිරීම සඟවන අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18992,7 +19136,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන පණිවුඩ පෙන්වන්න"
+"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන "
+"පණිවුඩ පෙන්වන්න"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19252,7 +19397,7 @@ msgstr "කුමක් හෝ වැරැද්දක් සිදු වි�
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "මෙම බෙදාගත් කතාබහ ප්‍රවේශනය කිරීමේ දී යම් වරදක් සිදු විය."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19333,7 +19478,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් උත්සාහ කරන්න."
+"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19342,16 +19488,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර ඇති බවට වග "
-"බලා ගන්න."
+"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර "
+"ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට Duck.ai එකෙන් අහන්න "
-"උත්සාහ කළ හැක."
+"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට "
+"Duck.ai එකෙන් අහන්න උත්සාහ කළ හැක."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19360,15 +19506,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ කිරීමට%1$sමෙහි ක්ලික් "
-"කරන්න%2$s ."
+"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ "
+"කිරීමට%1$sමෙහි ක්ලික් කරන්න%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
+"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19772,8 +19919,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය ලබාගන්න, නැතහොත් "
-"තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය "
+"ලබාගන්න, නැතහොත් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19841,7 +19988,9 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා කරනවාද?"
+msgstr ""
+"සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා "
+"කරනවාද?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20098,7 +20247,7 @@ msgstr "ආකෘතිය මාරු කරන්න"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "ආකෘතිය මාරු කරන්න"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20177,7 +20326,9 @@ msgstr "%1$sවෙත මාරු විය"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට යවනු ඇත"
+msgstr ""
+"ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට "
+"යවනු ඇත"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20232,7 +20383,8 @@ msgstr "Sync & Backup සක්‍රිය කරන ලදී!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය කළ නොහැක."
+"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය "
+"කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20281,9 +20433,9 @@ msgid ""
 msgstr ""
 "ප්‍රතිසාධන කේතය සමමුහුර්ත කරන්න\n"
 "\n"
-"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් උපාංග කිහිපයක් අතර "
-"සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
-"කර ගනී.\n"
+"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් "
+"උපාංග කිහිපයක් අතර සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි "
+"වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය කර ගනී.\n"
 "\n"
 "මෙම තොරතුරු ආරක්ෂිතව තබා ගන්න.\n"
 "මෙම කේතයට ප්‍රවේශය ඇති ඕනෑම අයෙකුට ඔබේ සමමුහුර්ත දත්ත වෙත ප්‍රවේශ විය හැක.\n"
@@ -20292,12 +20444,14 @@ msgstr ""
 "\n"
 "මෙම කේතය ක්‍රියා කරන්නේ කෙසේ ද?\n"
 "1. ඔබේ බ්‍රවුසරයෙන් Duck.ai වෙත ගොස් Duck.ai සැකසුම් විවෘත කරන්න.\n"
-"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය කරන්න\" තෝරන්න\n"
-"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන ස්ථානයේ "
-"අලවන්න\n"
+"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
+"කරන්න\" තෝරන්න\n"
+"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන "
+"ස්ථානයේ අලවන්න\n"
 "\n"
-"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි කාලයක් භාවිතා "
-"නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය කළ නොහැක."
+"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි "
+"කාලයක් භාවිතා නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය "
+"කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20358,7 +20512,7 @@ msgstr "සමමුහුර්ත කළ උපාංග"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "%1$s දින සමමුහුර්ත කරන ලදී"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20396,7 +20550,7 @@ msgstr "රූපවාහිනිය"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "වගුව"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20430,8 +20584,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිටියත්, වඩාත් වේගවත් ප්‍රවේශයක් සඳහා "
-"එය අපගේ නොමිලේ යෙදුම තුළම ලබා ගන්න."
+"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිටියත්, වඩාත් වේගවත් "
+"ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ යෙදුම තුළම ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20440,8 +20594,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිට බ්‍රවුස් කළ ද වඩාත් වේගවත් "
-"ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ ලබා දෙන බ්‍රවුසරය තුළට ඇතුළත් කරගන්න."
+"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිට බ්‍රවුස් කළ ද වඩාත් "
+"වේගවත් ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ ලබා දෙන බ්‍රවුසරය තුළට ඇතුළත් කරගන්න."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20465,7 +20619,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික සමීක්ෂණයට සහභාගි වන්න."
+"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික "
+"සමීක්ෂණයට සහභාගි වන්න."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20686,9 +20841,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද තොරතුරු තෙවන "
-"පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට "
-"ඇතුළත් වේ."
+"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද "
+"තොරතුරු තෙවන පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ "
+"අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට ඇතුළත් වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20697,8 +20852,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් Cloud Save කුඩා පිටු "
-"සලකුණු මඟින් ඉඩ දෙයි."
+"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් "
+"Cloud Save කුඩා පිටු සලකුණු මඟින් ඉඩ දෙයි."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20728,8 +20883,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය හැක්කේ ඔබට "
-"පමණි."
+"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය "
+"හැක්කේ ඔබට පමණි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -20750,7 +20905,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල සුරකින්නේ නැත."
+msgstr ""
+"ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල "
+"සුරකින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20809,8 +20966,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය කර ඇති බවට වග බලා "
-"ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
+"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය "
+"කර ඇති බවට වග බලා ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20825,8 +20982,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර කරුණාකර මිනිත්තු කිහිපයක් "
-"රැඳී සිටින්න."
+"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර "
+"කරුණාකර මිනිත්තු කිහිපයක් රැඳී සිටින්න."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20845,9 +21002,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් සහ DuckDuckGo "
-"ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම "
-"බ්‍රව්සර් අවසර භාවිතා කරයි."
+"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් "
+"සහ DuckDuckGo ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් "
+"අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම බ්‍රව්සර් අවසර භාවිතා කරයි."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20885,8 +21042,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ කිරීමට උත්සාහ "
-"කරන්න."
+"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ "
+"කිරීමට උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20895,8 +21052,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව කතාබහක් "
-"ආරම්භ කරන්න."
+"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව "
+"කතාබහක් ආරම්භ කරන්න."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20935,8 +21092,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත කරමිනි. AI "
-"කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා %4$s බලන්න)."
+"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත "
+"කරමිනි. AI කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි "
+"විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20946,8 +21104,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI කතාබස් "
-"සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
+"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI "
+"කතාබස් සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20956,8 +21114,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ අහිතකර "
-"තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
+"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ "
+"අහිතකර තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20968,14 +21126,14 @@ msgid ""
 "more info)."
 msgstr ""
 "මෙම සංවාදය DuckDuckGo AI Chat (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sහි %3$s ආකෘතිය "
-"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා "
-"%4$s බලන්න)."
+"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය "
+"(වැඩි විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "මෙම උපාංගය"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -20986,6 +21144,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"මෙම උපාංගයට අනෙකුත් උපාංගවල ඔබගේ සමමුහුර්ත දත්ත වෙත තවදුරටත් ප්‍රවේශ වීමට "
+"නොහැකි වනු ඇත. අවසාන කතාබස් %1$s තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21074,7 +21234,7 @@ msgstr "මෙම තොරතුරු ප්‍රයෝජනවත් නො
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "මෙය බෙදාගත් කතාබහක පිටපතකි."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21083,8 +21243,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එහි මෙනුව (තිත් තුන) විවෘත කර, එය ඔබේ කතාබස්වල ඉහළින්ම තබා "
-"ගැනීමට පින් කරන්න තෝරන්න!"
+"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එහි මෙනුව (තිත් තුන) විවෘත කර, එය ඔබේ "
+"කතාබස්වල ඉහළින්ම තබා ගැනීමට පින් කරන්න තෝරන්න!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21093,7 +21253,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එය මකා දැමීමට පැති මෙනුවේ ඇති Fire Button භාවිතා කරන්න!"
+"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එය මකා දැමීමට පැති මෙනුවේ ඇති Fire Button "
+"භාවිතා කරන්න!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21114,8 +21275,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. අනෙකුත් ආකෘති "
-"සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. "
+"අනෙකුත් ආකෘති සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21124,8 +21285,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. අනෙකුත් ආකෘති සපයන්නන් "
-"සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. "
+"අනෙකුත් ආකෘති සපයන්නන් සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21162,8 +21323,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ සුරකින "
-"අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
+"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය "
+"සමඟ සුරකින අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21172,8 +21333,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
-"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
+"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21183,21 +21344,21 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
-"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ වෙතත්, අපට %1$s හි AI-සහය "
-"සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
+"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ "
+"වෙතත්, අපට %1$s හි AI-සහය සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "මෙම බෙදාගත් කතාබස විවෘත කිරීමට නොහැකි විය. සබැඳිය අසම්පූර්ණ විය හැක."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "මෙම බෙදාගත් කතාබස් සබැඳිය තවදුරටත් ලබා ගත නොහැක."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21236,9 +21397,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup විසන්ධි කරයි. Sync "
-"& Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට "
-"හැකි වනු ඇත."
+"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup "
+"විසන්ධි කරයි. Sync & Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට "
+"තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට හැකි වනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21247,7 +21408,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු හැරවිය නොහැක."
+"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු "
+"හැරවිය නොහැක."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21385,8 +21547,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට අවශ්‍ය මාර්ගය "
-"තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
+"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට "
+"අවශ්‍ය මාර්ගය තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21396,9 +21558,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත කිරීම සැකසීමේ දී සුරකින "
-"ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ "
-"PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
+"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත "
+"කිරීම සැකසීමේ දී සුරකින ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් "
+"වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21407,8 +21569,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය නවතම "
-"අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
+"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය "
+"නවතම අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21416,8 +21578,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ වීමට ඔබේ බ්‍රවුසරයට ඉඩ "
-"දෙන්න."
+"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ "
+"වීමට ඔබේ බ්‍රවුසරයට ඉඩ දෙන්න."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21440,8 +21602,8 @@ msgstr "අද"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"පුද්ගලික AI කතාබස් උත්සාහ කිරීමට ටොගල් කරන්න, නැතහොත් %1$s %2$s මෙනුව තුළින් එය අක්‍රිය කරන්න."
-"%3$s"
+"පුද්ගලික AI කතාබස් උත්සාහ කිරීමට ටොගල් කරන්න, නැතහොත් %1$s %2$s මෙනුව තුළින් "
+"එය අක්‍රිය කරන්න.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21615,8 +21777,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ ප්‍රමාණයක් අවහිර "
-"කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
+"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ "
+"ප්‍රමාණයක් අවහිර කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21664,8 +21826,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
-"කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
+"ශාලාවට යන්නේ කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21674,8 +21836,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
-"කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
+"ශාලාවට යන්නේ කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21840,7 +22002,7 @@ msgstr "නොමිලේ අත්හදා බලන්න"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "නොමිලේ අත්හදා බලන්න!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21922,7 +22084,9 @@ msgstr "වෙනත් වචන සමග උත්සාහ කරන්න."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ කරන්න."
+msgstr ""
+"තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21935,7 +22099,9 @@ msgstr "වඩාත් නිවැරදි ප්‍රතිඵල සඳහ
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා දෙනු ඇත."
+msgstr ""
+"එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා "
+"දෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21959,7 +22125,7 @@ msgstr "නොමිලේ අත්හදා බලන්න"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "නොමිලේ අත්හදා බලන්න!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22153,8 +22319,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
-"No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22163,8 +22329,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
-"No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22206,7 +22372,7 @@ msgstr "තුර්ක්මනිස්තාන්"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "ක්‍රියා විරහිත කරන්න"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22224,7 +22390,7 @@ msgstr "Sync & Backup අක්‍රීය කරන්න"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Sync & Backup අක්‍රීය කර සර්වර දත්ත මකා දමන්න ද?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22365,8 +22531,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත කිරීමෙන් සෙවීමක් සහ "
-"ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
+"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත "
+"කිරීමෙන් සෙවීමක් සහ ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22496,8 +22662,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර %5$sSet "
-"Pages%6$s මත ක්ලික් කරන්න."
+"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර "
+"%5$sSet Pages%6$s මත ක්ලික් කරන්න."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22505,8 +22671,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: https://"
-"duckduckgo.com"
+"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22622,8 +22788,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා 2 ගුණයක් "
-"ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
+"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා "
+"2 ගුණයක් ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22701,7 +22867,7 @@ msgstr "නිශ්ශබ්දතාවය ඉවත්"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "මාතෘකාවක් නොමැති කතාබහ"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22742,7 +22908,7 @@ msgstr "බ්‍රව්සරය යාවත්කාලීන කරන්�
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "මෙම බෙදාගත් කතාබස් බැලීමට Duck.ai යාවත්කාලීන කරන්න."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22781,8 +22947,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට DuckDuckGo බ්‍රවුසරය "
-"යාවත්කාලීන කරන්න"
+"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට "
+"DuckDuckGo බ්‍රවුසරය යාවත්කාලීන කරන්න"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22907,15 +23073,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න, නැත්නම් තවත් "
-"රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත "
+"කරන්න, නැත්නම් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න"
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත "
+"උත්ශ්‍රේණිගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23011,9 +23178,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, වංචාකරුවන් සහ "
-"සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය "
-"නොවේ."
+"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, "
+"වංචාකරුවන් සහ සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා "
+"ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය නොවේ."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23068,8 +23235,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා කරන්න. එය "
-"ආරක්ෂිතව තබා ගන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය "
+"භාවිතා කරන්න. එය ආරක්ෂිතව තබා ගන්න."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23077,8 +23244,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා "
-"කරන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට "
+"මේ කේතය භාවිතා කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23228,8 +23395,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු "
-"ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
+"කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23238,8 +23405,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් TripAdvisor හි "
-"දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
+"කිරීම් TripAdvisor හි දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23251,8 +23418,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist සැකසුම්%2$s "
-"වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist "
+"සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23261,8 +23428,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sDuckAssist "
-"සැකසුම්%2$s වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට "
+"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23271,8 +23438,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති උපදෙස් "
-"පිළිපදින්න."
+"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති "
+"උපදෙස් පිළිපදින්න."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23287,9 +23454,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync & "
-"Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ සමමුහුර්ත "
-"කරන්න%8$s තෝරන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync "
+"& Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ "
+"සමමුහුර්ත කරන්න%8$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23299,9 +23466,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn On” තෝරන්න "
-"Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන "
-"PDF එකේ QR ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn "
+"On” තෝරන්න Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. "
+"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF එකේ QR ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23323,9 +23490,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත "
-"කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් උපාංගයක් සමග සමමුහුර්ත කරන්න” "
-"තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR කේතය ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai "
+"සැකසුම් විවෘත කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් "
+"උපාංගයක් සමග සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR "
+"කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23378,7 +23546,8 @@ msgstr "හඬ කතාබහ අවසන්"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් භාවිතා කරන්නේ නැහැ."
+"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් "
+"භාවිතා කරන්නේ නැහැ."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23522,8 +23691,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ "
-"ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
+"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට "
+"බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23543,9 +23712,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට ඔබව නිරීක්ෂණය කළ "
-"හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ යුතු වීමයි. DuckDuckGo යනු ස්වාධීන "
-"සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
+"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට "
+"ඔබව නිරීක්ෂණය කළ හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ "
+"යුතු වීමයි. DuckDuckGo යනු ස්වාධීන සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන "
+"සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23557,7 +23727,9 @@ msgstr "අපි නිර්නාමික කරමු"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ හැකිය."
+msgstr ""
+"ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23569,9 +23741,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
-"කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
-"හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
+"වාර්තා කිරීමට, කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව "
+"විමර්ශනය කර විසඳා ගත හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23583,15 +23755,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
-"කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
-"හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
+"වාර්තා කිරීමට, කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට "
+"ගැටලුව විමර්ශනය කර විසඳා ගත හැකිය."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr "ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ හැකිය."
+msgstr ""
+"ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -23599,7 +23773,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා කියවිය නොහැක."
+"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා "
+"කියවිය නොහැක."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23615,7 +23790,9 @@ msgstr "අපි පරිශීලක නාම හෝ පුද්ගලි�
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද නැත."
+msgstr ""
+"කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද "
+"නැත."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23627,8 +23804,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට පත් නොකරන්නෙමු. "
-"අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
+"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට "
+"පත් නොකරන්නෙමු. අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23642,8 +23819,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි පැවසුවහොත් එය "
-"අපට උපකාරී වීමට හැක:"
+"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි "
+"පැවසුවහොත් එය අපට උපකාරී වීමට හැක:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23652,8 +23829,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ අපට පැවසීමට "
-"ඔබගේ උදව් භාවිතා කළ හැකිය:"
+"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ "
+"අපට පැවසීමට ඔබගේ උදව් භාවිතා කළ හැකිය:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23693,8 +23870,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම වලට විකිණීමට "
-"කිසිවක් නැත."
+"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම "
+"වලට විකිණීමට කිසිවක් නැත."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23720,6 +23897,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"අපි දත්ත තැරැව්කාර අඩවිවලින් ඔබේ පුද්ගලික තොරතුරු සොයාගෙන ඉවත් කරන්නෙමු. ඊට "
+"අමතරව VPN එකක් සහ තවත් දේ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23728,8 +23907,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ ගිවිසුම් ඇති කරගෙන "
-"ඇත්තෙමු."
+"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ "
+"ගිවිසුම් ඇති කරගෙන ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23754,8 +23933,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ දත්ත සූරාකෑමෙන් "
-"නොවේ."
+"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ "
+"දත්ත සූරාකෑමෙන් නොවේ."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23764,8 +23943,8 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික පිහිටීම භාවිතා "
-"කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
+"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික "
+"පිහිටීම භාවිතා කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -23774,13 +23953,16 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"ඔබේ පෞද්ගලික තොරතුරු සඳහා අපි දත්ත තැරැව්කාර අඩවි නිතිපතා ස්කෑන් කරන අතර, "
+"භාවිතයට පහසු උපකරණ පුවරුවකින් අපගේ ප්‍රගතිය ඔබ සමඟ බෙදා ගන්නෙමු."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත රඳා සිටිමු."
+"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත "
+"රඳා සිටිමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23801,13 +23983,15 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි අභිමතය පරිදි "
-"යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
+"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි "
+"අභිමතය පරිදි යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර කරන්නෙමු."
+msgstr ""
+"ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර "
+"කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -23816,6 +24000,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"අපි ඔබේ විද්‍යුත් තැපෑල, නම, ලිපිනය සහ තවත් දේ සඳහා දත්ත තැරැව්කාර අඩවි "
+"ස්කෑන් කර, ඔබ ගැන සොයා ගන්නා ඕනෑම දෙයක් ඉවත් කිරීමට කටයුතු කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23824,8 +24010,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට මෙම දෝෂය දිගටම "
-"පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට "
+"මෙම දෝෂය දිගටම පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23834,8 +24020,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර විට ඔබගේ "
-"බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර "
+"විට ඔබගේ බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23850,7 +24036,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි මහන්සි වෙමින් සිටිමු."
+"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි "
+"මහන්සි වෙමින් සිටිමු."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23859,7 +24046,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත පූරණය කළ යුතුය."
+"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත "
+"පූරණය කළ යුතුය."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23968,8 +24156,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම කතාබහේ යෙදිය "
-"හැකි ය."
+"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම "
+"කතාබහේ යෙදිය හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23983,8 +24171,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර "
-"ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප "
+"විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23993,8 +24181,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් "
-"නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් "
+"පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24004,15 +24193,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ %1$sගේ %2$s "
-"විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් DuckDuckGo විසින් ගබඩා කර හෝ AI "
-"ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ "
+"%1$sගේ %2$s විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් "
+"DuckDuckGo විසින් ගබඩා කර හෝ AI ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න පුළුවන්."
+msgstr ""
+"නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න "
+"පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24080,8 +24271,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. පිටුව නැවත "
-"ප්‍රවේශනය කර උත්සාහ කරන්න."
+"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. "
+"පිටුව නැවත ප්‍රවේශනය කර උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24096,7 +24287,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ ප්‍රතිවිරෝධතා මොනවාද?"
+"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ "
+"ප්‍රතිවිරෝධතා මොනවාද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24117,8 +24309,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර විකල්ප "
-"මොනවාද."
+"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර "
+"විකල්ප මොනවාද."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24130,7 +24322,7 @@ msgstr "වාරිකවල සමහර වාසි සහ අවාසි �
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Duck.ai වෙතින් ලැබෙන ප්‍රතිලාභ මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24143,10 +24335,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ ප්‍රතිලාභ මොනවා "
-"ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ කිරීම් සහ රහස්‍යතා ආරක්ෂණ "
-"කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික "
-"අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
+"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ "
+"ප්‍රතිලාභ මොනවා ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ "
+"කිරීම් සහ රහස්‍යතා ආරක්ෂණ කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත "
+"පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් "
+"කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24382,7 +24575,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් වන්නේ කෙසේද?"
+"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් "
+"වන්නේ කෙසේද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24483,8 +24677,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම නිෂ්පාදන වෙළඳ නාම "
-"මොනවාද?"
+"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම "
+"නිෂ්පාදන වෙළඳ නාම මොනවාද?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24685,8 +24879,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai සමඟින්, ඔබගේ කතාබස් නිර්නාමික කර ඇති අතර ඒවා කිසි විටෙකත් AI පුහුණු කිරීමට භාවිත "
-"නොකෙරේ. '%1$s' මෙනුව තුළ ඕනෑම වේලාවක එය සක්‍රිය හෝ අක්‍රිය කරන්න."
+"Duck.ai සමඟින්, ඔබගේ කතාබස් නිර්නාමික කර ඇති අතර ඒවා කිසි විටෙකත් AI පුහුණු "
+"කිරීමට භාවිත නොකෙරේ. '%1$s' මෙනුව තුළ ඕනෑම වේලාවක එය සක්‍රිය හෝ අක්‍රිය "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24701,6 +24896,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"ඔබේ විද්‍යුත් තැපැල් ලිපිනය, නම, ලිපිනය සහ තවත් දේ දත්ත තැරැව්කාර අඩවිවලින් "
+"ඉවත් කිරීමට ඔබේ උපාංගයෙන්ම ක්‍රියා කරයි."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24967,7 +25164,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
+msgstr ""
+"ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24976,8 +25175,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර මත කඍජුව %1$s හෝ "
-"සෙවිය හැකිය."
+"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර "
+"මත කඍජුව %1$s හෝ සෙවිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24991,8 +25190,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s තුළ එය "
-"අක්‍රිය කළ හැකිය."
+"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s "
+"තුළ එය අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25001,21 +25200,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය "
-"අක්‍රිය කිරීමට හැකිය."
+"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් "
+"කිරීමට හෝ එය අක්‍රිය කිරීමට හැකිය."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ හැකිය."
+"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s ද භාාවිත "
-"කළ හැකිය."
+"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s "
+"ද භාාවිත කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25029,8 +25229,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, එය "
-"සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
+"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, "
+"එය සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25051,8 +25251,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස පළමු සමූහය "
-"මකනවා."
+"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස "
+"පළමු සමූහය මකනවා."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25145,8 +25345,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම වෙනත් වෙබ් අඩවියක් "
-"අහිතකර කිරීමට අවශ්ය වේ."
+"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම "
+"වෙනත් වෙබ් අඩවියක් අහිතකර කිරීමට අවශ්ය වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25201,7 +25401,7 @@ msgstr "ඔබට උත්සාහයන් 1ක් ඉතිරිව ඇත.
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "ඔබට බෙදාගත් කතාබස් සබැඳි කිසිවක් නැත."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25210,8 +25410,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් පුළුල් පරිශීලන "
-"සීමාවන් ඇත."
+"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් "
+"පුළුල් පරිශීලන සීමාවන් ඇත."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25220,8 +25420,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ අනෙකුත් "
-"DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
+"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ "
+"අනෙකුත් DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25243,9 +25443,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
-"කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
-"නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
+"වනු ඇත. අවසාන කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
+"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25255,9 +25455,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
-"කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
-"නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
+"වනු ඇත. අවසාන කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
+"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25270,7 +25470,9 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr "ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන ලැබෙනු ඇත."
+msgstr ""
+"ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන "
+"ලැබෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -25285,8 +25487,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome වෙනුවට අපගේ යෙදුම භාවිතා "
-"කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome "
+"වෙනුවට අපගේ යෙදුම භාවිතා කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25299,8 +25501,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර ගැනීමට ඉඟි ලබා "
-"ගන්න."
+"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර "
+"ගැනීමට ඉඟි ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25376,8 +25578,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
-"ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
+"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත "
+"කිරීම නැවත ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25387,8 +25590,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත ආරම්භ කිරීමට "
-"ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
+"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
+"ආරම්භ කිරීමට ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25402,8 +25606,9 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. ඒ වගේම, "
-"Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා කිරීමකට ලක් වෙන්න පුළුවන්."
+"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. "
+"ඒ වගේම, Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා "
+"කිරීමකට ලක් වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25424,14 +25629,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
+msgstr "ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල ස්ථානීය ගබඩාවේ ලබා ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "ඔබේ Duck.ai කතාබස් මුල සිට අග දක්වා සංකේතනය සමඟ සමමුහුර්ත වෙමින් පවතී."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25463,6 +25668,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
+"විසන්ධි වනු ඇත."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25472,8 +25679,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
-"ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
+"විසන්ධි වනු ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා "
+"ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25483,8 +25691,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
-"ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
+"විසන්ධි වනු ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත "
+"හැකිය:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25509,8 +25718,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත කිසිවිටෙක මෙම දත්ත "
-"වෙත ප්‍රවේශය නොමැත."
+"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත "
+"කිසිවිටෙක මෙම දත්ත වෙත ප්‍රවේශය නොමැත."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25518,8 +25727,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට කවදාවත් අවසරයක් "
-"නැහැ ඒ දත්ත වලට."
+"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට "
+"කවදාවත් අවසරයක් නැහැ ඒ දත්ත වලට."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25527,7 +25736,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
+msgstr ""
+"%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25540,7 +25751,8 @@ msgstr "ඔබගේ කතාබස් දැන් සුරැකෙමින
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ භාවිත නොකෙරේ"
+"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ "
+"භාවිත නොකෙරේ"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25554,7 +25766,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
+"කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25562,7 +25775,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
+"කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25570,8 +25784,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
+"පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25579,8 +25793,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
+"පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25595,8 +25809,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා කෘත්‍රිම බුද්ධි ආකෘති "
-"පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා ගැනීමට මේ පියවර අනුගමනය කරන්න."
+"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා "
+"කෘත්‍රිම බුද්ධි ආකෘති පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා "
+"ගැනීමට මේ පියවර අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25636,8 +25851,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ සම්බන්ධ කිරීමක් සිදු නොවේ. "
-"[%2$sඋදාහරණ පණිවිඩය%3$s]"
+"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ "
+"සම්බන්ධ කිරීමක් සිදු නොවේ. [%2$sඋදාහරණ පණිවිඩය%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25680,9 +25895,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ මුරපදය 512-bit "
-"යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත සැකසුම් ගොනුව පමණි. යතුර නම ලෙස "
-"භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
+"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ "
+"මුරපදය 512-bit යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත "
+"සැකසුම් ගොනුව පමණි. යතුර නම ලෙස භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. "
+"DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25697,8 +25913,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත හැකි පාර-දත්ත "
-"ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත සම්බන්ධ කළ නොහැක."
+"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත "
+"හැකි පාර-දත්ත ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත "
+"සම්බන්ධ කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25712,8 +25929,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම වේලාවක "
-"ඒවා ඉවත් කළ හැකි ය."
+"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම "
+"වේලාවක ඒවා ඉවත් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25745,8 +25962,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය ස්ථිර කර ගැනීමට "
-"%1$sDuckDuckGo No AI%2$s දිගුව සක්‍රීය කරන්න."
+"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය "
+"ස්ථිර කර ගැනීමට %1$sDuckDuckGo No AI%2$s දිගුව සක්‍රීය කරන්න."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25755,8 +25972,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය ස්ථිර කර ගැනීමට "
-"%1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය "
+"ස්ථිර කර ගැනීමට %1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර "
+"දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25776,8 +25994,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට අපේ බ්‍රවුසරය "
-"භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට "
+"අපේ බ්‍රවුසරය භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25786,7 +26004,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ කරන්න."
+"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25795,8 +26014,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button සමඟ "
-"මෙම සංවාදය ඉවත් කරන්න."
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button "
+"සමඟ මෙම සංවාදය ඉවත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25804,7 +26023,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr "ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ ගන්න."
+msgstr ""
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ "
+"ගන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25819,8 +26040,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම කරගෙන "
-"යන්න."
+"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් "
+"දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sk_SK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Toto zariadenie)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -95,8 +95,7 @@ msgstr "%1$s a %2$s Modely umelej inteligencie"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
+msgstr "%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -107,8 +106,7 @@ msgstr "Pokusy: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
+msgstr "DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -232,8 +230,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
+msgstr "%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -309,8 +306,7 @@ msgstr "Rebríček %1$s ešte nie je k dispozícii"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s dosahuje limity používania 2–5× rýchlejšie ako základné modely. %2$s"
+msgstr "%1$s dosahuje limity používania 2–5× rýchlejšie ako základné modely. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -474,8 +470,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
+msgstr "%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -500,22 +495,20 @@ msgstr "%1$sZistite, ako chránime informácie o vašej polohe%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sZistiť viac%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
+msgstr "%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
+msgstr "%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -527,8 +520,7 @@ msgstr "%1$sDlho stlačte%2$s ikonu aplikácie DuckDuckGo na úvodnej obrazovke"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
+msgstr "%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -795,7 +787,7 @@ msgstr "2. miesto v skupine %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2. názor"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -952,16 +944,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
+msgstr "K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
+msgstr "Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1488,7 +1478,7 @@ msgstr "Pridať na domovskú obrazovku"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Pridať do Mojich četov"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1601,8 +1591,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"Pokročilé modely môžu využiť limity 2-5x rýchlejšie než iné modely. %1$s"
+msgstr "Pokročilé modely môžu využiť limity 2-5x rýchlejšie než iné modely. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1859,7 +1848,7 @@ msgstr "Všetky typy"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Všetky tvoje zariadenia sú odpojené od synchronizácie."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1948,8 +1937,7 @@ msgstr "Už je to synchronizované."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
+msgstr "Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2386,7 +2374,7 @@ msgstr "Spýtaj sa na čokoľvek súkromne"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Spýtaj sa na čokoľvek súkromne"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -3024,8 +3012,7 @@ msgstr "Zablokovať túto stránku vo všetkých výsledkoch"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
+msgstr "Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -5226,8 +5213,7 @@ msgstr "Pokračuj v blokovaní reklám"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Tu pokračuj v nedávnych četoch. Alebo ich vymaž pomocou tlačidla Fire Button."
+msgstr "Tu pokračuj v nedávnych četoch. Alebo ich vymaž pomocou tlačidla Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5334,7 +5320,7 @@ msgstr "Kopírovať"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopírovať"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5345,8 +5331,7 @@ msgstr "Kopírovať"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
+msgstr "Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5384,13 +5369,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Kopírovať zdieľaný odkaz"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Skopíruj kód z iného zariadenia"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5399,6 +5384,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Skopíruj kód z iného zariadenia. Prejdi na %1$sNastavenia Duck.ai › Čety › "
+"Sync & Backup › Synchronizovať s iným zariadením%2$s, a&nbsp;skús to znova."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6085,7 +6072,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Odstrániť zdieľaný odkaz"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6106,6 +6093,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Odkaz po zmazaní prestane fungovať. Ľudia, ktorí si ho otvorili a pridali si "
+"konverzáciu do svojich četov, si svoju kópiu ponechajú."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6367,7 +6356,7 @@ msgstr "Skryť"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Skryť"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6509,8 +6498,7 @@ msgstr "Nevidíte súbor? %1$s%2$s%3$sKliknite sem a stiahnite si ho znova.%4$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr ""
-"Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
+msgstr "Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6874,8 +6862,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
+msgstr "Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7182,8 +7169,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite e-"
-"mailom tento anonymný kód %1$s na adresu %2$s"
+"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite "
+"e-mailom tento anonymný kód %1$s na adresu %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7191,15 +7178,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
+msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
+msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7232,7 +7217,7 @@ msgstr "Prehliadač DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Stránky pomoci DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7368,8 +7353,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
+msgstr "DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7582,8 +7566,7 @@ msgstr "Upravujem obrázok..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
+msgstr "Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -8067,7 +8050,7 @@ msgstr "Odborne vyrobené produkty pre ľudí, ktorým záleží na súkromí."
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Platnosť vypršala"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8081,7 +8064,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Vyprší %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8489,8 +8472,7 @@ msgstr "Finančný poradca"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
+msgstr "Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8502,8 +8484,7 @@ msgstr "Nájdi <b>%1$s</b> v&nbsp;tvojom priečinku so&nbsp;stiahnutými súborm
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
+msgstr "Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8978,8 +8959,7 @@ msgstr "Všeobecná umelá inteligencia s vysokou mierou moderovania"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
+msgstr "Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -9356,8 +9336,8 @@ msgstr "Získaj aplikáciu"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Získaj bezplatný prehliadač DuckDuckGo %1$sna blokovanie reklám na YouTube."
-"%2$s"
+"Získaj bezplatný prehliadač DuckDuckGo %1$sna blokovanie reklám na "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9462,13 +9442,14 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Prejdi na %1$sNastavenia Duck.ai%2$s › %3$sČety › Sync & Backup › "
+"Synchronizovať s&nbsp;iným zariadením%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
+msgstr "Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9578,7 +9559,7 @@ msgstr "Rozumiem"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Rozumiem"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10296,8 +10277,7 @@ msgstr "Otvárací čas chýba"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
+msgstr "Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -11163,8 +11143,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
+msgstr "Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11214,8 +11193,7 @@ msgstr "Je to rýchly, bezplatný a poskytuje ti ešte väčšiu ochranu online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
+msgstr "Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11558,7 +11536,7 @@ msgstr "Viac %1$sinformácií%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Zisti viac"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11673,8 +11651,7 @@ msgstr "Viac informácií o tom, ako to funguje"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
+msgstr "Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11737,8 +11714,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Umožní ti prepínať medzi odosielaním vyhľadávacích dopytov a výziev do Duck."
-"ai"
+"Umožní ti prepínať medzi odosielaním vyhľadávacích dopytov a výziev do "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12201,7 +12178,7 @@ msgstr "Spravujte stránku"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Spravovať"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12458,7 +12435,7 @@ msgstr "Ponuka"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Správy od tohto miesta sú viditeľné iba pre teba."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12834,7 +12811,7 @@ msgstr "Viac o Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Ďalšie akcie"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13034,7 +13011,7 @@ msgstr "Tlmená červená"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Moje zariadenia"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14111,6 +14088,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Na inom zariadení prejdi na %1$sNastavenia Duck.ai%2$s › %3$sČety › Sync & "
+"Backup › Synchronizovať s&nbsp;iným zariadením%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14119,6 +14098,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Na inom zariadení prejdi na %1$sNastavenia Duck.ai%2$s › %3$sČety › Sync & "
+"Backup › Synchronizovať s&nbsp;iným zariadením%4$s a naskenuj tento kód:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14127,6 +14108,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Na inom zariadení prejdi na %1$sNastavenia Duck.ai%2$s › %3$sČety › Sync & "
+"Backup › Synchronizovať s&nbsp;iným zariadením%4$s. Alebo naskenuj QR kód vo "
+"svojom Recovery PDF."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14197,8 +14181,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
+msgstr "Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14277,8 +14260,7 @@ msgstr "Otvorte položku Poloha a uistite sa, že je poloha %1$szapnutá%2$s."
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Privacy', then 'Location Services'."
-msgstr ""
-"Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
+msgstr "Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
 
 # smartling.placeholder_format=C
 #. Indicates a business is open 24 hours a day.
@@ -14421,8 +14403,7 @@ msgstr "Otvoriť panel Ako funguje Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
+msgstr "Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14882,7 +14863,7 @@ msgstr "Minulý rok"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Vložiť"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14900,7 +14881,7 @@ msgstr "Vložiť kód synchronizácie"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Vlož ho nižšie"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14959,7 +14940,7 @@ msgstr "Perzština"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14968,6 +14949,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal nájde tvoje údaje na stránkach "
+"sprostredkovateľov údajov, ktorí ich predávajú. Potom pracujeme na tom, aby "
+"sme ich za teba odstránili."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15246,8 +15230,7 @@ msgstr "Popíš, prečo je odpoveď v chate škodlivá alebo nezákonná. (nepov
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
+msgstr "Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -16239,7 +16222,7 @@ msgstr "Načítava sa webová stránka..."
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Si pripravený/-á na zatmenie slnka?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16281,8 +16264,7 @@ msgstr "Uvažovanie môže poskytnúť lepšie odpovede na zložité otázky."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Uvažovanie je dôkladnejšie, ale limity používania dosiahne 2–5× skôr. %1$s"
+msgstr "Uvažovanie je dôkladnejšie, ale limity používania dosiahne 2–5× skôr. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16435,7 +16417,7 @@ msgstr "Kód obnovy"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Kód obnovy"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16692,7 +16674,7 @@ msgstr "Odstrániť %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Odstránenie zariadenia"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16740,13 +16722,13 @@ msgstr "Odstráň zbytočnú interpunkciu"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Odstráň svoje informácie z internetu"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Odstráň svoje informácie online"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17405,8 +17387,7 @@ msgstr "Ulož si až 30 svojich najnovších chatov lokálne do svojho zariad
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
+msgstr "Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17442,7 +17423,7 @@ msgstr "Pozdrav Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Pozdrav Duck.ai – bezplatný, súkromný AI čet od DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17597,8 +17578,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
+msgstr "Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17754,8 +17734,7 @@ msgstr "Viditeľnosť vyhľadávania"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
+msgstr "Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -17891,8 +17870,7 @@ msgstr "Vyhľadávajte cez DuckDuckGo"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
+msgstr "Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -17942,8 +17920,7 @@ msgstr "Druhý názor"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
+msgstr "Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17972,8 +17949,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou end-"
-"to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných zariadení."
+"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou "
+"end-to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných "
+"zariadení."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18177,15 +18155,13 @@ msgstr "Vyberte %1$sDuckDuckGo%2$s a potom %3$sPridať ako predvolené%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
+msgstr "V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
+msgstr "V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18450,7 +18426,7 @@ msgstr "Srbčina (latinka)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Údaje servera boli zmazané"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18612,7 +18588,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Zdieľať"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18629,8 +18605,7 @@ msgstr "Zdieľať"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
+msgstr "Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18768,13 +18743,13 @@ msgstr "Podeľ sa o svoj názor na vyhľadávacie pole."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Zdieľané odkazy na čety"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Zdieľané odkazy na čety"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18904,8 +18879,7 @@ msgstr "Zobraziť DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
+msgstr "Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19165,8 +19139,7 @@ msgstr "Zobraziť vodorovné čiary medzi stránkami vo výsledkoch vyhľadávan
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
+msgstr "Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19182,14 +19155,12 @@ msgstr "Zobraziť najnavštevovanejšie odkazy na novej karte"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
+msgstr "Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
+msgstr "Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19220,8 +19191,7 @@ msgstr "Zobrazovať návrhy pod vyhľadávacím poľom pri písaní"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
+msgstr "Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19231,8 +19201,7 @@ msgstr "Zobraziť pozadie tlačidla Hľadať"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
+msgstr "Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19463,7 +19432,7 @@ msgstr "Vyskytla sa chyba"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Pri načítavaní tohto zdieľaného četu sa vyskytla chyba."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19543,8 +19512,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
+msgstr "Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19578,8 +19546,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
+msgstr "Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19633,8 +19600,7 @@ msgstr "Zdrojový text bol vymazaný"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
+msgstr "Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19900,8 +19866,7 @@ msgstr "Zablokujte skryté sledovače, ktoré na vás číhajú na iných weboch
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
+msgstr "Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20319,7 +20284,7 @@ msgstr "Model prepínača"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Prepnúť model"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20398,8 +20363,7 @@ msgstr "Prepnuté na %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
+msgstr "Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20584,7 +20548,7 @@ msgstr "Synchronizované zariadenia"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Synchronizované na %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20622,7 +20586,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabuľka"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20690,8 +20654,7 @@ msgstr "Získajte späť kontrolu nad svojimi osobnými údajmi!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
+msgstr "Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20997,8 +20960,7 @@ msgstr "Uplynul časový limit žiadosti. Skús to znova."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
+msgstr "Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -21117,8 +21079,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
+msgstr "Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21211,7 +21172,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Toto zariadenie"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21222,6 +21183,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Toto zariadenie už nebude mať prístup k tvojim synchronizovaným údajom na "
+"iných zariadeniach. Posledných %1$s četov zostane stále k dispozícii "
+"na lokálnom úložisku."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21310,7 +21274,7 @@ msgstr "Tieto informácie nie sú užitočné"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Toto je kópia zdieľaného četu."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21430,13 +21394,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Tento zdieľaný čet sa nepodarilo otvoriť. Odkaz môže byť neúplný."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Tento zdieľaný odkaz na čet už nie je k dispozícii."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21459,8 +21423,7 @@ msgstr "Tento preklad je nesprávny"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
+msgstr "Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21583,8 +21546,8 @@ msgstr "Tipy"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme vám."
-"%2$s"
+"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme "
+"vám.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21632,8 +21595,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete vytlačiť."
-"%3$sKliknite na ikonu tlače.%4$s"
+"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete "
+"vytlačiť.%3$sKliknite na ikonu tlače.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21687,8 +21650,7 @@ msgstr "Dnes"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"Prepnutím vyskúšaj súkromný AI čet alebo ho %1$svypni v ponuke %2$s.%3$s"
+msgstr "Prepnutím vyskúšaj súkromný AI čet alebo ho %1$svypni v ponuke %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22089,7 +22051,7 @@ msgstr "Vyskúšať zadarmo"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Vyskúšaj to zadarmo!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22171,15 +22133,13 @@ msgstr "Skúste iné kľúčové slová."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
+msgstr "Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
+msgstr "Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22210,7 +22170,7 @@ msgstr "Vyskúšaj to zadarmo"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Vyskúšaj to zadarmo!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22460,7 +22420,7 @@ msgstr "Turkménsko"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Vypnúť"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22478,7 +22438,7 @@ msgstr "Vypnúť Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Chceš vypnúť Sync & Backup a&nbsp;zmazať údaje zo&nbsp;servera?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22544,8 +22504,7 @@ msgstr "Vypnúť:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
+msgstr "Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -22568,8 +22527,7 @@ msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Presná 
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
+msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22775,14 +22733,13 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: https://"
-"duckduckgo.com."
+"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: "
+"https://duckduckgo.com."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr ""
-"Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
+msgstr "Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22795,8 +22752,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
+msgstr "Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22810,8 +22766,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
+msgstr "V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22970,7 +22925,7 @@ msgstr "Odtlmiť"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Čet bez názvu"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23011,7 +22966,7 @@ msgstr "Aktualizovať prehliadač"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Aktualizuj Duck.ai na zobrazenie tohto zdieľaného četu."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -24001,6 +23956,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Nájdeme a odstránime tvoje osobné údaje zo stránok sprostredkovateľov "
+"údajov. Získaj k tomu VPN a ďalšie výhody."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24055,6 +24012,9 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Pravidelne skenujeme stránky sprostredkovateľov údajov, kde vyhľadávame "
+"tvoje osobné údaje, a o našom napredovaní ťa informujeme v jednoducho "
+"použiteľnom paneli."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24100,6 +24060,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Prekontrolujeme stránky sprostredkovateľov údajov a vyhľadáme tvoj e-mail, "
+"meno, adresu a ďalšie údaje, a budeme pracovať na odstránení všetkého, čo "
+"o tebe nájdeme."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24410,8 +24373,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
+msgstr "Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24423,7 +24385,7 @@ msgstr "Aké sú výhody a nevýhody anuít?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Aké sú výhody Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24787,8 +24749,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
+msgstr "Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24806,8 +24767,7 @@ msgstr "Kde sledovať <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
+msgstr "Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24847,8 +24807,7 @@ msgstr "Kto sme"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
-"Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
+msgstr "Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25002,6 +24961,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Funguje priamo z tvojho zariadenia a odstraňuje tvoju e-mailovú adresu, "
+"meno, adresu a ďalšie údaje zo stránok sprostredkovateľov údajov."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25507,7 +25468,7 @@ msgstr "Zostáva vám 1 pokus."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Nemáš žiadne zdieľané odkazy na čet."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25738,13 +25699,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Tvojich %1$s posledných četov bude k dispozícii na lokálnom úložisku "
+"v týchto prehliadačoch:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Tvoje čety Duck.ai sa synchronizujú pomocou šifrovania typu end-to-end."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25776,6 +25739,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Tvoja záloha bude vymazaná zo servera DuckDuckGo. Všetky zariadenia budú "
+"odpojené od synchronizácie."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25815,8 +25780,7 @@ msgstr "Podľa vášho prehliadača ste tento odkaz už otvorili."
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
+msgstr "Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -25865,8 +25829,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
+msgstr "Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25927,8 +25890,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
+msgstr "Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26116,8 +26078,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
+msgstr "Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26455,8 +26416,7 @@ msgstr "oficiálnej webovej stránky"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
+msgstr "alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sk_SK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% plne zaočkovaných"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% zaočkovaných"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -87,7 +95,8 @@ msgstr "%1$s a %2$s Modely umelej inteligencie"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr "%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
+msgstr ""
+"%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -98,7 +107,8 @@ msgstr "Pokusy: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr "DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
+msgstr ""
+"DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -222,7 +232,8 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
+msgstr ""
+"%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -298,7 +309,8 @@ msgstr "Rebríček %1$s ešte nie je k dispozícii"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s dosahuje limity používania 2–5× rýchlejšie ako základné modely. %2$s"
+msgstr ""
+"%1$s dosahuje limity používania 2–5× rýchlejšie ako základné modely. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -462,7 +474,8 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr "%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
+msgstr ""
+"%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -483,17 +496,26 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sZistite, ako chránime informácie o vašej polohe%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
+msgstr ""
+"%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
+msgstr ""
+"%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -505,7 +527,8 @@ msgstr "%1$sDlho stlačte%2$s ikonu aplikácie DuckDuckGo na úvodnej obrazovke"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
+msgstr ""
+"%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -769,6 +792,12 @@ msgid "2nd in Group %s"
 msgstr "2. miesto v skupine %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -923,14 +952,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
+msgstr ""
+"K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
+msgstr ""
+"Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1454,6 +1485,12 @@ msgid "Add to Home Screen"
 msgstr "Pridať na domovskú obrazovku"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Doplnky"
@@ -1564,7 +1601,8 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "Pokročilé modely môžu využiť limity 2-5x rýchlejšie než iné modely. %1$s"
+msgstr ""
+"Pokročilé modely môžu využiť limity 2-5x rýchlejšie než iné modely. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1817,6 +1855,13 @@ msgid "All types"
 msgstr "Všetky typy"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1903,7 +1948,8 @@ msgstr "Už je to synchronizované."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
+msgstr ""
+"Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2335,6 +2381,12 @@ msgstr "Opýtaj sa na túto stránku"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask anything privately"
 msgstr "Spýtaj sa na čokoľvek súkromne"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2972,7 +3024,8 @@ msgstr "Zablokovať túto stránku vo všetkých výsledkoch"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
+msgstr ""
+"Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -5173,7 +5226,8 @@ msgstr "Pokračuj v blokovaní reklám"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "Tu pokračuj v nedávnych četoch. Alebo ich vymaž pomocou tlačidla Fire Button."
+msgstr ""
+"Tu pokračuj v nedávnych četoch. Alebo ich vymaž pomocou tlačidla Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5277,6 +5331,12 @@ msgid "Copy"
 msgstr "Kopírovať"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5285,7 +5345,8 @@ msgstr "Kopírovať"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
+msgstr ""
+"Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5316,6 +5377,28 @@ msgstr "Skopíruj alebo si ulož tento kód"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Kopírovať kód obnovy"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5997,6 +6080,14 @@ msgid "Delete recent chats?"
 msgstr "Zmazať nedávne chaty?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6007,6 +6098,14 @@ msgstr "Zmazať tento chat?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Odstránené chaty"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6264,6 +6363,13 @@ msgid "Dismiss"
 msgstr "Skryť"
 
 # smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
 msgctxt "duckassist"
 msgid "Dismiss"
@@ -6403,7 +6509,8 @@ msgstr "Nevidíte súbor? %1$s%2$s%3$sKliknite sem a stiahnite si ho znova.%4$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr "Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
+msgstr ""
+"Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6767,7 +6874,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
+msgstr ""
+"Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7074,8 +7182,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite "
-"e-mailom tento anonymný kód %1$s na adresu %2$s"
+"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite e-"
+"mailom tento anonymný kód %1$s na adresu %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7083,13 +7191,15 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
+msgstr ""
+"DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
+msgstr ""
+"DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7116,6 +7226,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Prehliadač DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7251,7 +7368,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
+msgstr ""
+"DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7464,7 +7582,8 @@ msgstr "Upravujem obrázok..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
+msgstr ""
+"Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7944,10 +8063,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "Odborne vyrobené produkty pre ľudí, ktorým záleží na súkromí."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Platnosť vypršala"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8355,7 +8489,8 @@ msgstr "Finančný poradca"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
+msgstr ""
+"Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8367,7 +8502,8 @@ msgstr "Nájdi <b>%1$s</b> v&nbsp;tvojom priečinku so&nbsp;stiahnutými súborm
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
+msgstr ""
+"Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8842,7 +8978,8 @@ msgstr "Všeobecná umelá inteligencia s vysokou mierou moderovania"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
+msgstr ""
+"Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -9219,8 +9356,8 @@ msgstr "Získaj aplikáciu"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Získaj bezplatný prehliadač DuckDuckGo %1$sna blokovanie reklám na "
-"YouTube.%2$s"
+"Získaj bezplatný prehliadač DuckDuckGo %1$sna blokovanie reklám na YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9319,10 +9456,19 @@ msgstr ""
 "iným zariadením%4$s. Alebo naskenuj QR kód vo svojom Recovery PDF."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
+msgstr ""
+"Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9427,6 +9573,12 @@ msgstr "Rozumiem"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Rozumiem"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10144,7 +10296,8 @@ msgstr "Otvárací čas chýba"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr "Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
+msgstr ""
+"Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -11010,7 +11163,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
+msgstr ""
+"Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11060,7 +11214,8 @@ msgstr "Je to rýchly, bezplatný a poskytuje ti ešte väčšiu ochranu online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
+msgstr ""
+"Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11400,6 +11555,12 @@ msgid "Learn %sMore%s"
 msgstr "Viac %1$sinformácií%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11512,7 +11673,8 @@ msgstr "Viac informácií o tom, ako to funguje"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
+msgstr ""
+"Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11575,8 +11737,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Umožní ti prepínať medzi odosielaním vyhľadávacích dopytov a výziev do "
-"Duck.ai"
+"Umožní ti prepínať medzi odosielaním vyhľadávacích dopytov a výziev do Duck."
+"ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12035,6 +12197,13 @@ msgid "Manage"
 msgstr "Spravujte stránku"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12284,6 +12453,12 @@ msgstr "Ponuka"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Ponuka"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12656,6 +12831,12 @@ msgid "More about Duck.ai"
 msgstr "Viac o Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Viac na"
@@ -12848,6 +13029,12 @@ msgstr "Stlmené"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Tlmená červená"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13918,6 +14105,30 @@ msgstr ""
 "vyberte %3$sikonu %4$s > Nastavenia%5$s."
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -13986,7 +14197,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
+msgstr ""
+"Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14065,7 +14277,8 @@ msgstr "Otvorte položku Poloha a uistite sa, že je poloha %1$szapnutá%2$s."
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Privacy', then 'Location Services'."
-msgstr "Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
+msgstr ""
+"Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
 
 # smartling.placeholder_format=C
 #. Indicates a business is open 24 hours a day.
@@ -14208,7 +14421,8 @@ msgstr "Otvoriť panel Ako funguje Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
+msgstr ""
+"Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14665,6 +14879,12 @@ msgid "Past year"
 msgstr "Minulý rok"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14675,6 +14895,12 @@ msgstr "Vložiť"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Vložiť kód synchronizácie"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14728,6 +14954,20 @@ msgstr "Trvalo zatvorené"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Perzština"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15006,7 +15246,8 @@ msgstr "Popíš, prečo je odpoveď v chate škodlivá alebo nezákonná. (nepov
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
+msgstr ""
+"Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15995,6 +16236,12 @@ msgid "Reading website…"
 msgstr "Načítava sa webová stránka..."
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16034,7 +16281,8 @@ msgstr "Uvažovanie môže poskytnúť lepšie odpovede na zložité otázky."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Uvažovanie je dôkladnejšie, ale limity používania dosiahne 2–5× skôr. %1$s"
+msgstr ""
+"Uvažovanie je dôkladnejšie, ale limity používania dosiahne 2–5× skôr. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16182,6 +16430,12 @@ msgstr "Obnoviť"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Kód obnovy"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16435,6 +16689,12 @@ msgid "Remove %s"
 msgstr "Odstrániť %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16475,6 +16735,18 @@ msgstr "Odstrániť vybraný text"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Odstráň zbytočnú interpunkciu"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17133,7 +17405,8 @@ msgstr "Ulož si až 30 svojich najnovších chatov lokálne do svojho zariad
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
+msgstr ""
+"Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17164,6 +17437,12 @@ msgstr "Uložte svoje nastavenia anonymne do cloudu"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Pozdrav Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17318,7 +17597,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
+msgstr ""
+"Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17474,7 +17754,8 @@ msgstr "Viditeľnosť vyhľadávania"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr "Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
+msgstr ""
+"Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -17610,7 +17891,8 @@ msgstr "Vyhľadávajte cez DuckDuckGo"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr "Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
+msgstr ""
+"Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -17660,7 +17942,8 @@ msgstr "Druhý názor"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
+msgstr ""
+"Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17689,9 +17972,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou "
-"end-to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných "
-"zariadení."
+"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou end-"
+"to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných zariadení."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17895,13 +18177,15 @@ msgstr "Vyberte %1$sDuckDuckGo%2$s a potom %3$sPridať ako predvolené%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
+msgstr ""
+"V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
+msgstr ""
+"V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18162,6 +18446,13 @@ msgid "Serbian (Latin)"
 msgstr "Srbčina (latinka)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18316,6 +18607,14 @@ msgid "Share"
 msgstr "Zdieľať"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18330,7 +18629,8 @@ msgstr "Zdieľať"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
+msgstr ""
+"Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18465,6 +18765,18 @@ msgid "Share your thoughts on the search box."
 msgstr "Podeľ sa o svoj názor na vyhľadávacie pole."
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
@@ -18592,7 +18904,8 @@ msgstr "Zobraziť DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
+msgstr ""
+"Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18852,7 +19165,8 @@ msgstr "Zobraziť vodorovné čiary medzi stránkami vo výsledkoch vyhľadávan
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
+msgstr ""
+"Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18868,12 +19182,14 @@ msgstr "Zobraziť najnavštevovanejšie odkazy na novej karte"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
+msgstr ""
+"Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
+msgstr ""
+"Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18904,7 +19220,8 @@ msgstr "Zobrazovať návrhy pod vyhľadávacím poľom pri písaní"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
+msgstr ""
+"Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18914,7 +19231,8 @@ msgstr "Zobraziť pozadie tlačidla Hľadať"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
+msgstr ""
+"Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19142,6 +19460,12 @@ msgid "Something went wrong"
 msgstr "Vyskytla sa chyba"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19219,7 +19543,8 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
+msgstr ""
+"Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19253,7 +19578,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
+msgstr ""
+"Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19307,7 +19633,8 @@ msgstr "Zdrojový text bol vymazaný"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
+msgstr ""
+"Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19573,7 +19900,8 @@ msgstr "Zablokujte skryté sledovače, ktoré na vás číhajú na iných weboch
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
+msgstr ""
+"Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19988,6 +20316,12 @@ msgid "Switch model"
 msgstr "Model prepínača"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20064,7 +20398,8 @@ msgstr "Prepnuté na %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
+msgstr ""
+"Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20245,6 +20580,13 @@ msgid "Synced Devices"
 msgstr "Synchronizované zariadenia"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Sýria"
 
@@ -20275,6 +20617,12 @@ msgstr "TBD"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20342,7 +20690,8 @@ msgstr "Získajte späť kontrolu nad svojimi osobnými údajmi!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
+msgstr ""
+"Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20648,7 +20997,8 @@ msgstr "Uplynul časový limit žiadosti. Skús to znova."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr "Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
+msgstr ""
+"Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -20767,7 +21117,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
+msgstr ""
+"Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20857,6 +21208,22 @@ msgstr ""
 "časti %4$s)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20938,6 +21305,12 @@ msgstr "Tento typ obrázka nie je podporovaný, pripoj JPG, PNG, WebP alebo GIF.
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Tieto informácie nie sú užitočné"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21054,6 +21427,18 @@ msgstr ""
 "nikdy nezobrazujú odpovede vytvorené pomocou AI."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21074,7 +21459,8 @@ msgstr "Tento preklad je nesprávny"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
+msgstr ""
+"Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21197,8 +21583,8 @@ msgstr "Tipy"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme "
-"vám.%2$s"
+"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme vám."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21246,8 +21632,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete "
-"vytlačiť.%3$sKliknite na ikonu tlače.%4$s"
+"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete vytlačiť."
+"%3$sKliknite na ikonu tlače.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21301,7 +21687,8 @@ msgstr "Dnes"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "Prepnutím vyskúšaj súkromný AI čet alebo ho %1$svypni v ponuke %2$s.%3$s"
+msgstr ""
+"Prepnutím vyskúšaj súkromný AI čet alebo ho %1$svypni v ponuke %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21699,6 +22086,12 @@ msgid "Try Free"
 msgstr "Vyskúšať zadarmo"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21778,13 +22171,15 @@ msgstr "Skúste iné kľúčové slová."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
+msgstr ""
+"Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
+msgstr ""
+"Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21810,6 +22205,12 @@ msgstr "Vyskúšaj to zadarmo"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Vyskúšaj to zadarmo"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22056,6 +22457,12 @@ msgid "Turkmenistan"
 msgstr "Turkménsko"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22066,6 +22473,12 @@ msgstr "Vypnúť Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Vypnúť Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22131,7 +22544,8 @@ msgstr "Vypnúť:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
+msgstr ""
+"Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -22154,7 +22568,8 @@ msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Presná 
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
+msgstr ""
+"Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22360,13 +22775,14 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: "
-"https://duckduckgo.com."
+"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: https://"
+"duckduckgo.com."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr "Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
+msgstr ""
+"Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22379,7 +22795,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
+msgstr ""
+"Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22393,7 +22810,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
+msgstr ""
+"V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22549,6 +22967,12 @@ msgid "Unmute"
 msgstr "Odtlmiť"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22582,6 +23006,12 @@ msgstr "Aktualizovať"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Aktualizovať prehliadač"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23565,6 +23995,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Ukončili sme čet z dôvodu nečinnosti. Chceš to skúsiť znova?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23611,6 +24049,14 @@ msgstr ""
 "okolia. Toto nastavenie môžete kedykoľvek zmeniť."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23646,6 +24092,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Zablokujeme sledovače, ktoré sa pokúsia zhromažďovať vaše údaje, kým "
 "prehliadate web."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23956,13 +24410,20 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
+msgstr ""
+"Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Aké sú výhody a nevýhody anuít?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24326,7 +24787,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
+msgstr ""
+"Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24344,7 +24806,8 @@ msgstr "Kde sledovať <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
+msgstr ""
+"Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24384,7 +24847,8 @@ msgstr "Kto sme"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr "Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
+msgstr ""
+"Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24530,6 +24994,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Bez nulovej viditeľnosti poskytovateľa"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25031,6 +25503,13 @@ msgid "You have 1 attempt left."
 msgstr "Zostáva vám 1 pokus."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25251,6 +25730,23 @@ msgid "YouTube Standard"
 msgstr "Štandardná licencia YouTube"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Vaša história vyhľadávania v DuckDuckGo je súkromná"
@@ -25272,6 +25768,14 @@ msgstr "Vaša skutočná poloha zostane súkromná"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Tvoja skutočná poloha zostane súkromná."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25311,7 +25815,8 @@ msgstr "Podľa vášho prehliadača ste tento odkaz už otvorili."
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr "Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
+msgstr ""
+"Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -25360,7 +25865,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
+msgstr ""
+"Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25421,7 +25927,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
+msgstr ""
+"Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25609,7 +26116,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
+msgstr ""
+"Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25947,7 +26455,8 @@ msgstr "oficiálnej webovej stránky"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
+msgstr ""
+"alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sl_SI\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -41,6 +42,14 @@ msgstr "% polno cepljenih"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% cepljenih"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -487,6 +496,13 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sPreberite, kako vašo lokacijo ohranjamo zasebno%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -507,13 +523,15 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
+msgstr ""
+"%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
+msgstr ""
+"%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -777,6 +795,12 @@ msgid "2nd in Group %s"
 msgstr "2. mesto v skupini %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -858,7 +882,8 @@ msgstr "Dosežena je 6-urna omejitev uporabe."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -938,7 +963,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
+msgstr ""
+"Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1461,6 +1487,12 @@ msgid "Add to Home Screen"
 msgstr "Dodaj na Domači Zaslon"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Dodatki"
@@ -1571,7 +1603,8 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "Napredni modeli lahko porabijo omejitve 2–5× hitreje kot drugi modeli. %1$s"
+msgstr ""
+"Napredni modeli lahko porabijo omejitve 2–5× hitreje kot drugi modeli. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1822,6 +1855,13 @@ msgstr "Vse velikosti"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Vse vrste"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2205,7 +2245,8 @@ msgstr "Ali ste prepričani, da želite izbrisati ta pogovor in začeti novega?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
+msgstr ""
+"Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2343,6 +2384,12 @@ msgstr "Vprašaj o tej strani"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask anything privately"
 msgstr "Vprašajte kar koli zasebno"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2568,7 +2615,8 @@ msgstr "Samodejno odgovarjanje"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
+msgstr ""
+"Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2976,7 +3024,8 @@ msgstr "Blokiraj to spletno mesto v vseh rezultatih"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
+msgstr ""
+"Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3858,8 +3907,8 @@ msgstr ""
 "klepeta z umetno inteligenco tretjih oseb, ki podpirajo modele OpenAI, "
 "Anthropic in druge. Če to nastavitev izklopiš, bodo gumbi in povezave za "
 "klepet v iskalniku DuckDuckGo skriti. Vendar pa lahko še vedno dostopaš do "
-"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš "
-"%1$shttps://duck.ai%2$s neposredno."
+"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš %1$shttps://duck."
+"ai%2$s neposredno."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4497,7 +4546,8 @@ msgstr "Kliknite %1$stukaj%2$s za prenos razširitve DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
+msgstr ""
+"Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4530,7 +4580,8 @@ msgstr "Kliknite %1$sNastavitve%2$s v spustnem meniju."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
+msgstr ""
+"Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5173,7 +5224,8 @@ msgstr "Nadaljuj blokiranje oglasov"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "Nadaljujte nedavne klepete tukaj. Ali pa jih izbrišite z gumbom Fire Button."
+msgstr ""
+"Nadaljujte nedavne klepete tukaj. Ali pa jih izbrišite z gumbom Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5277,6 +5329,12 @@ msgid "Copy"
 msgstr "Kopiraj"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5285,7 +5343,8 @@ msgstr "Kopiraj"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
+msgstr ""
+"Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5316,6 +5375,28 @@ msgstr "Kopirajte ali shranite to kodo"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Kopiraj obnovitveno kodo"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5701,7 +5782,8 @@ msgstr "Dosežena je dnevna omejitev"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5999,6 +6081,14 @@ msgid "Delete recent chats?"
 msgstr "Želite izbrisati nedavne klepete?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6009,6 +6099,14 @@ msgstr "Želite izbrisati ta klepet?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Izbrisani klepeti"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6266,6 +6364,13 @@ msgstr "Opusti"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Opusti"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6680,7 +6785,8 @@ msgstr "Spustite svoje fotografije ali datoteke PDF"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
+msgstr ""
+"Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6726,7 +6832,8 @@ msgstr "pogoji storitve Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
+msgstr ""
+"Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6772,7 +6879,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
+msgstr ""
+"Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6908,7 +7016,8 @@ msgstr "Duck.ai je nadgrajen!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
+msgstr ""
+"Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7085,7 +7194,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
+msgstr ""
+"DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7118,6 +7228,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Brskalnik DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7469,7 +7586,8 @@ msgstr "Urejanje slike ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
+msgstr ""
+"Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7530,7 +7648,8 @@ msgstr "Omogoči funkcije UI"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
+msgstr ""
+"Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7742,7 +7861,8 @@ msgstr "Prepričajte se, da so »Lokacijske storitve« %1$somogočene%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
+msgstr ""
+"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7754,7 +7874,8 @@ msgstr "Preverite, ali je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
+msgstr ""
+"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7778,7 +7899,8 @@ msgstr "Prepričajte se, da ima brskalnik omogočen %1$sdostop do lokacije%2$s."
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr "Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
+msgstr ""
+"Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7884,7 +8006,8 @@ msgstr "Ekvatorialna Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
+msgstr ""
+"V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7947,10 +8070,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "Vrhunsko zasnovani izdelki za ljudi, ki jim je mar za zasebnost."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Preteklo"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8594,7 +8732,8 @@ msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
+msgstr ""
+"Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9311,8 +9450,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve "
-"Duck.ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
+"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve Duck."
+"ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
 "napravo%4$s ter optično preberite to kodo:"
 
 # smartling.placeholder_format=C
@@ -9326,6 +9465,14 @@ msgstr ""
 "Pojdite v %1$sNastavitve Duck.ai%2$s v drugem brskalniku ali aplikaciji "
 "DuckDuckGo in odprite %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
 "napravo%4$s. Ali pa skenirajte kodo QR v svojem obnovitvenem PDF-ju."
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9436,6 +9583,12 @@ msgstr "Razumem"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Razumem"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10250,7 +10403,8 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
+msgstr ""
+"Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10697,7 +10851,8 @@ msgstr "V zgornjem meniju izberite %1$sOrodja%2$s > %3$sNastavitve%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
+msgstr ""
+"V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11023,7 +11178,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
+msgstr ""
+"Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11073,7 +11229,8 @@ msgstr "Je hiter, brezplačen in zagotavlja še večjo spletno zaščito."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
+msgstr ""
+"Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11413,6 +11570,12 @@ msgid "Learn %sMore%s"
 msgstr "%1$sVeč%2$s o tem"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11585,7 +11748,8 @@ msgstr "Omogoča anonimno iskanje z DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Omogoča preklapljanje med pošiljanjem iskalnih poizvedb in pozivov v Duck.ai"
+msgstr ""
+"Omogoča preklapljanje med pošiljanjem iskalnih poizvedb in pozivov v Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12046,6 +12210,13 @@ msgid "Manage"
 msgstr "Upravljanje"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12295,6 +12466,12 @@ msgstr "Meni"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Meni"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12557,7 +12734,8 @@ msgstr "Dosežena je mesečna omejitev"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12665,6 +12843,12 @@ msgid "More about Duck.ai"
 msgstr "Več o Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Več na"
@@ -12725,7 +12909,8 @@ msgstr "Več statističnih podatkov o medaljah je na voljo na %1$s"
 msgctxt ""
 "Note on the Olympics module as to where they can find more information"
 msgid "More medal stats on %solympics.com%s"
-msgstr "Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
+msgstr ""
+"Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
 
 # smartling.placeholder_format=C
 #. A link to more information on a topic. The placeholder is the name of a website. For example 'More on Wikipedia'.
@@ -12857,6 +13042,12 @@ msgstr "Utišano"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Udušeno rdeča"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13927,6 +14118,30 @@ msgstr ""
 "%3$skliknite ikono %4$s > Nastavitve%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14050,7 +14265,8 @@ msgstr "Odpri spletno mesto %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
+msgstr ""
+"Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14679,6 +14895,12 @@ msgid "Past year"
 msgstr "Preteklo leto"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14689,6 +14911,12 @@ msgstr "Prilepi"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Prilepite kodo za sinhronizacijo"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14742,6 +14970,20 @@ msgstr "Trajno zaprto"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Perzijščina"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14996,7 +15238,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
+msgstr ""
+"Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15004,7 +15247,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
+msgstr ""
+"Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -16005,6 +16249,12 @@ msgid "Reading website…"
 msgstr "Branje spletne strani ..."
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16052,7 +16302,8 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Razmišljanje je temeljitejše, vendar porabi omejitve 2–5-krat hitreje. %1$s"
+msgstr ""
+"Razmišljanje je temeljitejše, vendar porabi omejitve 2–5-krat hitreje. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16087,7 +16338,8 @@ msgstr "Nedavni zavihki"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr "Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
+msgstr ""
+"Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
 
 # smartling.placeholder_format=C
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
@@ -16194,6 +16446,12 @@ msgstr "Obnovitev"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Obnovitvena koda"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16414,7 +16672,8 @@ msgstr "Zapomni si mojo izbiro"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
+msgstr ""
+"Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16445,6 +16704,12 @@ msgstr "Odstrani %1$s"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "Odstrani %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16487,6 +16752,18 @@ msgstr "Odstranitev izbora besedila"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Odstranite nepotrebna ločila"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16783,7 +17060,8 @@ msgstr "Rezultati ne vključujejo informacij z blokiranih spletnih mest."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
+msgstr ""
+"Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17146,7 +17424,8 @@ msgstr "Shrani do 30 vaših najnovejših klepetov lokalno v vaši napravi."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
+msgstr ""
+"Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17177,6 +17456,12 @@ msgstr "Svoje nastavitve anonimno shranite v oblak"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Spoznajte Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17286,7 +17571,8 @@ msgstr "Pomaknite navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
+msgstr ""
+"Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17883,8 +18169,8 @@ msgstr "V meniju Safari izberite %1$s»Nastavitev za to spletno mesto ...«%2$s.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Izberite %1$sPo meri%2$s in v vnosno polje vnesite "
-"%3$shttps://duckduckgo.com%4$s"
+"Izberite %1$sPo meri%2$s in v vnosno polje vnesite %3$shttps://duckduckgo."
+"com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18175,6 +18461,13 @@ msgid "Serbian (Latin)"
 msgstr "Srbščina (latinica)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18329,6 +18622,14 @@ msgid "Share"
 msgstr "Deli"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18478,6 +18779,18 @@ msgid "Share your thoughts on the search box."
 msgstr "Delite svoje mnenje o iskalnem polju."
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
@@ -18606,7 +18919,8 @@ msgstr "Pokaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
+msgstr ""
+"Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18789,7 +19103,8 @@ msgstr "Prikaži stransko vrstico"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Prikažite nasvete po korakih, da lahko kar najbolje izkoristite Duck.ai."
+msgstr ""
+"Prikažite nasvete po korakih, da lahko kar najbolje izkoristite Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18891,7 +19206,8 @@ msgstr "Prikaže občasne opomnike, da dodate DuckDuckGo v svoje naprave"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr "Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
+msgstr ""
+"Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18927,7 +19243,8 @@ msgstr "Prikaže pozdravno sporočilo na vrhu strani z rezultati iskanja"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
+msgstr ""
+"Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19148,6 +19465,12 @@ msgid "Something went wrong"
 msgstr "Nekaj je šlo narobe"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19261,7 +19584,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
+msgstr ""
+"Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19572,7 +19896,8 @@ msgstr "Ustavi ustvarjanje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
+msgstr ""
+"Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -19994,6 +20319,12 @@ msgid "Switch model"
 msgstr "Model stikala"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20070,7 +20401,8 @@ msgstr "Preklopljeno na model %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
+msgstr ""
+"S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20249,6 +20581,13 @@ msgid "Synced Devices"
 msgstr "Sinhronizirane naprave"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Sirija"
 
@@ -20279,6 +20618,12 @@ msgstr "Še ni znano"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20347,8 +20692,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo "
-"Duck.ai."
+"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20619,7 +20964,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
+msgstr ""
+"Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20862,6 +21208,22 @@ msgstr ""
 "%4$s)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20943,6 +21305,12 @@ msgstr "Ta vrsta slike ni podprta, priložite JPG, PNG, WebP ali GIF."
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Te informacije niso uporabne"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21057,6 +21425,18 @@ msgstr ""
 "podatke brskalnika duckduckgo.com, boste morda znova videli odgovore s "
 "pomočjo umetne inteligence. Vendar imamo tudi začetno stran, ki nikoli ne "
 "prikazuje odgovorov s pomočjo umetne inteligence na %1$s."
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21204,7 +21584,8 @@ msgstr "Nasveti"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
+msgstr ""
+"Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21535,7 +21916,8 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
+msgstr ""
+"Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21543,7 +21925,8 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
+msgstr ""
+"Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21707,6 +22090,12 @@ msgid "Try Free"
 msgstr "Poskusite brezplačno"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21769,7 +22158,8 @@ msgstr "Poskusi dodati mesto, državo ali poštno številko"
 #. Message to display during errors for users who have AI enabled to encourage them to use that feature while the site is having issues. Example: 'Try asking Duck.ai, our private AI chat service:'
 msgctxt "noresults"
 msgid "Try asking %s, our private AI chat service:"
-msgstr "Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
+msgstr ""
+"Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
 
 # smartling.placeholder_format=C
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
@@ -21801,7 +22191,8 @@ msgstr "Preizkusite omogočiti anonimno lokacijo za natančnejše rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
+msgstr ""
+"Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21820,6 +22211,12 @@ msgstr "Preizkusite brezplačno"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Preizkusite brezplačno"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21981,7 +22378,8 @@ msgstr "Preizkusite nedavno dodana odprtokodna modela Llama 3.1 in Mixtral"
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
+msgstr ""
+"Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22065,6 +22463,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22075,6 +22479,12 @@ msgstr "Izklopi funkcijo Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Izklopi Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22145,7 +22555,8 @@ msgstr "Za natančnejše rezultate vklopite %1$sNatančno lokacijo%2$s."
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
+msgstr ""
+"Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22314,7 +22725,8 @@ msgstr "Povratnih informacij ni mogoče poslati"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
+msgstr ""
+"Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -22361,12 +22773,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
+msgstr ""
+"Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
+msgstr ""
+"Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22513,7 +22927,8 @@ msgstr "Odklenite napredne modele umetne inteligence z naročnino %1$s"
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr "Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
+msgstr ""
+"Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -22556,6 +22971,12 @@ msgid "Unmute"
 msgstr "Vklopi zvok"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22589,6 +23010,12 @@ msgstr "Posodobitev"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Posodobi brskalnik"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22872,7 +23299,8 @@ msgstr "Uporabite DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
+msgstr ""
+"Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23453,7 +23881,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
+msgstr ""
+"Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23568,6 +23997,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Klepet smo prekinili zaradi neaktivnosti. Želite poskusiti znova?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23615,6 +24052,14 @@ msgstr ""
 "v vaši bližini. Pozneje si lahko vedno premislite."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23633,7 +24078,8 @@ msgstr ""
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr "Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
+msgstr ""
+"Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -23653,6 +24099,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Blokirali bomo sledilnike, ki bodo med brskanjem poskušali zbirati vaše "
 "podatke."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23686,7 +24140,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
+msgstr ""
+"Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23796,7 +24251,8 @@ msgstr "Dosežena je tedenska omejitev uporabe"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23941,7 +24397,8 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
+msgstr ""
+"Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -23964,6 +24421,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Katere so nekatere prednosti in slabosti rent?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24344,7 +24807,8 @@ msgstr "Kje gledati: <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
+msgstr ""
+"Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24530,6 +24994,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Brez vidnosti ponudniku"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25029,6 +25501,13 @@ msgid "You have 1 attempt left."
 msgstr "Na voljo imate še en poskus."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25087,7 +25566,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
+msgstr ""
+"Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25191,7 +25671,8 @@ msgstr "Dosegli ste najdaljše trajanje glasovnega klepeta za eno sejo."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
+msgstr ""
+"Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25248,6 +25729,23 @@ msgid "YouTube Standard"
 msgstr "YouTube Standard"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Vaša zgodovina iskanja DuckDuckGo je zasebna"
@@ -25269,6 +25767,14 @@ msgstr "Vaša dejanska lokacija ostane zasebna"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Vaša dejanska lokacija ostane zasebna."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25642,13 +26148,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
+msgstr ""
+"Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
+msgstr ""
+"Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25731,7 +26239,8 @@ msgstr "od %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
+msgstr ""
+"omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25944,7 +26453,8 @@ msgstr "uradno spletno stran"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
+msgstr ""
+"ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sl_SI\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
-"n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -49,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (ta naprava)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -500,7 +499,7 @@ msgstr "%1$sPreberite, kako vašo lokacijo ohranjamo zasebno%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sVeč o tem%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -523,15 +522,13 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
+msgstr "%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
+msgstr "%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -798,7 +795,7 @@ msgstr "2. mesto v skupini %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "Drugo mnenje"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -882,8 +879,7 @@ msgstr "Dosežena je 6-urna omejitev uporabe."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -963,8 +959,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
+msgstr "Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1490,7 +1485,7 @@ msgstr "Dodaj na Domači Zaslon"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Dodaj v Moje klepete"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1603,8 +1598,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"Napredni modeli lahko porabijo omejitve 2–5× hitreje kot drugi modeli. %1$s"
+msgstr "Napredni modeli lahko porabijo omejitve 2–5× hitreje kot drugi modeli. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1861,7 +1855,7 @@ msgstr "Vse vrste"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Za vse vaše naprave je sinhronizacija prekinjena."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -2245,8 +2239,7 @@ msgstr "Ali ste prepričani, da želite izbrisati ta pogovor in začeti novega?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
+msgstr "Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2389,7 +2382,7 @@ msgstr "Vprašajte kar koli zasebno"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Vprašajte kar koli zasebno"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2615,8 +2608,7 @@ msgstr "Samodejno odgovarjanje"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
+msgstr "Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3024,8 +3016,7 @@ msgstr "Blokiraj to spletno mesto v vseh rezultatih"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
+msgstr "Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3907,8 +3898,8 @@ msgstr ""
 "klepeta z umetno inteligenco tretjih oseb, ki podpirajo modele OpenAI, "
 "Anthropic in druge. Če to nastavitev izklopiš, bodo gumbi in povezave za "
 "klepet v iskalniku DuckDuckGo skriti. Vendar pa lahko še vedno dostopaš do "
-"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš %1$shttps://duck."
-"ai%2$s neposredno."
+"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš "
+"%1$shttps://duck.ai%2$s neposredno."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4546,8 +4537,7 @@ msgstr "Kliknite %1$stukaj%2$s za prenos razširitve DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
+msgstr "Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4580,8 +4570,7 @@ msgstr "Kliknite %1$sNastavitve%2$s v spustnem meniju."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
+msgstr "Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5224,8 +5213,7 @@ msgstr "Nadaljuj blokiranje oglasov"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Nadaljujte nedavne klepete tukaj. Ali pa jih izbrišite z gumbom Fire Button."
+msgstr "Nadaljujte nedavne klepete tukaj. Ali pa jih izbrišite z gumbom Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5332,7 +5320,7 @@ msgstr "Kopiraj"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopiraj"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5343,8 +5331,7 @@ msgstr "Kopiraj"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
+msgstr "Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5382,13 +5369,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Kopiraj deljeno povezavo"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Kopirajte kodo iz druge naprave"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5397,6 +5384,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Kopirajte kodo iz druge naprave. Odprite %1$sNastavitve Duck.ai › Klepeti › "
+"Sync & Backup › Sinhronizacija z drugo napravo%2$s in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5782,8 +5771,7 @@ msgstr "Dosežena je dnevna omejitev"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6086,7 +6074,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Izbriši deljeno povezavo"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6107,6 +6095,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Če povezavo izbrišete, preneha delovati. Ljudje, ki so jo odprli in dodali "
+"pogovor med svoje klepete, bodo obdržali svojo kopijo."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6370,7 +6360,7 @@ msgstr "Opusti"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Opusti"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6785,8 +6775,7 @@ msgstr "Spustite svoje fotografije ali datoteke PDF"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
+msgstr "Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6832,8 +6821,7 @@ msgstr "pogoji storitve Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
+msgstr "Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6879,8 +6867,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
+msgstr "Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7016,8 +7003,7 @@ msgstr "Duck.ai je nadgrajen!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
+msgstr "Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7194,8 +7180,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
+msgstr "DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7234,7 +7219,7 @@ msgstr "Brskalnik DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Strani s pomočjo za DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7586,8 +7571,7 @@ msgstr "Urejanje slike ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
+msgstr "Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7648,8 +7632,7 @@ msgstr "Omogoči funkcije UI"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
+msgstr "Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7861,8 +7844,7 @@ msgstr "Prepričajte se, da so »Lokacijske storitve« %1$somogočene%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
+msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7874,8 +7856,7 @@ msgstr "Preverite, ali je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
+msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7899,8 +7880,7 @@ msgstr "Prepričajte se, da ima brskalnik omogočen %1$sdostop do lokacije%2$s."
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
+msgstr "Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8006,8 +7986,7 @@ msgstr "Ekvatorialna Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
+msgstr "V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8074,7 +8053,7 @@ msgstr "Vrhunsko zasnovani izdelki za ljudi, ki jim je mar za zasebnost."
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Poteklo"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8088,7 +8067,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Poteče %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8732,8 +8711,7 @@ msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
+msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9450,8 +9428,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve Duck."
-"ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
+"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve "
+"Duck.ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
 "napravo%4$s ter optično preberite to kodo:"
 
 # smartling.placeholder_format=C
@@ -9473,6 +9451,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Odprite %1$sNastavitve Duck.ai%2$s › %3$sKlepeti › Sync & Backup › "
+"Sinhronizacija z drugo napravo%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9588,7 +9568,7 @@ msgstr "Razumem"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Razumem"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10403,8 +10383,7 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
+msgstr "Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10851,8 +10830,7 @@ msgstr "V zgornjem meniju izberite %1$sOrodja%2$s > %3$sNastavitve%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
+msgstr "V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11178,8 +11156,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
+msgstr "Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11229,8 +11206,7 @@ msgstr "Je hiter, brezplačen in zagotavlja še večjo spletno zaščito."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
+msgstr "Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11573,7 +11549,7 @@ msgstr "%1$sVeč%2$s o tem"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Več o tem"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11748,8 +11724,7 @@ msgstr "Omogoča anonimno iskanje z DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Omogoča preklapljanje med pošiljanjem iskalnih poizvedb in pozivov v Duck.ai"
+msgstr "Omogoča preklapljanje med pošiljanjem iskalnih poizvedb in pozivov v Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12214,7 +12189,7 @@ msgstr "Upravljanje"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Upravljanje"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12471,7 +12446,7 @@ msgstr "Meni"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Sporočila od te točke dalje so vidna le vam."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12734,8 +12709,7 @@ msgstr "Dosežena je mesečna omejitev"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12846,7 +12820,7 @@ msgstr "Več o Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Več dejanj"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12909,8 +12883,7 @@ msgstr "Več statističnih podatkov o medaljah je na voljo na %1$s"
 msgctxt ""
 "Note on the Olympics module as to where they can find more information"
 msgid "More medal stats on %solympics.com%s"
-msgstr ""
-"Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
+msgstr "Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
 
 # smartling.placeholder_format=C
 #. A link to more information on a topic. The placeholder is the name of a website. For example 'More on Wikipedia'.
@@ -13047,7 +13020,7 @@ msgstr "Udušeno rdeča"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Moje naprave"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14124,6 +14097,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"V drugi napravi odprite %1$sNastavitve Duck.ai%2$s › %3$sKlepeti › Sync & "
+"Backup › Sinhronizacija z drugo napravo%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14132,6 +14107,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"V drugi napravi odprite %1$sNastavitve Duck.ai%2$s › %3$sKlepeti › Sync & "
+"Backup › Sinhronizacija z drugo napravo%4$s in skenirajte to kodo:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14140,6 +14117,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"V drugi napravi odprite %1$sNastavitve Duck.ai%2$s › %3$sKlepeti › Sync & "
+"Backup › Sinhronizacija z drugo napravo%4$s. Ali pa skenirajte kodo QR v "
+"svojem obnovitvenem PDF-ju."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14265,8 +14245,7 @@ msgstr "Odpri spletno mesto %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
+msgstr "Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14898,7 +14877,7 @@ msgstr "Preteklo leto"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Prilepi"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14916,7 +14895,7 @@ msgstr "Prilepite kodo za sinhronizacijo"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Prilepite jo spodaj"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14975,7 +14954,7 @@ msgstr "Perzijščina"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14984,6 +14963,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Orodje Personal Information Removal (Odstranitev osebnih podatkov) poišče "
+"vaše podatke na spletnih mestih posrednikov podatkov, kjer se vaši podatki "
+"prodajajo. Nato si prizadevamo, da jih v vašem imenu odstranimo."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15238,8 +15220,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
+msgstr "Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15247,8 +15228,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
+msgstr "Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -16252,7 +16232,7 @@ msgstr "Branje spletne strani ..."
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Ste pripravljeni na sončni mrk?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16302,8 +16282,7 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Razmišljanje je temeljitejše, vendar porabi omejitve 2–5-krat hitreje. %1$s"
+msgstr "Razmišljanje je temeljitejše, vendar porabi omejitve 2–5-krat hitreje. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16338,8 +16317,7 @@ msgstr "Nedavni zavihki"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr ""
-"Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
+msgstr "Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
 
 # smartling.placeholder_format=C
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
@@ -16451,7 +16429,7 @@ msgstr "Obnovitvena koda"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Obnovitvena koda"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16672,8 +16650,7 @@ msgstr "Zapomni si mojo izbiro"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
+msgstr "Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16709,7 +16686,7 @@ msgstr "Odstrani %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Odstranitev naprave"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16757,13 +16734,13 @@ msgstr "Odstranite nepotrebna ločila"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Odstranite svoje podatke iz interneta"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Odstranite svoje podatke iz spleta"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17060,8 +17037,7 @@ msgstr "Rezultati ne vključujejo informacij z blokiranih spletnih mest."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
+msgstr "Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17424,8 +17400,7 @@ msgstr "Shrani do 30 vaših najnovejših klepetov lokalno v vaši napravi."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
+msgstr "Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17461,7 +17436,7 @@ msgstr "Spoznajte Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Spoznajte Duck.ai, brezplačen in zaseben klepet z UI ponudnika DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17571,8 +17546,7 @@ msgstr "Pomaknite navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
+msgstr "Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18169,8 +18143,8 @@ msgstr "V meniju Safari izberite %1$s»Nastavitev za to spletno mesto ...«%2$s.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Izberite %1$sPo meri%2$s in v vnosno polje vnesite %3$shttps://duckduckgo."
-"com%4$s"
+"Izberite %1$sPo meri%2$s in v vnosno polje vnesite "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18465,7 +18439,7 @@ msgstr "Srbščina (latinica)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Podatki v strežniku so izbrisani"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18627,7 +18601,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Deli"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18782,13 +18756,13 @@ msgstr "Delite svoje mnenje o iskalnem polju."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Povezave do deljenih klepetov"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Povezave do deljenih klepetov"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18919,8 +18893,7 @@ msgstr "Pokaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
+msgstr "Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19103,8 +19076,7 @@ msgstr "Prikaži stransko vrstico"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Prikažite nasvete po korakih, da lahko kar najbolje izkoristite Duck.ai."
+msgstr "Prikažite nasvete po korakih, da lahko kar najbolje izkoristite Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19206,8 +19178,7 @@ msgstr "Prikaže občasne opomnike, da dodate DuckDuckGo v svoje naprave"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
+msgstr "Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19243,8 +19214,7 @@ msgstr "Prikaže pozdravno sporočilo na vrhu strani z rezultati iskanja"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
+msgstr "Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19468,7 +19438,7 @@ msgstr "Nekaj je šlo narobe"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Pri nalaganju tega deljenega klepeta je prišlo do napake."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19584,8 +19554,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
+msgstr "Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19896,8 +19865,7 @@ msgstr "Ustavi ustvarjanje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
+msgstr "Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20322,7 +20290,7 @@ msgstr "Model stikala"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Preklopi model"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20401,8 +20369,7 @@ msgstr "Preklopljeno na model %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
+msgstr "S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20585,7 +20552,7 @@ msgstr "Sinhronizirane naprave"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Sinhronizirano dne %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20623,7 +20590,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabela"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20692,8 +20659,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo Duck."
-"ai."
+"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20964,8 +20931,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
+msgstr "Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21211,7 +21177,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Ta naprava"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21222,6 +21188,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Ta naprava ne bo več mogla dostopati do vaših sinhroniziranih podatkov v "
+"drugih napravah. Zadnjih %1$s klepetov bo še vedno na voljo v lokalnem "
+"pomnilniku."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21310,7 +21279,7 @@ msgstr "Te informacije niso uporabne"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "To je kopija deljenega klepeta."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21430,13 +21399,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Tega deljenega klepeta ni bilo mogoče odpreti. Povezava je morda nepopolna."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Ta povezava do deljenega klepeta ni več na voljo."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21584,8 +21553,7 @@ msgstr "Nasveti"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
+msgstr "Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21916,8 +21884,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
+msgstr "Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21925,8 +21892,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
+msgstr "Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22093,7 +22059,7 @@ msgstr "Poskusite brezplačno"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Preizkusite brezplačno!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22158,8 +22124,7 @@ msgstr "Poskusi dodati mesto, državo ali poštno številko"
 #. Message to display during errors for users who have AI enabled to encourage them to use that feature while the site is having issues. Example: 'Try asking Duck.ai, our private AI chat service:'
 msgctxt "noresults"
 msgid "Try asking %s, our private AI chat service:"
-msgstr ""
-"Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
+msgstr "Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
 
 # smartling.placeholder_format=C
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
@@ -22191,8 +22156,7 @@ msgstr "Preizkusite omogočiti anonimno lokacijo za natančnejše rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
+msgstr "Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22216,7 +22180,7 @@ msgstr "Preizkusite brezplačno"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Preizkusite brezplačno!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22378,8 +22342,7 @@ msgstr "Preizkusite nedavno dodana odprtokodna modela Llama 3.1 in Mixtral"
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
+msgstr "Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22466,7 +22429,7 @@ msgstr "Turkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Izklopi"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22484,7 +22447,7 @@ msgstr "Izklopi Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Želite izklopiti funkcijo Sync & Backup in izbrisati podatke iz strežnika?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22555,8 +22518,7 @@ msgstr "Za natančnejše rezultate vklopite %1$sNatančno lokacijo%2$s."
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
+msgstr "Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22725,8 +22687,7 @@ msgstr "Povratnih informacij ni mogoče poslati"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
+msgstr "Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -22773,14 +22734,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
+msgstr "Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
+msgstr "Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22927,8 +22886,7 @@ msgstr "Odklenite napredne modele umetne inteligence z naročnino %1$s"
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
+msgstr "Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -22974,7 +22932,7 @@ msgstr "Vklopi zvok"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Nepoimenovan klepet"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23015,7 +22973,7 @@ msgstr "Posodobi brskalnik"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Za ogled tega deljenega klepeta posodobite Duck.ai."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23299,8 +23257,7 @@ msgstr "Uporabite DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
+msgstr "Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23881,8 +23838,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
+msgstr "Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24003,6 +23959,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Poiščemo vaše osebne podatke na spletnih mestih posrednikov podatkov in jih "
+"odstranimo. Poleg tega pridobite VPN in še več."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24058,6 +24016,9 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Redno pregledujemo spletna mesta posrednikov podatkov za vaše osebne "
+"podatke, svoj napredek pa z vami delimo na nadzorni plošči, ki je preprosta "
+"za uporabo."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24078,8 +24039,7 @@ msgstr ""
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr ""
-"Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
+msgstr "Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -24107,6 +24067,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Pregledali bomo spletna mesta posrednikov podatkov za vaš e-poštni naslov, "
+"ime, naslov in drugo ter si prizadevali za odstranitev vsega, kar najdemo o "
+"vas."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24140,8 +24103,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
+msgstr "Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24251,8 +24213,7 @@ msgstr "Dosežena je tedenska omejitev uporabe"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24397,8 +24358,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
+msgstr "Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -24426,7 +24386,7 @@ msgstr "Katere so nekatere prednosti in slabosti rent?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Kakšne so prednosti Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24807,8 +24767,7 @@ msgstr "Kje gledati: <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
+msgstr "Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25002,6 +24961,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Deluje neposredno iz vaše naprave in odstrani vaš e-poštni naslov, ime, "
+"naslov in drugo s spletnih mest posrednikov podatkov."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25505,7 +25466,7 @@ msgstr "Na voljo imate še en poskus."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Nimate povezav do deljenih klepetov."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25566,8 +25527,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
+msgstr "Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25671,8 +25631,7 @@ msgstr "Dosegli ste najdaljše trajanje glasovnega klepeta za eno sejo."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
+msgstr "Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25737,13 +25696,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Vaši najnovejši klepeti (%1$s) bodo na voljo v lokalnem pomnilniku v teh "
+"brskalnikih:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Vaši klepeti Duck.ai se sinhronizirajo s celovitim šifriranjem."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25775,6 +25736,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Vaša varnostna kopija bo izbrisana iz strežnika DuckDuckGo. Za vse naprave "
+"bo sinhronizacija prekinjena."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26148,15 +26111,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
+msgstr "Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
+msgstr "Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26239,8 +26200,7 @@ msgstr "od %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
+msgstr "omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26453,8 +26413,7 @@ msgstr "uradno spletno stran"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
+msgstr "ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sq_AL/LC_MESSAGES/duckduckgo.po
+++ b/locales/sq_AL/LC_MESSAGES/duckduckgo.po
@@ -35,6 +35,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% Të Vaksinuar"
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -394,6 +401,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%sMësoni si e mbajmë vendndodhjen tuaj private%s."
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -630,6 +643,11 @@ msgstr ""
 msgctxt "Sports module"
 msgid "2nd in Group %s"
 msgstr "I dyti në Grupin %s"
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
@@ -1185,6 +1203,11 @@ msgstr "Shtoje te %s"
 msgid "Add to Home Screen"
 msgstr "Shtoje te Skena e Kreut"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Shtesa"
@@ -1478,6 +1501,12 @@ msgstr "Krejt madhësitë"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Krejt llojet"
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
@@ -1892,6 +1921,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4268,6 +4302,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4301,6 +4340,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4861,6 +4919,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4869,6 +4934,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5075,6 +5147,12 @@ msgstr "Hidhe tej"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5725,6 +5803,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6413,9 +6497,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7519,6 +7616,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7605,6 +7709,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9231,6 +9340,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Mësoni %sMë Tepër%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9751,6 +9865,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9957,6 +10077,11 @@ msgstr "Menu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10258,6 +10383,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Më tepër te"
@@ -10415,6 +10545,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "E kuqe e zënë"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11295,6 +11430,27 @@ msgstr ""
 "Në Mac, %sKlikoni Maxthon > Parapëlqime%s, Në Windows, %sKlikoni mbi ikonën "
 "%s > Rregullime%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11916,6 +12072,11 @@ msgstr "Javën e kaluar"
 msgid "Past year"
 msgstr "Vitin e kaluar"
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11924,6 +12085,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11969,6 +12135,18 @@ msgstr ""
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persisht"
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
 msgctxt "Assistant role option label for Personal trainer"
@@ -12988,6 +13166,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13137,6 +13320,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13345,6 +13533,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13378,6 +13571,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13932,6 +14135,11 @@ msgstr "Ruajini në mënyrë anonime, në re, rregullimet tuaja"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14738,6 +14946,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Serbisht (Latine)"
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14864,6 +15078,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14983,6 +15204,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15535,6 +15766,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16229,6 +16465,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16426,6 +16667,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16451,6 +16698,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "TV"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16915,6 +17167,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16984,6 +17250,11 @@ msgstr ""
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Ky informacion s’qe i dobishëm"
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
@@ -17066,6 +17337,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17587,6 +17868,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17680,6 +17966,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17879,6 +18170,11 @@ msgstr "Turqisht"
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17887,6 +18183,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18281,6 +18582,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18308,6 +18614,11 @@ msgstr "Përditësoje"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -19097,6 +19408,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -19133,6 +19451,13 @@ msgstr ""
 "Vendndodhjen tuaj anonime e përdorim vetëm për të dhënë përfundime më të "
 "mira, më afër jush. Mund të ndërroni mendje kur të doni më vonë."
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -19163,6 +19488,13 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Do të bllokojmë gjurmues që provojnë të grumbullojnë të dhëna, dora-dorës që "
 "shfletoni."
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
 msgctxt "noresults"
@@ -19406,6 +19738,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19871,6 +20208,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20277,6 +20621,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Ju mbetet edhe 1 provë."
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20448,6 +20798,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube Standard"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Historiku i kërkimeve tuaja me DuckDuckGo-në është privat"
@@ -20465,6 +20830,13 @@ msgstr "Vendndodhja juaj faktike mbetet private"
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/sr_RS/LC_MESSAGES/duckduckgo.po
+++ b/locales/sr_RS/LC_MESSAGES/duckduckgo.po
@@ -40,6 +40,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -396,6 +403,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%sСазнајте како чувамо вашу локацију приватном%s"
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -630,6 +643,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1185,6 +1203,11 @@ msgstr "Додај у %s"
 msgid "Add to Home Screen"
 msgstr "Додај на почетни екран"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Додаци"
@@ -1478,6 +1501,12 @@ msgstr "Све величине"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Све врсте"
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
@@ -1893,6 +1922,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4234,6 +4268,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4266,6 +4305,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4826,6 +4884,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4834,6 +4899,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5040,6 +5112,12 @@ msgstr "Затвори"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5687,6 +5765,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6366,9 +6450,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7466,6 +7563,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7550,6 +7654,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9163,6 +9272,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Сазнајте %sвише%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9683,6 +9797,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9889,6 +10009,11 @@ msgstr "Мени"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Мени"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10191,6 +10316,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Више на"
@@ -10348,6 +10478,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Пригушено црвена"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11227,6 +11362,27 @@ msgstr ""
 "На Макинтошу, %sКликните Maxthon > Подешавања%s, За Виндовс, %sКликните %s "
 "иконицу > Подешавања%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11844,6 +12000,11 @@ msgstr "Прошле седмице"
 msgid "Past year"
 msgstr "Прошле године"
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11852,6 +12013,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11897,6 +12063,18 @@ msgstr ""
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Персијски"
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
 msgctxt "Assistant role option label for Personal trainer"
@@ -12910,6 +13088,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13059,6 +13242,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13266,6 +13454,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13299,6 +13492,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13847,6 +14050,11 @@ msgstr "Сачувај своја подешавања анонимно на о�
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14627,6 +14835,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Српски (латиница)"
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14752,6 +14966,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14871,6 +15092,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15423,6 +15654,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16112,6 +16348,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16309,6 +16550,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16334,6 +16581,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "Телевизија"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16794,6 +17046,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16862,6 +17128,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16945,6 +17216,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17465,6 +17746,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17557,6 +17843,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17756,6 +18047,11 @@ msgstr "Турски"
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17764,6 +18060,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18145,6 +18446,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18172,6 +18478,11 @@ msgstr "Ажурирање"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18951,6 +19262,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18987,6 +19305,13 @@ msgstr ""
 "Користимо само вашу анонимну локацију да бисмо вам пружили боље резултате. "
 "Увек се касније можете предомислити."
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -19011,6 +19336,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19255,6 +19587,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19720,6 +20057,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20123,6 +20467,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20294,6 +20644,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Јутуб стандард"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20311,6 +20676,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sv_SE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,7 +22,8 @@ msgstr "!Bang-sökgenvägar"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr "”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
+msgstr ""
+"”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -41,6 +42,14 @@ msgstr "% fullvaccinerade"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% vaccinerade"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -370,7 +379,8 @@ msgstr "%1$s använt"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s förbrukar gränserna upp till 2–5 gånger snabbare än basmodellerna %2$s"
+msgstr ""
+"%1$s förbrukar gränserna upp till 2–5 gånger snabbare än basmodellerna %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -434,7 +444,8 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
+msgstr ""
+"%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -483,6 +494,13 @@ msgstr "%1$sLäs mer%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sLäs om hur vi håller din plats privat%2$s."
+
+# smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -769,6 +787,12 @@ msgstr "2:a serven vunna poäng"
 msgctxt "Sports module"
 msgid "2nd in Group %s"
 msgstr "2:a i grupp %1$s"
+
+# smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1329,7 +1353,8 @@ msgstr "Installera tillägget DuckDuckGo"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
+msgstr ""
+"Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1454,6 +1479,12 @@ msgstr "Lägg till i %1$s"
 #. Button that creates a shortcut to the current page on the home screen of the user's phone.
 msgid "Add to Home Screen"
 msgstr "Lägg till på hemskärmen"
+
+# smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1604,7 +1635,8 @@ msgstr "Afrikaans"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
+msgstr ""
+"Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
@@ -1820,6 +1852,13 @@ msgid "All types"
 msgstr "Alla typer"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1854,7 +1893,8 @@ msgstr "Vill du tillåta anonym filgranskning för den här chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
+msgstr ""
+"Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2187,19 +2227,22 @@ msgstr "Är du fortfarande där?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
+msgstr ""
+"Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Är du säker på att du vill rensa den här konversationen och starta en ny?"
+msgstr ""
+"Är du säker på att du vill rensa den här konversationen och starta en ny?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
+msgstr ""
+"Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2339,6 +2382,12 @@ msgid "Ask anything privately"
 msgstr "Fråga vad som helst privat"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2412,11 +2461,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist är en valbar funktion i våra sökresultat som anonymt kan generera "
-"AI-assisterade svar på sökfrågor. För att göra detta skannar den webben "
-"efter relevant innehåll och använder sedan AI-driven naturlig språkteknologi "
-"för att generera ett kort svar baserat på relevant information som hittats. "
-"Det är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
+"Assist är en valbar funktion i våra sökresultat som anonymt kan generera AI-"
+"assisterade svar på sökfrågor. För att göra detta skannar den webben efter "
+"relevant innehåll och använder sedan AI-driven naturlig språkteknologi för "
+"att generera ett kort svar baserat på relevant information som hittats. Det "
+"är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
 "källor och baseras på %1$sgenomsökning av webben%2$s."
 
 # smartling.placeholder_format=C
@@ -2518,7 +2567,8 @@ msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten avslutats."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
+msgstr ""
+"Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2559,7 +2609,8 @@ msgstr "Autosvar"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
+msgstr ""
+"Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3207,8 +3258,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Surfa som vanligt medan vi ger dig integritetsskydd. Vi har förenat vår "
-"sökmotor, spårningsblockerare och tvingande kryptering i ett "
-"%1$s%2$s-tillägg%3$s."
+"sökmotor, spårningsblockerare och tvingande kryptering i ett %1$s%2$s-"
+"tillägg%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3842,12 +3893,12 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med "
-"AI-chattmodeller från tredje part med stöd för modeller från OpenAI, "
-"Anthropic och fler. Om du stänger av den här inställningen döljs "
-"chattknappar och länkar på DuckDuckGo Search. Du kan dock fortfarande komma "
-"åt chatten när den här inställningen är avstängd genom att gå till "
-"%1$shttps://duck.ai%2$s direkt."
+"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med AI-"
+"chattmodeller från tredje part med stöd för modeller från OpenAI, Anthropic "
+"och fler. Om du stänger av den här inställningen döljs chattknappar och "
+"länkar på DuckDuckGo Search. Du kan dock fortfarande komma åt chatten när "
+"den här inställningen är avstängd genom att gå till %1$shttps://duck.ai%2$s "
+"direkt."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4087,7 +4138,8 @@ msgstr "Kontrollera stavningen"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
+msgstr ""
+"Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4520,7 +4572,8 @@ msgstr "Klicka på %1$sInställningar%2$s i rullgardinsmenyn."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
+msgstr ""
+"Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5267,6 +5320,12 @@ msgid "Copy"
 msgstr "Kopiera"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5306,6 +5365,28 @@ msgstr "Kopiera eller spara den här koden"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Kopiera återställningskod"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5991,6 +6072,14 @@ msgid "Delete recent chats?"
 msgstr "Radera senaste chattarna?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6001,6 +6090,14 @@ msgstr "Radera den här chatten?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Raderade chattar"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6096,7 +6193,8 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
+msgstr ""
+"Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6256,6 +6354,13 @@ msgid "Dismiss"
 msgstr "Avvisa"
 
 # smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
 msgctxt "duckassist"
 msgid "Dismiss"
@@ -6389,7 +6494,8 @@ msgstr "Ser du inte DuckDuckGo i listan?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
+msgstr ""
+"Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6437,8 +6543,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan "
-"AI-funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
+"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan AI-"
+"funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6825,8 +6931,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai låter dig chatta privat med populära AI-modeller. Att inaktivera det "
-"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka "
-"%1$sduck.ai%2$s direkt."
+"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka %1$sduck."
+"ai%2$s direkt."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6906,9 +7012,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym "
-"AI-chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, "
-"AI-modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
+"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym AI-"
+"chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, AI-"
+"modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7077,7 +7183,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
+msgstr ""
+"DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7104,6 +7211,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo-webbläsaren %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7932,10 +8046,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "Experttillverkade produkter för personer som bryr sig om integritet."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Utgånget"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7960,7 +8089,8 @@ msgstr "Förklara det accepterade svaret med enkla ord."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
+msgstr ""
+"Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8197,7 +8327,8 @@ msgstr "Feedback har skickats"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
+msgstr ""
+"Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8351,7 +8482,8 @@ msgstr "Hitta <b>%1$s</b> i din nedladdningsmapp"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
+msgstr ""
+"Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8388,7 +8520,8 @@ msgstr "Hitta sökresultat närmare dig."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
+msgstr ""
+"Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8570,7 +8703,8 @@ msgstr "Kostnadsfria och privata chattar, anonymiserade av oss"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
+msgstr ""
+"Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8978,7 +9112,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "Skaffa DuckDuckGo VPN, avancerade Duck.ai och Identity Theft Restoration."
+msgstr ""
+"Skaffa DuckDuckGo VPN, avancerade Duck.ai och Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9091,9 +9226,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Få tillgång till avancerade AI-modeller i Duck.ai med ett "
-"DuckDuckGo-abonnemang, som även inkluderar vårt VPN och andra premiumskydd "
-"för integritet."
+"Få tillgång till avancerade AI-modeller i Duck.ai med ett DuckDuckGo-"
+"abonnemang, som även inkluderar vårt VPN och andra premiumskydd för "
+"integritet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9302,6 +9437,14 @@ msgstr ""
 "återställnings-PDF."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -9410,6 +9553,12 @@ msgstr "Jag förstår"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Jag fattar"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9575,7 +9724,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
+msgstr ""
+"Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10462,7 +10612,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
+msgstr ""
+"Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11042,7 +11193,8 @@ msgstr "Det är snabbt, gratis och ger dig ännu mer skydd online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
+msgstr ""
+"Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11382,6 +11534,12 @@ msgid "Learn %sMore%s"
 msgstr "Läs %1$smer%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11646,7 +11804,8 @@ msgstr "Länkar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
+msgstr ""
+"Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11757,7 +11916,8 @@ msgstr "Läser in fler sökresultat med bilder när du skrollar"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
+msgstr ""
+"Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12011,6 +12171,13 @@ msgid "Manage"
 msgstr "Hantera"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12260,6 +12427,12 @@ msgstr "Meny"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Meny"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12630,6 +12803,12 @@ msgid "More about Duck.ai"
 msgstr "Mer om Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Läs mer på"
@@ -12822,6 +13001,12 @@ msgstr "Ljud av"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Matt röd"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13063,11 +13248,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nya promptar och svar krypteras och lagras tillfälligt på en "
-"DuckDuckGo-server efter att de har skickats, så att du kan återställa "
-"chatten om din internetanslutning bryts. Om du inaktiverar chatthistoriken "
-"raderas fästa chattar och tillfällig lagring av nya promptar och svar "
-"inaktiveras."
+"Nya promptar och svar krypteras och lagras tillfälligt på en DuckDuckGo-"
+"server efter att de har skickats, så att du kan återställa chatten om din "
+"internetanslutning bryts. Om du inaktiverar chatthistoriken raderas fästa "
+"chattar och tillfällig lagring av nya promptar och svar inaktiveras."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13893,6 +14077,30 @@ msgstr ""
 "%4$s-ikonen > Inställningar%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14641,6 +14849,12 @@ msgid "Past year"
 msgstr "Senaste året"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14651,6 +14865,12 @@ msgstr "Klistra in"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Klistra in synkroniseringskod"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14704,6 +14924,20 @@ msgstr "Permanent stängd"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Persiska"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14917,7 +15151,8 @@ msgstr "Fäst"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Fastnålade chattar kommer att visas högst upp bland dina senaste chattar."
+msgstr ""
+"Fastnålade chattar kommer att visas högst upp bland dina senaste chattar."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14958,7 +15193,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Lös följande utmaning för att bekräfta att prompten görs av en människa."
+msgstr ""
+"Lös följande utmaning för att bekräfta att prompten görs av en människa."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14966,7 +15202,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Lös följande utmaning för att bekräfta att sökningen görs av en människa."
+msgstr ""
+"Lös följande utmaning för att bekräfta att sökningen görs av en människa."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15749,7 +15986,8 @@ msgstr "Fråga mig"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Be mig använda min ungefärliga plats för att få sökresultat i närheten."
+msgstr ""
+"Be mig använda min ungefärliga plats för att få sökresultat i närheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15965,6 +16203,12 @@ msgid "Reading website…"
 msgstr "Läser in webbplatsen..."
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16064,8 +16308,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på "
-"DuckDuckGo-servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
+"servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16074,8 +16318,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på "
-"DuckDuckGo-servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
+"servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16156,6 +16400,12 @@ msgstr "Återställning"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Återställningskod"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16409,6 +16659,12 @@ msgid "Remove %s"
 msgstr "Ta bort %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16449,6 +16705,18 @@ msgstr "Ta bort textmarkeringen"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Ta bort onödiga skiljetecken"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17108,7 +17376,8 @@ msgstr "Spara upp till 30 av dina senaste chattar lokalt på din enhet."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
+msgstr ""
+"Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17139,6 +17408,12 @@ msgstr "Spara dina inställningar anonymt i molnet"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Säg hej till Duck.ai"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17285,13 +17560,15 @@ msgstr "Skrolla nedåt och leta reda på %1$sdin webbläsare%2$s i listan."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
+msgstr ""
+"Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
+msgstr ""
+"Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17633,7 +17910,8 @@ msgstr "En andra åsikt"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
+msgstr ""
+"Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17642,8 +17920,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med "
-"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
+"kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17652,8 +17930,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med "
-"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
+"kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17672,8 +17950,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Lagra dina chattar på ett säkert sätt på vår server med "
-"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra dina chattar på ett säkert sätt på vår server med end-to-end-"
+"kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18129,6 +18407,13 @@ msgid "Serbian (Latin)"
 msgstr "Serbiska (latinskt)"
 
 # smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -18229,7 +18514,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
+msgstr ""
+"Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18279,6 +18565,14 @@ msgstr "Seychellerna"
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr "Dela"
+
+# smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18427,6 +18721,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Dela med dig av dina tankar om sökrutan."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18832,12 +19138,14 @@ msgstr "Visar mest besökta länkar i ny flik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
+msgstr ""
+"Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
+msgstr ""
+"Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18855,7 +19163,8 @@ msgstr "Visar sidnummer där sidan med sökresultat bryts"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
+msgstr ""
+"Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18881,7 +19190,8 @@ msgstr "Visar välkomstmeddelande högst upp på sidan med sökresultat"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
+msgstr ""
+"Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19100,6 +19410,12 @@ msgstr "Övrigt"
 msgctxt "duckai_migration"
 msgid "Something went wrong"
 msgstr "Något gick fel"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19704,7 +20020,8 @@ msgstr "Förslag på rubrik för ett blogginlägg"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
+msgstr ""
+"Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19944,6 +20261,12 @@ msgstr "Byt modell"
 msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr "Byt modell"
+
+# smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20198,6 +20521,13 @@ msgid "Synced Devices"
 msgstr "Synkroniserade enheter"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Syrien"
 
@@ -20228,6 +20558,12 @@ msgstr "Kommer"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20667,7 +21003,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
+msgstr ""
+"Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20810,6 +21147,22 @@ msgstr ""
 "information (se %4$s för mer information)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20893,6 +21246,12 @@ msgid "This information isn’t useful"
 msgstr "Den här informationen är inte användbar"
 
 # smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
@@ -20959,8 +21318,8 @@ msgstr "Denna sida kräver javascript för att fungera."
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
 msgstr ""
-"Innehållet på den här sidan kommer att skickas med ditt meddelande till "
-"Duck.ai"
+"Innehållet på den här sidan kommer att skickas med ditt meddelande till Duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21007,6 +21366,18 @@ msgstr ""
 "har dock även en startsida som aldrig visar AI-assisterade svar på %1$s."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21033,7 +21404,8 @@ msgstr "Denna video kan ännu inte visas här. Du kan titta på den på %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
+msgstr ""
+"Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21218,8 +21590,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"För att överföra din chatthistorik till Duck.ai, uppdatera "
-"DuckDuckGo-webbläsaren till den senaste versionen och försök igen."
+"För att överföra din chatthistorik till Duck.ai, uppdatera DuckDuckGo-"
+"webbläsaren till den senaste versionen och försök igen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21251,8 +21623,8 @@ msgstr "Idag"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Växla för att prova privat AI-chatt eller %1$sinaktivera den i menyn "
-"%2$s.%3$s"
+"Växla för att prova privat AI-chatt eller %1$sinaktivera den i menyn %2$s."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21648,6 +22020,12 @@ msgid "Try Free"
 msgstr "Prova gratis"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21763,6 +22141,12 @@ msgstr "Prova gratis"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Prova gratis"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22008,6 +22392,12 @@ msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22018,6 +22408,12 @@ msgstr "Inaktivera Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Inaktivera Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22299,13 +22695,14 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: "
-"https://duckduckgo.com"
+"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
+msgstr ""
+"Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22332,7 +22729,8 @@ msgstr "Under sektionen %1$sSök%2$s, klicka på %3$sHantera sökmotorer...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
+msgstr ""
+"Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22439,8 +22837,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås upp avancerade AI-modeller och högre gränser med en "
-"DuckDuckGo-prenumeration"
+"Lås upp avancerade AI-modeller och högre gränser med en DuckDuckGo-"
+"prenumeration"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22494,6 +22892,12 @@ msgid "Unmute"
 msgstr "Slå på ljudet"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22527,6 +22931,12 @@ msgstr "Uppdatera"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Uppdatera webbläsare"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22810,7 +23220,8 @@ msgstr "Använd DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
+msgstr ""
+"Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23108,10 +23519,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna "
-"Duck.ai-inställningarna. Välj Aktivera under Sync & Backup och välj "
-"Synkronisera med en annan enhet. Eller skanna QR-koden på din "
-"återställnings-PDF."
+"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna Duck."
+"ai-inställningarna. Välj Aktivera under Sync & Backup och välj Synkronisera "
+"med en annan enhet. Eller skanna QR-koden på din återställnings-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23164,8 +23574,8 @@ msgstr "Röstchatt avslutad"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Röstchatt är anonymiserad av oss och används aldrig för att träna "
-"AI-modeller."
+"Röstchatt är anonymiserad av oss och används aldrig för att träna AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23345,7 +23755,8 @@ msgstr "Vi anonymiserar"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
+msgstr ""
+"Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23379,14 +23790,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr "Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
+msgstr ""
+"Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
+msgstr ""
+"Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23397,7 +23810,8 @@ msgstr "Vi förföljer dig inte med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "Vi lagrar inte användarnamn eller annan personligt identifierbar information."
+msgstr ""
+"Vi lagrar inte användarnamn eller annan personligt identifierbar information."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23428,7 +23842,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
+msgstr ""
+"Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23499,6 +23914,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Vi avslutade chatten på grund av inaktivitet. Vill du försöka igen?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23545,6 +23968,14 @@ msgstr ""
 "dig. Du kan alltid ändra dig senare."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23580,7 +24011,16 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
+msgstr ""
+"Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23781,7 +24221,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
+msgstr ""
+"Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23876,7 +24317,8 @@ msgstr "Kan du ge några faktorer man ska tänka på när man köper en datorsk�
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
+msgstr ""
+"Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23893,6 +24335,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Kan du ge några för- och nackdelar med livränta?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -23970,7 +24418,8 @@ msgstr "Vilka är de viktigaste lärdomarna?"
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr "Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
+msgstr ""
+"Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
@@ -23995,7 +24444,8 @@ msgstr "Vilka är de mest rekommenderade rätterna här?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
+msgstr ""
+"Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24222,7 +24672,8 @@ msgstr "Vad vill du ge feedback om?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
+msgstr ""
+"Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24254,7 +24705,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
+msgstr ""
+"När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24312,7 +24764,8 @@ msgstr "Vilka är vi"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr "Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
+msgstr ""
+"Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24458,6 +24911,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Ingen leverantörssynlighet"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24705,7 +25166,8 @@ msgstr "Ja, ny användare!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Ja, vi slänger data när du är klar med dem och de kan inte återställas."
+msgstr ""
+"Ja, vi slänger data när du är klar med dem och de kan inte återställas."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24724,7 +25186,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
+msgstr ""
+"Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24910,7 +25373,8 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr "Du kan återställa dina inställningar efter att du har tagit bort kakor."
+msgstr ""
+"Du kan återställa dina inställningar efter att du har tagit bort kakor."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24953,6 +25417,13 @@ msgstr "Du har %1$s försök kvar."
 msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "Du har 1 försök kvar."
+
+# smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25163,8 +25634,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. "
-"YouTube-videor som visas här spåras därför av YouTube/Google."
+"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. YouTube-"
+"videor som visas här spåras därför av YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25176,6 +25647,23 @@ msgstr "Integritetsvarning för YouTube"
 msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Standard för YouTube"
+
+# smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25199,6 +25687,14 @@ msgstr "Din aktuella plats förblir privat"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Din aktuella plats förblir privat."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25280,8 +25776,8 @@ msgstr "Dina chattar sparas nu."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Dina chattar är privata, sparas aldrig och används inte för att träna "
-"AI-modeller"
+"Dina chattar är privata, sparas aldrig och används inte för att träna AI-"
+"modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25424,10 +25920,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure "
-"Hash-algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande "
-"inställningsfil lämnar din webbläsare. Vi sparar inställningsfilen med "
-"nyckeln som namn. DuckDuckGo känner aldrig till ditt lösenord."
+"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure Hash-"
+"algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande inställningsfil "
+"lämnar din webbläsare. Vi sparar inställningsfilen med nyckeln som namn. "
+"DuckDuckGo känner aldrig till ditt lösenord."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25660,7 +26156,8 @@ msgstr "av %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
+msgstr ""
+"av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25874,8 +26371,8 @@ msgstr "den officiella webbplatsen"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat "
-"%3$s-tecken)"
+"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat %3$s-"
+"tecken)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sv_SE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,8 +22,7 @@ msgstr "!Bang-sökgenvägar"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
+msgstr "”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -49,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Den här enheten)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -379,8 +378,7 @@ msgstr "%1$s använt"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s förbrukar gränserna upp till 2–5 gånger snabbare än basmodellerna %2$s"
+msgstr "%1$s förbrukar gränserna upp till 2–5 gånger snabbare än basmodellerna %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -444,8 +442,7 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
+msgstr "%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -500,7 +497,7 @@ msgstr "%1$sLäs om hur vi håller din plats privat%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sLäs mer%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -792,7 +789,7 @@ msgstr "2:a i grupp %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2:a åsikt"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1353,8 +1350,7 @@ msgstr "Installera tillägget DuckDuckGo"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
+msgstr "Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1484,7 +1480,7 @@ msgstr "Lägg till på hemskärmen"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Lägg till i Mina chattar"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1635,8 +1631,7 @@ msgstr "Afrikaans"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
+msgstr "Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
@@ -1856,7 +1851,7 @@ msgstr "Alla typer"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Alla dina enheter är bortkopplade från Sync."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1893,8 +1888,7 @@ msgstr "Vill du tillåta anonym filgranskning för den här chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
+msgstr "Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2227,22 +2221,19 @@ msgstr "Är du fortfarande där?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
+msgstr "Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Är du säker på att du vill rensa den här konversationen och starta en ny?"
+msgstr "Är du säker på att du vill rensa den här konversationen och starta en ny?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
+msgstr "Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2385,7 +2376,7 @@ msgstr "Fråga vad som helst privat"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Fråga vad som helst privat"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2461,11 +2452,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist är en valbar funktion i våra sökresultat som anonymt kan generera AI-"
-"assisterade svar på sökfrågor. För att göra detta skannar den webben efter "
-"relevant innehåll och använder sedan AI-driven naturlig språkteknologi för "
-"att generera ett kort svar baserat på relevant information som hittats. Det "
-"är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
+"Assist är en valbar funktion i våra sökresultat som anonymt kan generera "
+"AI-assisterade svar på sökfrågor. För att göra detta skannar den webben "
+"efter relevant innehåll och använder sedan AI-driven naturlig språkteknologi "
+"för att generera ett kort svar baserat på relevant information som hittats. "
+"Det är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
 "källor och baseras på %1$sgenomsökning av webben%2$s."
 
 # smartling.placeholder_format=C
@@ -2567,8 +2558,7 @@ msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten avslutats."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
+msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2609,8 +2599,7 @@ msgstr "Autosvar"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
+msgstr "Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3258,8 +3247,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Surfa som vanligt medan vi ger dig integritetsskydd. Vi har förenat vår "
-"sökmotor, spårningsblockerare och tvingande kryptering i ett %1$s%2$s-"
-"tillägg%3$s."
+"sökmotor, spårningsblockerare och tvingande kryptering i ett "
+"%1$s%2$s-tillägg%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3893,12 +3882,12 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med AI-"
-"chattmodeller från tredje part med stöd för modeller från OpenAI, Anthropic "
-"och fler. Om du stänger av den här inställningen döljs chattknappar och "
-"länkar på DuckDuckGo Search. Du kan dock fortfarande komma åt chatten när "
-"den här inställningen är avstängd genom att gå till %1$shttps://duck.ai%2$s "
-"direkt."
+"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med "
+"AI-chattmodeller från tredje part med stöd för modeller från OpenAI, "
+"Anthropic och fler. Om du stänger av den här inställningen döljs "
+"chattknappar och länkar på DuckDuckGo Search. Du kan dock fortfarande komma "
+"åt chatten när den här inställningen är avstängd genom att gå till "
+"%1$shttps://duck.ai%2$s direkt."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4138,8 +4127,7 @@ msgstr "Kontrollera stavningen"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
+msgstr "Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4572,8 +4560,7 @@ msgstr "Klicka på %1$sInställningar%2$s i rullgardinsmenyn."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
+msgstr "Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5323,7 +5310,7 @@ msgstr "Kopiera"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopiera"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5372,13 +5359,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Kopiera delad länk"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Kopiera koden från en annan enhet"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5387,6 +5374,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Kopiera koden från en annan enhet. Gå till %1$sDuck.ai-inställningar › "
+"Chattar › Sync & Backup › Synkronisera med en annan enhet%2$s och försök "
+"igen."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6077,7 +6067,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Ta bort delad länk"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6098,6 +6088,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Att ta bort en länk gör att den slutar fungera. Personer som har öppnat den "
+"och lagt till konversationen i sina chattar behåller sin egen kopia."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6193,8 +6185,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
+msgstr "Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6358,7 +6349,7 @@ msgstr "Avvisa"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Avvisa"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6494,8 +6485,7 @@ msgstr "Ser du inte DuckDuckGo i listan?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
+msgstr "Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6543,8 +6533,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan AI-"
-"funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
+"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan "
+"AI-funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6931,8 +6921,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai låter dig chatta privat med populära AI-modeller. Att inaktivera det "
-"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka %1$sduck."
-"ai%2$s direkt."
+"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka "
+"%1$sduck.ai%2$s direkt."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7012,9 +7002,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym AI-"
-"chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, AI-"
-"modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
+"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym "
+"AI-chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, "
+"AI-modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7183,8 +7173,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
+msgstr "DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7217,7 +7206,7 @@ msgstr "DuckDuckGo-webbläsaren %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo-hjälpsidor"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -8050,7 +8039,7 @@ msgstr "Experttillverkade produkter för personer som bryr sig om integritet."
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Utgånget"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8064,7 +8053,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Går ut %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8089,8 +8078,7 @@ msgstr "Förklara det accepterade svaret med enkla ord."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
+msgstr "Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8327,8 +8315,7 @@ msgstr "Feedback har skickats"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
+msgstr "Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8482,8 +8469,7 @@ msgstr "Hitta <b>%1$s</b> i din nedladdningsmapp"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
+msgstr "Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8520,8 +8506,7 @@ msgstr "Hitta sökresultat närmare dig."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
+msgstr "Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8703,8 +8688,7 @@ msgstr "Kostnadsfria och privata chattar, anonymiserade av oss"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
+msgstr "Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9112,8 +9096,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Skaffa DuckDuckGo VPN, avancerade Duck.ai och Identity Theft Restoration."
+msgstr "Skaffa DuckDuckGo VPN, avancerade Duck.ai och Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9226,9 +9209,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Få tillgång till avancerade AI-modeller i Duck.ai med ett DuckDuckGo-"
-"abonnemang, som även inkluderar vårt VPN och andra premiumskydd för "
-"integritet."
+"Få tillgång till avancerade AI-modeller i Duck.ai med ett "
+"DuckDuckGo-abonnemang, som även inkluderar vårt VPN och andra premiumskydd "
+"för integritet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9443,6 +9426,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Gå till %1$sDuck.ai-inställningar%2$s › %3$sChattar › Sync & Backup › "
+"Synkronisera med en annan enhet%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9558,7 +9543,7 @@ msgstr "Jag fattar"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Jag förstår"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9724,8 +9709,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
+msgstr "Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10612,8 +10596,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
+msgstr "Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11193,8 +11176,7 @@ msgstr "Det är snabbt, gratis och ger dig ännu mer skydd online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
+msgstr "Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11537,7 +11519,7 @@ msgstr "Läs %1$smer%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Läs mer"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11804,8 +11786,7 @@ msgstr "Länkar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
+msgstr "Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11916,8 +11897,7 @@ msgstr "Läser in fler sökresultat med bilder när du skrollar"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
+msgstr "Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12175,7 +12155,7 @@ msgstr "Hantera"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Hantera"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12432,7 +12412,7 @@ msgstr "Meny"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Meddelanden efter den här punkten är bara synliga för dig."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12806,7 +12786,7 @@ msgstr "Mer om Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Fler åtgärder"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13006,7 +12986,7 @@ msgstr "Matt röd"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Mina enheter"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13248,10 +13228,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nya promptar och svar krypteras och lagras tillfälligt på en DuckDuckGo-"
-"server efter att de har skickats, så att du kan återställa chatten om din "
-"internetanslutning bryts. Om du inaktiverar chatthistoriken raderas fästa "
-"chattar och tillfällig lagring av nya promptar och svar inaktiveras."
+"Nya promptar och svar krypteras och lagras tillfälligt på en "
+"DuckDuckGo-server efter att de har skickats, så att du kan återställa "
+"chatten om din internetanslutning bryts. Om du inaktiverar chatthistoriken "
+"raderas fästa chattar och tillfällig lagring av nya promptar och svar "
+"inaktiveras."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14083,6 +14064,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"På en annan enhet går du till %1$sDuck.ai-inställningar%2$s › %3$sChattar › "
+"Sync & Backup › Synkronisera med en annan enhet%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14091,6 +14074,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Gå på en annan enhet till %1$sDuck.ai-inställningar%2$s › %3$sChattar › Sync "
+"& Backup › Synkronisera med en annan enhet%4$s och skanna den här koden:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14099,6 +14084,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"På en annan enhet går du till %1$sDuck.ai-inställningar%2$s › %3$sChattar › "
+"Sync & Backup › Synkronisera med en annan enhet%4$s. Eller skanna QR-koden "
+"på din återställnings-PDF."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14852,7 +14840,7 @@ msgstr "Senaste året"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Klistra in"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14870,7 +14858,7 @@ msgstr "Klistra in synkroniseringskod"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Klistra in det nedan"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14929,7 +14917,7 @@ msgstr "Persiska"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14938,6 +14926,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal hittar din information på datamäklarwebbplatser "
+"som säljer den. Sedan arbetar vi för att få den borttagen åt dig."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15151,8 +15141,7 @@ msgstr "Fäst"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Fastnålade chattar kommer att visas högst upp bland dina senaste chattar."
+msgstr "Fastnålade chattar kommer att visas högst upp bland dina senaste chattar."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15193,8 +15182,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Lös följande utmaning för att bekräfta att prompten görs av en människa."
+msgstr "Lös följande utmaning för att bekräfta att prompten görs av en människa."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15202,8 +15190,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Lös följande utmaning för att bekräfta att sökningen görs av en människa."
+msgstr "Lös följande utmaning för att bekräfta att sökningen görs av en människa."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15986,8 +15973,7 @@ msgstr "Fråga mig"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Be mig använda min ungefärliga plats för att få sökresultat i närheten."
+msgstr "Be mig använda min ungefärliga plats för att få sökresultat i närheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16206,7 +16192,7 @@ msgstr "Läser in webbplatsen..."
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Är du redo för solförmörkelsen?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16308,8 +16294,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
-"servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på "
+"DuckDuckGo-servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16318,8 +16304,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
-"servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på "
+"DuckDuckGo-servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16405,7 +16391,7 @@ msgstr "Återställningskod"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Återställningskod"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16662,7 +16648,7 @@ msgstr "Ta bort %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Ta bort enhet"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16710,13 +16696,13 @@ msgstr "Ta bort onödiga skiljetecken"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Ta bort dina uppgifter från internet"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Ta bort dina uppgifter online"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17376,8 +17362,7 @@ msgstr "Spara upp till 30 av dina senaste chattar lokalt på din enhet."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
+msgstr "Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17413,7 +17398,7 @@ msgstr "Säg hej till Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Säg hej till Duck.ai – gratis, privat AI-chatt av DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17560,15 +17545,13 @@ msgstr "Skrolla nedåt och leta reda på %1$sdin webbläsare%2$s i listan."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
+msgstr "Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
+msgstr "Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17910,8 +17893,7 @@ msgstr "En andra åsikt"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
+msgstr "Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17920,8 +17902,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17930,8 +17912,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17950,8 +17932,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Lagra dina chattar på ett säkert sätt på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra dina chattar på ett säkert sätt på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18411,7 +18393,7 @@ msgstr "Serbiska (latinskt)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Serverdata har raderats"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18514,8 +18496,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
+msgstr "Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18572,7 +18553,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Dela"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18726,13 +18707,13 @@ msgstr "Dela med dig av dina tankar om sökrutan."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Delade chattlänkar"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Delade chattlänkar"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19138,14 +19119,12 @@ msgstr "Visar mest besökta länkar i ny flik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
+msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
+msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19163,8 +19142,7 @@ msgstr "Visar sidnummer där sidan med sökresultat bryts"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
+msgstr "Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19190,8 +19168,7 @@ msgstr "Visar välkomstmeddelande högst upp på sidan med sökresultat"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
+msgstr "Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19415,7 +19392,7 @@ msgstr "Något gick fel"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Något gick fel när den här delade chatten skulle laddas."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -20020,8 +19997,7 @@ msgstr "Förslag på rubrik för ett blogginlägg"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
+msgstr "Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20266,7 +20242,7 @@ msgstr "Byt modell"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Byt modell"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20525,7 +20501,7 @@ msgstr "Synkroniserade enheter"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Synkroniserades %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20563,7 +20539,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tabell"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -21003,8 +20979,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
+msgstr "Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21150,7 +21125,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Denna enhet"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21161,6 +21136,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Den här enheten kommer inte längre att få tillgång till dina synkroniserade "
+"data på andra enheter. De sista %1$s chattarna kommer fortfarande att finnas "
+"tillgängliga i lokal lagring."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21249,7 +21227,7 @@ msgstr "Den här informationen är inte användbar"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Det här är en kopia av en delad chatt."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21318,8 +21296,8 @@ msgstr "Denna sida kräver javascript för att fungera."
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
 msgstr ""
-"Innehållet på den här sidan kommer att skickas med ditt meddelande till Duck."
-"ai"
+"Innehållet på den här sidan kommer att skickas med ditt meddelande till "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21369,13 +21347,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Den här delade chatten kunde inte öppnas. Länken kan vara ofullständig."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Den här delade chattlänken är inte längre tillgänglig."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21404,8 +21382,7 @@ msgstr "Denna video kan ännu inte visas här. Du kan titta på den på %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
+msgstr "Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21590,8 +21567,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"För att överföra din chatthistorik till Duck.ai, uppdatera DuckDuckGo-"
-"webbläsaren till den senaste versionen och försök igen."
+"För att överföra din chatthistorik till Duck.ai, uppdatera "
+"DuckDuckGo-webbläsaren till den senaste versionen och försök igen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21623,8 +21600,8 @@ msgstr "Idag"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Växla för att prova privat AI-chatt eller %1$sinaktivera den i menyn %2$s."
-"%3$s"
+"Växla för att prova privat AI-chatt eller %1$sinaktivera den i menyn "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22023,7 +22000,7 @@ msgstr "Prova gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Prova gratis!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22146,7 +22123,7 @@ msgstr "Prova gratis"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Prova gratis!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22395,7 +22372,7 @@ msgstr "Turkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Inaktivera"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22413,7 +22390,7 @@ msgstr "Inaktivera Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Inaktivera Sync & Backup och radera serverdata?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22695,14 +22672,13 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: https://"
-"duckduckgo.com"
+"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
+msgstr "Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22729,8 +22705,7 @@ msgstr "Under sektionen %1$sSök%2$s, klicka på %3$sHantera sökmotorer...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
+msgstr "Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22837,8 +22812,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås upp avancerade AI-modeller och högre gränser med en DuckDuckGo-"
-"prenumeration"
+"Lås upp avancerade AI-modeller och högre gränser med en "
+"DuckDuckGo-prenumeration"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22895,7 +22870,7 @@ msgstr "Slå på ljudet"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Chatt utan titel"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22936,7 +22911,7 @@ msgstr "Uppdatera webbläsare"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Uppdatera Duck.ai för att visa den här delade chatten."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23220,8 +23195,7 @@ msgstr "Använd DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
+msgstr "Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23519,9 +23493,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna Duck."
-"ai-inställningarna. Välj Aktivera under Sync & Backup och välj Synkronisera "
-"med en annan enhet. Eller skanna QR-koden på din återställnings-PDF."
+"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna "
+"Duck.ai-inställningarna. Välj Aktivera under Sync & Backup och välj "
+"Synkronisera med en annan enhet. Eller skanna QR-koden på din "
+"återställnings-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23574,8 +23549,8 @@ msgstr "Röstchatt avslutad"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Röstchatt är anonymiserad av oss och används aldrig för att träna AI-"
-"modeller."
+"Röstchatt är anonymiserad av oss och används aldrig för att träna "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23755,8 +23730,7 @@ msgstr "Vi anonymiserar"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
+msgstr "Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23790,16 +23764,14 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
+msgstr "Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
+msgstr "Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23810,8 +23782,7 @@ msgstr "Vi förföljer dig inte med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Vi lagrar inte användarnamn eller annan personligt identifierbar information."
+msgstr "Vi lagrar inte användarnamn eller annan personligt identifierbar information."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23842,8 +23813,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
+msgstr "Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23920,6 +23890,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Vi hittar och tar bort dina personuppgifter från datamäklarwebbplatser. Plus "
+"får du ett VPN och mer."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23974,6 +23946,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Vi skannar regelbundet datamäklarwebbplatser efter dina personuppgifter och "
+"delar våra framsteg med dig i en lättanvänd översikt."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24011,8 +23985,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
+msgstr "Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24021,6 +23994,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Vi skannar datamäklarwebbplatser efter din e-postadress, ditt namn, din "
+"adress med mera och arbetar för att få bort allt vi hittar om dig."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24221,8 +24196,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
+msgstr "Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24317,8 +24291,7 @@ msgstr "Kan du ge några faktorer man ska tänka på när man köper en datorsk�
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
+msgstr "Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24340,7 +24313,7 @@ msgstr "Kan du ge några för- och nackdelar med livränta?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Vilka är fördelarna med Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24418,8 +24391,7 @@ msgstr "Vilka är de viktigaste lärdomarna?"
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
-"Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
+msgstr "Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
@@ -24444,8 +24416,7 @@ msgstr "Vilka är de mest rekommenderade rätterna här?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
+msgstr "Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24672,8 +24643,7 @@ msgstr "Vad vill du ge feedback om?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
+msgstr "Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24705,8 +24675,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
+msgstr "När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24764,8 +24733,7 @@ msgstr "Vilka är vi"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
-"Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
+msgstr "Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24919,6 +24887,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Fungerar direkt från din enhet för att ta bort din e-postadress, ditt namn, "
+"din adress med mera från datamäklarwebbplatser."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25166,8 +25136,7 @@ msgstr "Ja, ny användare!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, vi slänger data när du är klar med dem och de kan inte återställas."
+msgstr "Ja, vi slänger data när du är klar med dem och de kan inte återställas."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25186,8 +25155,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
+msgstr "Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25373,8 +25341,7 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr ""
-"Du kan återställa dina inställningar efter att du har tagit bort kakor."
+msgstr "Du kan återställa dina inställningar efter att du har tagit bort kakor."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25423,7 +25390,7 @@ msgstr "Du har 1 försök kvar."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Du har inga delade chattlänkar."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25634,8 +25601,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. YouTube-"
-"videor som visas här spåras därför av YouTube/Google."
+"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. "
+"YouTube-videor som visas här spåras därför av YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25657,13 +25624,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"Dina %1$s senaste chattar kommer att finnas tillgängliga i lokal lagring i "
+"dessa webbläsare:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Dina Duck.ai-chattar synkroniseras med end-to-end-kryptering."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25695,6 +25664,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Din säkerhetskopia kommer att raderas från DuckDuckGos server. Alla enheter "
+"kommer att kopplas bort från synkronisering."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25776,8 +25747,8 @@ msgstr "Dina chattar sparas nu."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Dina chattar är privata, sparas aldrig och används inte för att träna AI-"
-"modeller"
+"Dina chattar är privata, sparas aldrig och används inte för att träna "
+"AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25920,10 +25891,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure Hash-"
-"algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande inställningsfil "
-"lämnar din webbläsare. Vi sparar inställningsfilen med nyckeln som namn. "
-"DuckDuckGo känner aldrig till ditt lösenord."
+"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure "
+"Hash-algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande "
+"inställningsfil lämnar din webbläsare. Vi sparar inställningsfilen med "
+"nyckeln som namn. DuckDuckGo känner aldrig till ditt lösenord."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26156,8 +26127,7 @@ msgstr "av %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
+msgstr "av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26371,8 +26341,8 @@ msgstr "den officiella webbplatsen"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat %3$s-"
-"tecken)"
+"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat "
+"%3$s-tecken)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ta_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ta_IN/LC_MESSAGES/duckduckgo.po
@@ -43,6 +43,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% தடுப்பூசி போட்டுக்கொண்டேன்"
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -393,6 +400,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%sஉங்கள் இடத்தை மறைக்க கற்றுக்கொள்ளுங்கள்%s."
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -627,6 +640,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1185,6 +1203,11 @@ msgstr "%s உடன் சேர்க்கவும்"
 msgid "Add to Home Screen"
 msgstr "முகப்பு திரையில் சேற்கவும்"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "துணை நிரல்கள்"
@@ -1478,6 +1501,12 @@ msgstr "அனைத்து அளவு"
 msgctxt "image-type"
 msgid "All types"
 msgstr "அனைத்து வகைகள்"
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
@@ -1891,6 +1920,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4231,6 +4265,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4263,6 +4302,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4823,6 +4881,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4831,6 +4896,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5037,6 +5109,12 @@ msgstr "நிராகரி"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5686,6 +5764,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #  Marked fuzzy because of translated trademark
@@ -6373,9 +6457,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7469,6 +7566,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7553,6 +7657,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9163,6 +9272,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "%sமேலும்%s அறிய"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9683,6 +9797,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9889,6 +10009,11 @@ msgstr "பட்டி"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "பட்டியல்"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10190,6 +10315,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "மேலும்"
@@ -10351,6 +10481,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "முடக்கப்பட்டுள்ளது"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11230,6 +11365,27 @@ msgstr ""
 "Mac ல், %s கிளிக் Maxthon > Preference%s, Windows ல், %sகிளிக் %s icon > "
 "Settings%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11845,6 +12001,11 @@ msgstr "கடந்த வாரம்"
 msgid "Past year"
 msgstr "கடந்த ஆண்டு"
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11853,6 +12014,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11898,6 +12064,18 @@ msgstr ""
 msgctxt "language_name"
 msgid "Persian"
 msgstr "பாரசீக"
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
 msgctxt "Assistant role option label for Personal trainer"
@@ -12913,6 +13091,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13062,6 +13245,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13269,6 +13457,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13302,6 +13495,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13853,6 +14056,11 @@ msgstr "உங்கள் அமைவுகளை மேகத்தில் 
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14639,6 +14847,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "செர்பியன் (லத்தீன்)"
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14765,6 +14979,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14884,6 +15105,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15436,6 +15667,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16125,6 +16361,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16322,6 +16563,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16347,6 +16594,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "தொலைக்காட்சி"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16808,6 +17060,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16876,6 +17142,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16959,6 +17230,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17477,6 +17758,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17569,6 +17855,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17768,6 +18059,11 @@ msgstr "துருக்கிய"
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17776,6 +18072,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18159,6 +18460,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18186,6 +18492,11 @@ msgstr "புதுப்பிக்கவும்"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18967,6 +19278,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -19003,6 +19321,13 @@ msgstr ""
 "உங்களுக்கு நெருக்கமான சிறந்த முடிவுகளை வழங்க, உங்கள் அநாமதேய இருப்பிடத்தை மட்டுமே "
 "நாங்கள் பயன்படுத்துகிறோம். நீங்கள் எப்போது வேண்டுமானாலும் உங்கள் மனதை மாற்றிக்கொள்ளலாம்."
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -19029,6 +19354,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19273,6 +19605,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19737,6 +20074,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20140,6 +20484,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20311,6 +20661,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube தரநிலை"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20328,6 +20693,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/te_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/te_IN/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "%s కు జోడించండి"
 msgid "Add to Home Screen"
 msgstr "హోమ్ స్క్రీన్ పై జత చేసుకోండి"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "పొడగింతలు"
@@ -1471,6 +1494,12 @@ msgstr "అన్ని పరిమాణాలు"
 msgctxt "image-type"
 msgid "All types"
 msgstr "అన్ని రకాలు"
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
@@ -1882,6 +1911,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4197,6 +4231,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4229,6 +4268,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4789,6 +4847,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4797,6 +4862,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5003,6 +5075,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5650,6 +5728,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6312,9 +6396,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7405,6 +7502,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7489,6 +7593,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9076,6 +9185,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "%sఇంకా%s తెలుసుకోండి"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9593,6 +9707,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9799,6 +9919,11 @@ msgstr "మెనూ"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "మెనూ"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10100,6 +10225,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "ఇంకా ఇక్కడ"
@@ -10259,6 +10389,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "నిశబ్దపు ఎరుపు"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11136,6 +11271,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11740,6 +11896,11 @@ msgstr "పోయిన వారం"
 msgid "Past year"
 msgstr "పోయిన సంవత్సరం"
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11748,6 +11909,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11792,6 +11958,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12806,6 +12984,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12955,6 +13138,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13162,6 +13350,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13195,6 +13388,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13743,6 +13946,11 @@ msgstr "మీ అమరికలను అజ్ఞాతంగా క్లౌ
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14507,6 +14715,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14631,6 +14845,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14750,6 +14971,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15297,6 +15528,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15986,6 +16222,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16183,6 +16424,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16208,6 +16455,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "టీవీ"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16660,6 +16912,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16728,6 +16994,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16811,6 +17082,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17325,6 +17606,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17417,6 +17703,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17616,6 +17907,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17624,6 +17920,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18001,6 +18302,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18028,6 +18334,11 @@ msgstr "తాజాకరించు"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18800,6 +19111,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18834,6 +19152,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18858,6 +19183,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19102,6 +19434,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19564,6 +19901,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19964,6 +20308,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20130,6 +20480,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "యూట్యూబ్ ప్రమాణము"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20147,6 +20512,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: th_TH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "% ฉีดวัคซีนครบแล้ว"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% ฉีดวัคซีนแล้ว"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -183,8 +191,7 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
-"Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -195,8 +202,7 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
-"Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -213,8 +219,7 @@ msgid ""
 "model."
 msgstr ""
 "%1$s สามารถใช้ได้เฉพาะกับการสมัครใช้งาน DuckDuckGo เท่านั้น "
-"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
-"หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -222,9 +227,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s ไม่สามารถใช้งานได้ชั่วคราว "
-"โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
+msgstr "%1$s ไม่สามารถใช้งานได้ชั่วคราว โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -322,7 +325,6 @@ msgid ""
 "their servers."
 msgstr ""
 "%1$s ทํางานในสภาพแวดล้อมการดําเนินการที่เชื่อถือได้ "
-""
 "นี่หมายความว่าแม้แต่ผู้ให้บริการโมเดลก็ไม่สามารถดูคำแนะนำของคุณหรือการตอบสนองของโมเดล "
 "หรือบันทึกการแชทนี้บนเซิร์ฟเวอร์ของพวกเขา"
 
@@ -410,8 +412,7 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น "
-"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -421,9 +422,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น "
-"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+msgstr "%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -443,8 +442,7 @@ msgstr "%1$sคลิก%2$sเพิ่ม%3$sเลือก%4$sอนุญ�
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s "
-"จากนั้นคลิก%8$sตกลง%9$s"
+"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s จากนั้นคลิก%8$sตกลง%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -484,21 +482,25 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sเรียนรู้วิธีที่เรารักษาความเป็นส่วนตัวให้กับข้อมูลตำแหน่งที่ตั้งของคุณ%2$s"
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sเรียนรู้เพิ่มเติม%2$s "
-"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
+"%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sเรียนรู้เพิ่มเติม%2$s "
-"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
+msgstr "%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -774,6 +776,12 @@ msgid "2nd in Group %s"
 msgstr "อันดับ 2 ของกลุ่ม %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -976,9 +984,8 @@ msgid ""
 "aichat%s."
 msgstr ""
 "AI Chat ช่วยให้คุณสนทนาแบบไม่ต้องระบุชื่อด้วยโมเดลแชท AI ของบริษัทอื่น "
-"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search "
-"คุณยังคงสามารถเข้าถึง AI Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
-"%1$sduckduckgo.com/aichat%2$s"
+"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search คุณยังคงสามารถเข้าถึง AI Chat "
+"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$sduckduckgo.com/aichat%2$s"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1041,8 +1048,7 @@ msgid ""
 msgstr ""
 "คำตอบที่ได้รับความช่วยเหลือจาก AI ขณะนี้ยังไม่รองรับคำถามที่ถามต่อโดยตรง "
 "แต่เรามีและมักจะเชื่อมโยงไปยัง %1$sDuck.ai%2$s สำหรับคำถามที่ถามต่อ "
-"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic "
-"และอีกมากมาย"
+"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic และอีกมากมาย"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1227,8 +1233,7 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
-"หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1263,9 +1268,7 @@ msgstr "โฆษณา"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s "
-"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+msgstr "การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1273,8 +1276,7 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft "
-"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1453,6 +1455,12 @@ msgid "Add to Home Screen"
 msgstr "เพิ่มไปที่หน้าจอหลัก"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "ส่วนเสริม"
@@ -1603,9 +1611,7 @@ msgstr "หลังจากดาวน์โหลดและเปิด �
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย "
-"ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
+msgstr "หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1742,8 +1748,7 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "การแชททั้งหมดจะถูกทำให้ไม่ระบุชื่อโดย DuckDuckGo "
-"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo "
-"หรือผู้ให้บริการโมเดล"
+"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo หรือผู้ให้บริการโมเดล"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1790,8 +1795,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) "
-"จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ AI"
+"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ "
+"AI"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1810,6 +1815,13 @@ msgstr "ทุกขนาด"
 msgctxt "image-type"
 msgid "All types"
 msgstr "ทุกประเภท"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1855,10 +1867,8 @@ msgid ""
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
 "อนุญาตให้ %1$s ค้นหาเว็บเพื่อปรับปรุงการตอบสนองต่อข้อความแจ้งที่เกี่ยวข้อง "
-"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI "
-"ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
-"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี "
-"%3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
+"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
+"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี %3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2003,8 +2013,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
-"%4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2013,8 +2022,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
-"%4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2028,8 +2036,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ "
-"เลือกความถี่ที่คุณต้องการให้แสดง หรือปิดการใช้งานโดยสมบูรณ์"
+"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ เลือกความถี่ที่คุณต้องการให้แสดง "
+"หรือปิดการใช้งานโดยสมบูรณ์"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2076,8 +2084,7 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น "
-"บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
+"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2197,8 +2204,7 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด "
-"รวมถึงแชทที่ปักหมุดไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด รวมถึงแชทที่ปักหมุดไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2207,8 +2213,7 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด "
-"การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2246,8 +2251,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ "
-"ด้วยตนเอง การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
+"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ ด้วยตนเอง "
+"การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2328,6 +2333,12 @@ msgid "Ask anything privately"
 msgstr "ถามอะไรก็ได้แบบส่วนตัว"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2384,16 +2395,12 @@ msgid ""
 "answers are only available in the U.S. (English) region."
 msgstr ""
 "Assist สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
-""
 "โดยไม่ระบุตัวตนให้กับการค้นหาบางรายการโดยอิงจากการสรุปเนื้อหาเว็บที่เกี่ยวข้อง "
-"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
-"Assist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
-"(แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI เมื่อคุณคลิกปุ่ม Assist), "
-"บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
-"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
-"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา "
-"(ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ Assist UI "
+"ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"เมื่อคุณคลิกปุ่ม Assist), บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
+"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2405,14 +2412,9 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist "
-""
-"เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก "
-"AI สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
-"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
-"ตามข้อมูลที่เกี่ยวข้องที่พบ "
-""
+"Assist เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ "
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -2440,8 +2442,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"ที่คาเฟ่ สนามบิน หรือโรงแรม DuckDuckGo VPN "
-"จะเข้ารหัสการเชื่อมต่อของคุณและซ่อนที่อยู่ IP ของคุณเมื่อใช้ Wi‑Fi"
+"ที่คาเฟ่ สนามบิน หรือโรงแรม DuckDuckGo VPN จะเข้ารหัสการเชื่อมต่อของคุณและซ่อนที่อยู่ IP "
+"ของคุณเมื่อใช้ Wi‑Fi"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2588,8 +2590,8 @@ msgid ""
 "Assist is only available in English regions."
 msgstr ""
 "แสดง Assist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง Assist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
-"Assist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ Assist "
+"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2599,8 +2601,8 @@ msgid ""
 "For now, DuckAssist is only available in English regions."
 msgstr ""
 "แสดง DuckAssist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง DuckAssist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
-"DuckAssist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ DuckAssist "
+"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2806,8 +2808,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ "
-"PII เช่น ชื่อ ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
+"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ PII เช่น ชื่อ "
+"ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3198,17 +3200,15 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ "
-"เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
-"และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
+"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ เรารวมเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา "
-"เครื่องมือบล็อกตัวติดตาม "
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
 "และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
@@ -3217,9 +3217,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง "
-"ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private Search, การบล็อกตัวติดตาม "
-"และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private "
+"Search, การบล็อกตัวติดตาม และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3326,11 +3325,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"ตามค่าเริ่มต้น "
-"การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
+"ตามค่าเริ่มต้น การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
 "(ในเบราว์เซอร์ของคุณ) คุณสามารถใช้ Cloud Save "
-"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ "
-"(บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
+"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ (บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวตนได้บนระบบคลาวด์และรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
 
 # smartling.placeholder_format=C
@@ -3339,9 +3336,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง "
-"คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู "
-"%1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
+"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3350,8 +3346,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง "
-"OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
+"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3838,8 +3834,7 @@ msgstr ""
 "Chat (ผ่านบริการ Duck.ai ของเรา) ให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI "
 "ของบุคคลที่สาม ซึ่งรองรับโมเดลจาก OpenAI, Anthropic และอีกมากมาย "
 "การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม "
-"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
-"%1$shttps://duck.ai%2$s โดยตรง"
+"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3970,8 +3965,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo "
-"หรือเซิร์ฟเวอร์ระยะไกล การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
+"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo หรือเซิร์ฟเวอร์ระยะไกล "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3984,11 +3979,9 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "แชทจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
-"DuckDuckGo หลังจากที่ส่งไปแล้ว "
-"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
-"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
+"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4011,8 +4004,7 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน "
-"Duck.ai "
+"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน Duck.ai "
 "จะได้รับการตรวจสอบโดยไม่ระบุชื่อโดยผู้ให้บริการกลั่นกรองเนื้อหาสำหรับ %2$s"
 
 # smartling.placeholder_format=C
@@ -4073,9 +4065,7 @@ msgstr "ตรวจสอบการสะกดคำ"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"ตรวจสอบ subreddit ของ DuckDuckGo "
-"เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
+msgstr "ตรวจสอบ subreddit ของ DuckDuckGo เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4178,8 +4168,7 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"เลือกจากตำแหน่งเซิร์ฟเวอร์กว่า 40 "
-"แห่งทั่วโลกเพื่อช่วยบล็อกเว็บไซต์ที่เป็นอันตรายและการหลอกลวง"
+"เลือกจากตำแหน่งเซิร์ฟเวอร์กว่า 40 แห่งทั่วโลกเพื่อช่วยบล็อกเว็บไซต์ที่เป็นอันตรายและการหลอกลวง"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4378,9 +4367,8 @@ msgid ""
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชท "
-""
-"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน "
-"AI Chat เป็นเวลา 7 วันขึ้นไป"
+"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน AI "
+"Chat เป็นเวลา 7 วันขึ้นไป"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4391,8 +4379,8 @@ msgid ""
 "on your browser."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชทล่าสุด "
-"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 "
-"วันหากไม่ได้ใช้ Duck.ai ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
+"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 วันหากไม่ได้ใช้ Duck.ai "
+"ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4401,8 +4389,7 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ "
-"บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
+"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4411,8 +4398,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s "
-"บริการแชท AI ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
+"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s บริการแชท AI "
+"ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4454,8 +4441,7 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน "
-"Mac)"
+"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน Mac)"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4486,8 +4472,7 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows "
-"ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
+"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4579,8 +4564,7 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
 "คลิกหรือแตะ %1$sลบข้อมูลของฉัน%2$s การดำเนินการนี้จะลบข้อมูลออกจากระบบคลาวด์ "
-"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ "
-"%3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
+"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ %3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4661,8 +4645,7 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก "
-"%3$sDuckDuckGo%4$s"
+"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก %3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4870,8 +4853,7 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save "
-"ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
+"Cloud Save ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
 "ซึ่งเป็นการดำเนินการที่ไม่บังคับ"
 
 # smartling.placeholder_format=C
@@ -5247,6 +5229,12 @@ msgid "Copy"
 msgstr "คัดลอก"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5286,6 +5274,28 @@ msgstr "คัดลอกหรือบันทึกรหัสนี้"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "คัดลอกรหัสกู้คืน"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5961,6 +5971,14 @@ msgid "Delete recent chats?"
 msgstr "ลบแชทล่าสุดใช่ไหม"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -5971,6 +5989,14 @@ msgstr "ลบแชทนี้ใช่ไหม"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "แชทที่ถูกลบ"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6228,6 +6254,13 @@ msgid "Dismiss"
 msgstr "ปิด"
 
 # smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
 msgctxt "duckassist"
 msgid "Dismiss"
@@ -6399,8 +6432,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ "
-"AI ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ AI "
+"ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6409,8 +6442,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s "
-"เพื่อค้นหาโดยไม่มีฟีเจอร์ AI และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s เพื่อค้นหาโดยไม่มีฟีเจอร์ AI "
+"และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6694,8 +6727,7 @@ msgid ""
 "pages automatically in Settings."
 msgstr ""
 "ตอนนี้ Duck.ai สามารถช่วยตอบคําถามเกี่ยวกับหน้าเว็บที่คุณกำลังดูอยู่ได้แล้ว "
-"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน "
-"ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
+"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6746,8 +6778,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo "
-"แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://duck.ai"
+"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://"
+"duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6762,8 +6794,7 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
-"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
+"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6784,9 +6815,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม "
-"การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai แต่คุณยังสามารถไปที่ "
-"%1$sduck.ai%2$s โดยตรง"
+"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai "
+"แต่คุณยังสามารถไปที่ %1$sduck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6797,10 +6827,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม "
-"รวมถึงโมเดลจาก OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat "
-"และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai "
-"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
+"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม รวมถึงโมเดลจาก "
+"OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo "
+"Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://"
+"duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6861,9 +6891,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI "
-"แบบไม่ระบุตัวตน, แชท AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, "
-"โมเดล AI โอเพนซอร์ส, AI ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
+"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI แบบไม่ระบุตัวตน, แชท "
+"AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, โมเดล AI โอเพนซอร์ส, AI "
+"ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6892,12 +6922,10 @@ msgid ""
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
 "DuckAssist สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง "
-"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
-"DuckAssist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
-"(แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
-"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
-"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) สำหรับตอนนี้ DuckAssist "
-"มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ DuckAssist "
+"UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
+"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) "
+"สำหรับตอนนี้ DuckAssist มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6906,9 +6934,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo "
-"AI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก "
-"OpenAI, Anthropic และอื่นๆ อีกมากมาย"
+"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo AI "
+"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก OpenAI, Anthropic "
+"และอื่นๆ อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6917,9 +6945,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo "
-"%1$sAI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
-"ที่รองรับโมเดลการแชทจาก OpenAI และ Anthropic"
+"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo %1$sAI "
+"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ที่รองรับโมเดลการแชทจาก OpenAI และ "
+"Anthropic"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6932,10 +6960,8 @@ msgid ""
 "checked for accuracy."
 msgstr ""
 "DuckAssist "
-""
 "เป็นคุณลักษณะใหม่ในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia "
-"และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
 "จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ขับเคลื่อนด้วย AI เพื่อสร้างข้อมูลสรุป "
 "โปรดทราบว่าขณะนี้คำตอบนั้นอิงจาก Wikipedia และเนื้อหาที่เกี่ยวข้อง "
 "และไม่ได้มีการตรวจสอบความถูกต้อง"
@@ -6953,16 +6979,11 @@ msgid ""
 "sources and based on %scrawling the web%s."
 msgstr ""
 "DuckAssist "
-""
 "เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
-"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
-"ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
-"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ "
-"โดยอ้างอิงแหล่งที่มาของคำตอบ "
-""
+"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ "
+"AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
+"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ โดยอ้างอิงแหล่งที่มาของคำตอบ "
 "เพื่อให้คุณสามารถไปยังแหล่งข้อมูลเพื่อดูข้อมูลโดยละเอียดเพิ่มเติมได้อย่างง่ายดาย "
-""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -6972,8 +6993,7 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"คำตอบ DuckAssist "
-"สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
+"คำตอบ DuckAssist สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6981,9 +7001,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว "
-"โปรดแชทต่อในวันพรุ่งนี้"
+msgstr "DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว โปรดแชทต่อในวันพรุ่งนี้"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6992,8 +7010,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
-"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
+"%2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7002,8 +7020,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
-"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
+"%2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7020,8 +7038,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
-"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ "
+"%1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7029,9 +7047,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว "
-"โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
+msgstr "DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7064,6 +7080,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "เบราว์เซอร์ DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7180,8 +7203,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น "
-"ชื่อ ที่อยู่อีเมล หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
+"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น ชื่อ ที่อยู่อีเมล "
+"หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7189,8 +7212,7 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s "
-"ของ Duck.ai"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s ของ Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7199,8 +7221,7 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ "
-"%2$s ของเรา"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ %2$s ของเรา"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7209,9 +7230,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม "
-"รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google และ Facebook "
-"ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
+"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google "
+"และ Facebook ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7223,11 +7243,9 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ "
-"เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
+"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
 "ข้อมูลดังกล่าวจะได้รับการจัดเก็บไว้บนอุปกรณ์ของคุณเท่านั้น เมื่อคุณค้นหา "
-"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา "
-"ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
+"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
 "จากนั้นเราจะทิ้งข้อมูลดังกล่าวในทันทีเพื่อให้ไม่มีการระบุตัวตนของคุณได้ "
 "%1$sดูข้อมูลเพิ่มเติมเกี่ยวกับวิธีที่เราออกแบบเทคโนโลยีนี้เพื่อปกป้องความเป็นส่วนตัวของคุณ%2$s"
 
@@ -7249,9 +7267,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ "
-"ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น และใกล้คุณมากขึ้น "
-"%1$sดูข้อมูลเพิ่มเติม%2$s"
+"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น "
+"และใกล้คุณมากขึ้น %1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7343,9 +7360,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน "
-"เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo จากนั้นเราจะสุ่มคำ "
-"4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
+"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo "
+"จากนั้นเราจะสุ่มคำ 4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
 "เพื่อให้มั่นใจว่ารหัสผ่านมีความยาวอักขระอย่างน้อย 18-20 ตัว"
 
 # smartling.placeholder_format=C
@@ -7553,9 +7569,7 @@ msgstr "เปิดใช้งานการค้นหาเว็บ"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น "
-"คุณสามารถเปลี่ยนใจได้ในภายหลัง"
+msgstr "เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น คุณสามารถเปลี่ยนใจได้ในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7761,8 +7775,7 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s "
-"การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
+"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7788,8 +7801,7 @@ msgstr "ป้อนข้อความ"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s "
-"นามแฝง%6$s: d%7$s"
+"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s นามแฝง%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7892,10 +7904,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "ผลิตภัณฑ์ที่ผลิตขึ้นอย่างช่างฝีมือสำหรับผู้ที่ใส่ใจเรื่องความเป็นส่วนตัวอย่างมาก"
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "หมดอายุ"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8174,9 +8201,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง "
-"จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
+msgstr "โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8265,9 +8290,7 @@ msgstr "กรองภาพที่สร้างโดย AI จากผ�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
-"กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ "
-"%1$sดูข้อมูลเพิ่มเติม%2$s"
+msgstr "กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ %1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8539,7 +8562,7 @@ msgstr "แก้ไข แชร์ และใช้ได้อย่าง�
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์ ได้อย่างอิสระ"
+msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -8639,8 +8662,7 @@ msgid ""
 "strong>."
 msgstr ""
 "จากแถบเมนูแอปบน Mac ให้เลือก <strong>DuckDuckGo</strong> &gt; "
-"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก "
-"<strong>ติดตั้งการอัปเดต</strong>"
+"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก <strong>ติดตั้งการอัปเดต</strong>"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8926,8 +8948,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"รับ DuckDuckGo VPN, Duck.ai ขั้นสูง, บริการลบข้อมูลส่วนบุคคล และ Identity "
-"Theft Restoration"
+"รับ DuckDuckGo VPN, Duck.ai ขั้นสูง, บริการลบข้อมูลส่วนบุคคล และ Identity Theft "
+"Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -8992,9 +9014,7 @@ msgstr "เริ่ม"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ "
-"เพียงครั้งเดียว"
+msgstr "รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ เพียงครั้งเดียว"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9015,8 +9035,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน, แชท AI ขั้นสูง (ทางเลือก), "
-"บริการ Personal Info Removal และ Identity Theft Restoration"
+"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน, แชท AI ขั้นสูง (ทางเลือก), บริการ Personal "
+"Info Removal และ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9025,8 +9045,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน (no-log), แชท AI "
-"ขั้นสูงที่เป็นตัวเลือกเสริม และบริการ Identity Theft Restoration"
+"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน (no-log), แชท AI ขั้นสูงที่เป็นตัวเลือกเสริม "
+"และบริการ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9035,8 +9055,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo "
-"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
+"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9047,8 +9067,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo "
-"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
+"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9092,9 +9112,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"รับ VPN ที่รวดเร็ว ไม่เก็บบันทึกการใช้งานของเรา, ตัวเลือกในการเข้าถึงโมเดล "
-"AI ขั้นสูงพร้อมขีดจำกัดการแชทที่สูงขึ้น และการป้องกันระดับพรีเมียมอื่นๆ "
-"อีกมากมาย"
+"รับ VPN ที่รวดเร็ว ไม่เก็บบันทึกการใช้งานของเรา, ตัวเลือกในการเข้าถึงโมเดล AI "
+"ขั้นสูงพร้อมขีดจำกัดการแชทที่สูงขึ้น และการป้องกันระดับพรีเมียมอื่นๆ อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9103,8 +9122,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"รับ VPN ที่ปลอดภัยและไม่เก็บบันทึกของเรา, Duck.ai ขั้นสูง, Personal "
-"Information Removal และ Identity Theft Restoration"
+"รับ VPN ที่ปลอดภัยและไม่เก็บบันทึกของเรา, Duck.ai ขั้นสูง, Personal Information Removal "
+"และ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9112,8 +9131,8 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"รับ VPN แบบไม่บันทึกกิจกรรมที่ปลอดภัย, Duck.ai ขั้นสูง และ Identity Theft "
-"Restoration ของเรา"
+"รับ VPN แบบไม่บันทึกกิจกรรมที่ปลอดภัย, Duck.ai ขั้นสูง และ Identity Theft Restoration "
+"ของเรา"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9213,9 +9232,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
-"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device › Copy Text "
-"Code%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
+"%3$sChats › Sync & Backup › Sync With Another Device › Copy Text Code%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9224,8 +9242,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
-"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
+"%3$sChats › Sync & Backup › Sync With Another Device%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9235,9 +9253,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
-"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
-"แล้วสแกนรหัสนี้:"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
+"%3$sChats › Sync & Backup › Sync With Another Device%4$s แล้วสแกนรหัสนี้:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9247,9 +9264,17 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
-"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
-"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
+"%3$sChats › Sync & Backup › Sync With Another Device%4$s หรือสแกนคิวอาร์บน PDF "
+"การกู้คืนของคุณ"
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9265,8 +9290,7 @@ msgid ""
 "“Location Services” is turned on."
 msgstr ""
 "ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
-"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" "
-"เปิดอยู่"
+"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" เปิดอยู่"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9275,8 +9299,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
-"บริการหาตําแหน่งที่ตั้ง%2$s แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
+"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการหาตําแหน่งที่ตั้ง%2$s "
+"แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9361,6 +9385,12 @@ msgstr "เข้าใจแล้ว"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "เข้าใจแล้ว"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9958,9 +9988,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist "
-"เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
+msgstr "เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10053,8 +10081,7 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor "
-"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10196,7 +10223,6 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-""
 "ฉันจะบอกเพื่อนร่วมงานอย่างมีไหวพริบเกี่ยวกับการเคาะดินสออย่างต่อเนื่องได้อย่างไร "
 "และฉันควรจะพูดว่าอะไร"
 
@@ -10319,9 +10345,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ "
-"ที่คล้ายกันหรือไม่และเพราะเหตุใด"
+msgstr "ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ ที่คล้ายกันหรือไม่และเพราะเหตุใด"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10356,8 +10380,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > "
-"ทั่วไป > รีเซ็ต > \"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > ทั่วไป > รีเซ็ต > "
+"\"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10367,9 +10391,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ "
-"ให้ไปที่ %1$s⋮ > เมนู > การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s "
-"และตรวจสอบว่า DuckDuckGo ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ ให้ไปที่ %1$s⋮ > เมนู > "
+"การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s และตรวจสอบว่า DuckDuckGo "
+"ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10404,8 +10428,7 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
-"คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
+"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
 "คุณสามารถบันทึกโค้ดนี้ลงในอุปกรณ์ของคุณเป็นไฟล์ข้อความได้"
 
 # smartling.placeholder_format=C
@@ -10422,8 +10445,7 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ "
-"%2$s ของเรา"
+"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ %2$s ของเรา"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10431,8 +10453,7 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" "
-"(เปิดด้วย)"
+"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" (เปิดด้วย)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10574,7 +10595,6 @@ msgid ""
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
 "ในเบราว์เซอร์เก่ากว่าบางรายการ "
-""
 "เราจำเป็นต้องเปลี่ยนเส้นทางการคลิกของคุณผ่านเซิร์ฟเวอร์ของเราเพื่อป้องกันการรั่วไหลของข้อมูลการค้นหา "
 "%1$sดูข้อมูลเพิ่มเติม%2$s"
 
@@ -11010,11 +11030,9 @@ msgid ""
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
 "รายการต่างๆ "
-""
 "ได้รับการจัดลำดับตามความเกี่ยวข้องกับข้อความค้นหาของคุณและจัดส่งผ่านเครือข่ายโฆษณาของ "
-"Microsoft การคลิกนำไปสู่หน้า Landing Page "
-"ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา DuckDuckGo "
-"ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
+"Microsoft การคลิกนำไปสู่หน้า Landing Page ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา "
+"DuckDuckGo ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11023,8 +11041,7 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว "
-"และมีความปลอดภัยมากกว่า"
+"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว และมีความปลอดภัยมากกว่า"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11097,8 +11114,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
 msgstr ""
-"รักษาความเป็นส่วนตัวของแอปและกิจกรรมออนไลน์ทั้งหมดของคุณบนอุปกรณ์สูงสุด 5 "
-"เครื่องพร้อมกัน"
+"รักษาความเป็นส่วนตัวของแอปและกิจกรรมออนไลน์ทั้งหมดของคุณบนอุปกรณ์สูงสุด 5 เครื่องพร้อมกัน"
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11330,6 +11346,12 @@ msgstr "เรียนรู้%1$sเพิ่มเติม%2$s"
 msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "เรียนรู้%1$sเพิ่มเติม%2$s"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11961,6 +11983,13 @@ msgid "Manage"
 msgstr "จัดการ"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12210,6 +12239,12 @@ msgstr "เมนู"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "เมนู"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12578,6 +12613,12 @@ msgid "More about Duck.ai"
 msgstr "ข้อมูลเพิ่มเติมเกี่ยวกับ Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "อื่นๆ ที่"
@@ -12770,6 +12811,12 @@ msgstr "ปิดเสียง"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "แดงเรียบ"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13011,11 +13058,9 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
-"DuckDuckGo หลังจากที่ส่งไปแล้ว "
-"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
-"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
+"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13837,8 +13882,32 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows "
-"%3$sให้คลิกไอคอน %4$s > การตั้งค่า%5$s"
+"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows %3$sให้คลิกไอคอน %4$s "
+"> การตั้งค่า%5$s"
+
+# smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13866,8 +13935,7 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ "
-"โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
+"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13893,9 +13961,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น "
-"มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
+msgstr "เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14232,8 +14298,7 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"เครื่องมือค้นหาอื่นๆ "
-"จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
+"เครื่องมือค้นหาอื่นๆ จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
 "แต่เราไม่ติดตามคุณอย่างแน่นอน"
 
 # smartling.placeholder_format=C
@@ -14249,8 +14314,8 @@ msgid ""
 "more premium protections. All in one subscription."
 msgstr ""
 "VPN แบบไม่บันทึกกิจกรรมที่รวดเร็วของเรามาพร้อมกับการแชท AI "
-"ที่ชาญฉลาดยิ่งขึ้นพร้อมขีดจำกัดที่สูงขึ้น รวมถึงการป้องกันระดับพรีเมียมอื่นๆ "
-"อีกมากมาย การสมัครสมาชิกแบบครบวงจรในที่เดียว"
+"ที่ชาญฉลาดยิ่งขึ้นพร้อมขีดจำกัดที่สูงขึ้น รวมถึงการป้องกันระดับพรีเมียมอื่นๆ อีกมากมาย "
+"การสมัครสมาชิกแบบครบวงจรในที่เดียว"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14258,8 +14323,7 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: "
-"เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
+"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14267,9 +14331,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา "
-"เครื่องมือบล็อกตัวติดตาม เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย "
-"พร้อมใช้งานบน %1$siOS และ Android%2$s"
+"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย พร้อมใช้งานบน %1$siOS และ Android%2$s"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14522,8 +14585,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, "
-"ลายนิ้วมือจากเบราว์เซอร์ หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
+"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, ลายนิ้วมือจากเบราว์เซอร์ "
+"หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14590,6 +14653,12 @@ msgid "Past year"
 msgstr "ปีก่อนหน้า"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14600,6 +14669,12 @@ msgstr "วาง"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "วางรหัสซิงค์"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14653,6 +14728,20 @@ msgstr "ปิดถาวร"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "เปอร์เซีย"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14723,10 +14812,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้คำตอบที่ได้รับความช่วยเหลือจาก "
-"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
-"หากต้องการปิดและซ่อนปุ่ม Assist ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
+"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
+"ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14736,9 +14824,8 @@ msgid ""
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า "
-"หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด ให้ไปที่%1$sการตั้งค่า "
-"DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด "
+"ให้ไปที่%1$sการตั้งค่า DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14749,8 +14836,8 @@ msgid ""
 "Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
-"หากต้องการปิดและซ่อนปุ่ม Assist โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
+"โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14798,9 +14885,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ "
-"DuckDuckGo"
+msgstr "เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15725,9 +15810,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น "
-"[แทรกข้อความของคุณเองที่นี่]"
+msgstr "ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น [แทรกข้อความของคุณเองที่นี่]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15899,6 +15982,12 @@ msgid "Reading website…"
 msgstr "กำลังอ่านเว็บไซต์…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16016,9 +16105,8 @@ msgid ""
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
 "การแชทล่าสุดจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ "
-"DuckDuckGo หลังจากที่ส่งไปแล้ว "
-"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ DuckDuckGo "
+"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16087,6 +16175,12 @@ msgstr "การฟื้นตัว"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "รหัสการกู้คืน"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16294,8 +16388,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ "
-"&quot;รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
+"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ &quot;"
+"รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16336,6 +16430,12 @@ msgstr "ลบ %1$s"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "ลบ %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16380,13 +16480,24 @@ msgid "Remove unnecessary punctuation"
 msgstr "ลบเครื่องหมายวรรคตอนที่ไม่จำเป็น"
 
 # smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"ถาม\" ออก "
-"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"ถาม\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -16395,8 +16506,7 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"สร้าง\" ออก "
-"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"สร้าง\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -16455,9 +16565,8 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo "
-"เพื่อช่วยปรับปรุงบริการค้นหาของเรา ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ "
-"%1$s เพื่อช่วยปรับปรุงบริการ"
+"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo เพื่อช่วยปรับปรุงบริการค้นหาของเรา "
+"ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ %1$s เพื่อช่วยปรับปรุงบริการ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16465,8 +16574,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ "
-"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ "
+"ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16475,9 +16584,8 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo "
-"รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ และจะไม่ระบุตัวตน "
-"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ "
+"และจะไม่ระบุตัวตน โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16569,9 +16677,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
-"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
-"หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
+"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
 "%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -16581,9 +16688,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
-"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
-"หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
+"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
 "อยู่ภายใต้%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -16594,11 +16700,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
-"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
-"หรือคำแนะนำทางวิชาชีพอื่น ๆ "
-"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search "
-"Assist อยู่ภายใต้ %1$sข้อกำหนดการให้บริการ%2$sของเรา"
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
+"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่น ๆ "
+"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search Assist อยู่ภายใต้ "
+"%1$sข้อกำหนดการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17070,6 +17175,12 @@ msgid "Say hello to Duck.ai"
 msgstr "ขอแนะนำ Duck.ai"
 
 # smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai!"
@@ -17185,8 +17296,7 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s "
-"(หรือ%5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ%5$sเพิ่มใหม่%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17195,8 +17305,7 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ "
-"%5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ %5$sเพิ่มใหม่%6$s)"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17275,11 +17384,10 @@ msgid ""
 "subset of English speaking regions."
 msgstr ""
 "Search Assist สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการดำเนินการนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น "
-"ๆ คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ "
-"(เฉพาะเมื่อคลิก Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
-"(ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ Search Assist "
-"มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
+"คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ (เฉพาะเมื่อคลิก "
+"Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ "
+"Search Assist มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17287,8 +17395,7 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ "
-"ลองค้นหาอีกครั้ง"
+"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ ลองค้นหาอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17297,9 +17404,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ "
-"ในการทำเช่นนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ "
-"AI เพื่อสร้างคำตอบสั้น ๆ ตามข้อมูลที่พบ"
+"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการทำเช่นนี้ "
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
+"ตามข้อมูลที่พบ"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17420,8 +17527,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" "
-"โดยตรงบน Wikipedia"
+"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" โดยตรงบน "
+"Wikipedia"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17441,8 +17548,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "ค้นหาอย่างเป็นส่วนตัวด้วยแอปหรือส่วนขยายของเรา "
-"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ "
-"%1$sduckduckgo.com%2$s"
+"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ %1$sduckduckgo."
+"com%2$s"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17461,10 +17568,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-""
 "การตั้งค่าการค้นหาจะถูกเก็บไว้ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคลและที่เก็บข้อมูลภายในในเบราว์เซอร์ของคุณ "
 "แต่คุณยังสามารถใช้ Cloud Save "
-""
 "เพื่อจัดเก็บการตั้งค่าของคุณโดยไม่ระบุตัวตนบนเซิร์ฟเวอร์ระยะไกลในคลาวด์ได้อีกด้วย "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวบุคคลได้บนระบบคลาวด์ "
 "และวลีรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
@@ -17586,7 +17691,6 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-""
 "จัดเก็บแชทได้เกือบไม่จำกัดบนเซิร์ฟเวอร์ของเราอย่างปลอดภัยด้วยการเข้ารหัสแบบครบวงจร "
 "และเข้าถึงได้จากอุปกรณ์ที่ซิงค์ทั้งหมดของคุณ"
 
@@ -17765,8 +17869,7 @@ msgstr "เลือก %1$s\"การตั้งค่าสำหรับ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s "
-"ลงในช่องการป้อนข้อมูล"
+"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s ลงในช่องการป้อนข้อมูล"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17831,8 +17934,7 @@ msgstr "เลือก%1$sจัดการส่วนเสริม%2$sจ�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน "
-"Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน Windows)"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17840,8 +17942,7 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน "
-"Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17905,9 +18006,7 @@ msgstr "เลือก%1$sการตั้งค่า%2$s จากนั้
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ "
-"ตามต้องการ)"
+msgstr "เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ ตามต้องการ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18029,8 +18128,7 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ส่งพรอมต์ไปยังโมเดล AI "
-"พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
+"ส่งพรอมต์ไปยังโมเดล AI พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
 "คำแนะนำเหล่านี้จะใช้กับการสนทนาทั้งหมดของคุณต่อไป"
 
 # smartling.placeholder_format=C
@@ -18052,6 +18150,13 @@ msgstr "เซอร์เบีย (ซีริลลิก)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "เซอร์เบีย (ละติน)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18147,16 +18252,13 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ตั้งค่า Sync & Backup "
-"หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
+"ตั้งค่า Sync & Backup หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง "
-"หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
+msgstr "ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18206,6 +18308,14 @@ msgstr "เซเชลส์"
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr "แชร์"
+
+# smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18354,6 +18464,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "แบ่งปันความคิดของคุณในช่องค้นหา"
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18769,8 +18891,7 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ "
-"DuckDuckGo"
+"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19027,6 +19148,12 @@ msgid "Something went wrong"
 msgstr "เกิดข้อผิดพลาดบางอย่าง"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19126,9 +19253,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s "
-"เพื่อลองอีกครั้ง"
+msgstr "ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s เพื่อลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -19607,9 +19732,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ "
-"สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
+msgstr "เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19863,6 +19986,12 @@ msgid "Switch model"
 msgstr "เปลี่ยนโมเดล"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20042,9 +20171,8 @@ msgid ""
 msgstr ""
 "รหัสกู้คืนการซิงค์\n"
 "\n"
-"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท "
-"Duck.ai ของคุณระหว่างอุปกรณ์หลายเครื่อง "
-"และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
+"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท Duck.ai "
+"ของคุณระหว่างอุปกรณ์หลายเครื่อง และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
 "\n"
 "เก็บรักษาข้อมูลนี้ให้ปลอดภัย\n"
 "ทุกคนที่มีสิทธิ์เข้าถึงรหัสนี้สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณ\n"
@@ -20054,11 +20182,9 @@ msgstr ""
 "วิธีการทำงานของโค้ดนี้คืออะไร?\n"
 "1. ไปที่ Duck.ai ในเบราว์เซอร์ของคุณ แล้วเปิดการตั้งค่า Duck.ai\n"
 "2. เลือก \"เปิดใช้งาน Sync & Backup\" จากนั้นเลือก \"Recover Synced Data\"\n"
-"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code "
-"here\"\n"
+"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code here\"\n"
 "\n"
-"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup "
-"เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
+"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
 "ข้อมูลของคุณจะถูกลบออกจากเซิร์ฟเวอร์และไม่สามารถกู้คืนได้"
 
 # smartling.placeholder_format=C
@@ -20116,6 +20242,13 @@ msgid "Synced Devices"
 msgstr "อุปกรณ์ที่ซิงค์แล้ว"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "ซีเรีย"
 
@@ -20146,6 +20279,12 @@ msgstr "แจ้งภายหลัง"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "ทีวี"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20179,8 +20318,7 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"พก Duck.ai ไปกับคุณได้ทุกที่ "
-"รับแบบรวมอยู่ในแอปฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
+"พก Duck.ai ไปกับคุณได้ทุกที่ รับแบบรวมอยู่ในแอปฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
 "ไม่ว่าคุณจะอยู่ที่ไหน"
 
 # smartling.placeholder_format=C
@@ -20190,8 +20328,7 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"พก Duck.ai ไปกับคุณทุกที่ "
-"รับแบบที่รวมอยู่ในเบราว์เซอร์ฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
+"พก Duck.ai ไปกับคุณทุกที่ รับแบบที่รวมอยู่ในเบราว์เซอร์ฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
 "ไม่ว่าคุณจะท่องเว็บอยู่ที่ไหน"
 
 # smartling.placeholder_format=C
@@ -20215,9 +20352,7 @@ msgstr "ควบคุมข้อมูลส่วนบุคคลของ
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai "
-"ดีขึ้นได้อย่างไรบ้าง"
+msgstr "ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai ดีขึ้นได้อย่างไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20438,7 +20573,6 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-""
 "นั่นหมายความว่าข้อมูลที่ส่งระหว่างอุปกรณ์ของคุณกับหน้าเว็บเบื้องหลังลิงก์นี้มีความเสี่ยงมากขึ้นต่อการถูกดักข้อมูลโดยบุคคลที่สาม "
 "ในบางกรณีซึ่งเกิดขึ้นไม่บ่อย ข้อมูลนี้รวมถึงรหัสผ่านหรือรายละเอียดการชำระเงิน"
 
@@ -20480,7 +20614,6 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-""
 "คีย์การเข้ารหัสจะถูกบันทึกไว้เฉพาะในที่เก็บข้อมูลในเครื่องของเบราว์เซอร์ของคุณ "
 "และมีเพียงคุณเท่านั้นที่สามารถเข้าถึงได้"
 
@@ -20503,9 +20636,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ "
-"บนเซิร์ฟเวอร์ของเขา"
+msgstr "ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ บนเซิร์ฟเวอร์ของเขา"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20598,7 +20729,6 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-""
 "สิทธิ์ของเบราว์เซอร์เหล่านี้ใช้เพื่อเพิ่มการปกป้องความเป็นส่วนตัวบนเว็บไซต์ที่คุณเยี่ยมชมโดยการบล็อกตัวติดตามที่ซ่อนอยู่ "
 "การเข้ารหัสการเชื่อมต่อเมื่อสามารถทำได้ และการตั้งค่าให้ DuckDuckGo "
 "เป็นเครื่องมือค้นหาเริ่มต้นของคุณ"
@@ -20646,9 +20776,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป "
-"ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
+msgstr "เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20719,9 +20847,24 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s "
-"แชท AI อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s "
-"สำหรับข้อมูลเพิ่มเติม)"
+"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s แชท AI "
+"อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s สำหรับข้อมูลเพิ่มเติม)"
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20807,14 +20950,20 @@ msgid "This information isn’t useful"
 msgstr "ข้อมูลนี้ไม่เป็นประโยชน์"
 
 # smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"นี่เป็นเพียงตัวอย่างแชทเท่านั้น เปิดเมนูของแชทนี้ (จุดสามจุด) จากนั้นเลือก "
-"ปักหมุด เพื่อให้อยู่ที่ด้านบนสุดของแชท!"
+"นี่เป็นเพียงตัวอย่างแชทเท่านั้น เปิดเมนูของแชทนี้ (จุดสามจุด) จากนั้นเลือก ปักหมุด "
+"เพื่อให้อยู่ที่ด้านบนสุดของแชท!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20843,8 +20992,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน "
-"ผู้ให้บริการโมเดลอื่นๆ เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
+"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน ผู้ให้บริการโมเดลอื่นๆ "
+"เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20853,8 +21002,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ "
-"ผู้ให้บริการโมเดลอื่นๆ ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
+"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ ผู้ให้บริการโมเดลอื่นๆ "
+"ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20891,7 +21040,6 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-""
 "การดำเนินการนี้จะบันทึกการแชทของคุณด้วยการเข้ารหัสแบบครบวงจรบนเซิร์ฟเวอร์ที่ปลอดภัยของ "
 "DuckDuckGo ซึ่งต่อมาสามารถเข้าถึงได้จากเบราว์เซอร์ใดก็ตาม"
 
@@ -20902,9 +21050,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
-"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
-"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
+"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20914,10 +21061,21 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
-"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
-"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
+"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
 "เรามีหน้าเริ่มต้นที่ไม่แสดงคำตอบที่ได้รับความช่วยเหลือจาก AI ด้วยที่ %1$s"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20956,9 +21114,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ "
-"Sync & Backup คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ "
-"ที่เชื่อมต่อกับ Sync & Backup"
+"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ Sync & Backup "
+"คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ ที่เชื่อมต่อกับ Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20967,8 +21124,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ "
-"เว้นแต่ว่าจะมีการปักหมุดไว้ การกระทำนี้ย้อนกลับไม่ได้"
+"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ เว้นแต่ว่าจะมีการปักหมุดไว้ "
+"การกระทำนี้ย้อนกลับไม่ได้"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20986,9 +21143,7 @@ msgstr "การตั้งค่าทั้งหมดของคุณจ
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น "
-"ดำเนินการต่อหรือไม่"
+msgstr "การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น ดำเนินการต่อหรือไม่"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21107,7 +21262,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "วิธีการพิมพ์เส้นทาง:%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
+msgstr ""
+"วิธีการพิมพ์เส้นทาง:"
+"%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21117,8 +21274,7 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ "
-"คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
+"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
 "รหัสนี้อาจถูกบันทึกเป็น PDF บนอุปกรณ์ที่คุณใช้ตั้งค่าการซิงค์ในตอนแรก"
 
 # smartling.placeholder_format=C
@@ -21380,9 +21536,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: "
-"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr "แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21390,9 +21544,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: "
-"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr "แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21554,6 +21706,12 @@ msgid "Try Free"
 msgstr "ลองใช้ฟรี"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21665,6 +21823,12 @@ msgstr "ลองใช้ฟรี"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "ลองใช้ฟรี"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21858,8 +22022,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา "
-"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา %1$sDuckDuckGo No "
+"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21868,8 +22032,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา "
-"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา %1$sDuckDuckGo No "
+"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21908,6 +22072,12 @@ msgid "Turkmenistan"
 msgstr "เติร์กเมนิสถาน"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -21918,6 +22088,12 @@ msgstr "ปิด Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "ปิด Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22189,8 +22365,7 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s "
-"จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22198,8 +22373,7 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: "
-"https://duckduckgo.com"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22315,8 +22489,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus "
-"ถึง 2 เท่า โดยการอัปเกรดเป็น Pro"
+"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า "
+"โดยการอัปเกรดเป็น Pro"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22391,6 +22565,12 @@ msgid "Unmute"
 msgstr "เปิดเสียง"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22424,6 +22604,12 @@ msgstr "อัปเดต"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "อัปเดตเบราว์เซอร์"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22462,8 +22648,7 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai "
-"และเข้าถึงโมเดลขั้นสูง"
+"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai และเข้าถึงโมเดลขั้นสูง"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22691,9 +22876,8 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ "
-"นักต้มตุ๋น และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย "
-"ไม่จำเป็นต้องมีบัญชี"
+"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ นักต้มตุ๋น "
+"และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย ไม่จำเป็นต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22747,9 +22931,7 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr ""
-"ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
-"เก็บรักษาไว้ให้ปลอดภัย"
+msgstr "ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ เก็บรักษาไว้ให้ปลอดภัย"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -22928,9 +23110,7 @@ msgstr "หมู่เกาะเวอร์จิน"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr ""
-"ไปที่ %1$sการตั้งค่า Assist%2$s "
-"เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
+msgstr "ไปที่ %1$sการตั้งค่า Assist%2$s เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -22938,9 +23118,7 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr ""
-"ไปที่ %1$sการตั้งค่า DuckAssist%2$s "
-"เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
+msgstr "ไปที่ %1$sการตั้งค่า DuckAssist%2$s เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -22963,9 +23141,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s "
-"> %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another "
-"Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s > %3$sSync "
+"& Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22975,9 +23152,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก "
-"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
-"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก \"เปิด\" ภายใต้ Sync "
+"& Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22987,9 +23163,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ "
-"%1$sDuck.ai Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s "
-"จากนั้นเลือก %7$sSync With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ %1$sDuck.ai "
+"Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync "
+"With Another Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22999,9 +23175,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า "
-"Duck.ai เลือก \"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
-"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า Duck.ai เลือก "
+"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF "
+"การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23053,10 +23229,7 @@ msgstr "แชทด้วยเสียงสิ้นสุดลง"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-""
-"เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล "
-"AI"
+msgstr "เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23221,10 +23394,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ "
-"เพราะเราต้องสตรีมเนื้อหาจากที่นั่น DuckDuckGo "
-"เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube "
-"ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
+"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ เพราะเราต้องสตรีมเนื้อหาจากที่นั่น "
+"DuckDuckGo เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23236,9 +23407,7 @@ msgstr "เราทำให้ไม่ระบุตัวตน"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s "
-"แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
+msgstr "เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23250,9 +23419,8 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
-"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย โปรดแชร์การสนทนานี้กับ "
-"DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
+"โปรดแชร์การสนทนานี้กับ DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23264,8 +23432,7 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
-"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
 "โปรดแชร์คำแนะนำและการตอบสนองของคุณเพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
@@ -23279,9 +23446,7 @@ msgstr "เราสามารถใช้%1$sตำแหน่งที่�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"เราไม่สามารถอ่านไฟล์ที่แนบมาได้ "
-"เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
+msgstr "เราไม่สามารถอ่านไฟล์ที่แนบมาได้ เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23309,8 +23474,7 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ "
-"เราไม่ติดตามคุณ อย่างแน่นอน"
+"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ เราไม่ติดตามคุณ อย่างแน่นอน"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23323,9 +23487,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"เนื่องจากเราไม่ได้ติดตามคุณ "
-"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
+msgstr "เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23334,8 +23496,7 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"เนื่องจากเราไม่ได้ติดตามคุณ "
-"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
+"เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23396,14 +23557,21 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "เราสิ้นสุดการแชทเนื่องจากไม่มีการใช้งาน ต้องการลองอีกครั้งใช่ไหม"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"เรามีข้อตกลงกับผู้ให้บริการ AI "
-"ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
+"เรามีข้อตกลงกับผู้ให้บริการ AI ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23438,17 +23606,22 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-""
 "เราใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนของคุณเพียงเพื่อให้ได้ผลลัพธ์ที่แม่นยำยิ่งขึ้นและใกล้คุณมากขึ้นเท่านั้น "
 "คุณสามารถเปลี่ยนใจได้เสมอในภายหลัง"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo "
-"ให้ดียิ่งขึ้นสำหรับทุกคน"
+msgstr "เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo ให้ดียิ่งขึ้นสำหรับทุกคน"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23478,14 +23651,21 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr "เราจะบล็อกตัวติดตามที่พยายามรวบรวมข้อมูลของคุณในขณะที่คุณท่องเว็บ"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
 msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ "
-"ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
+"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23518,8 +23698,7 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล "
-"เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
+"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23627,9 +23806,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr ""
-"ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว "
-"คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
+msgstr "ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23643,8 +23820,7 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว "
-"เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
+"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23665,8 +23841,7 @@ msgid ""
 "to train AI models."
 msgstr ""
 "ยินดีต้อนรับสู่ DuckDuckGo AI Chat! เซสชันแชทนี้ขับเคลื่อนโดย %2$s ของ %1$s "
-"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo "
-"หรือใช้เพื่อฝึกโมเดล AI"
+"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo หรือใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23773,15 +23948,19 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ "
-"\"เราต้องทำให้ได้ดีกว่านี้\""
+msgstr "มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ \"เราต้องทำให้ได้ดีกว่านี้\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "ข้อดีและข้อเสียของเงินรายปีมีอะไรบ้าง"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -23794,11 +23973,10 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo "
-"สำหรับผู้ที่สนใจใช้ Duck.ai อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ "
-"DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ ที่ชัดเจนพร้อมชื่อหัวข้อ "
-"โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น ง่าย "
-"และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
+"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo สำหรับผู้ที่สนใจใช้ Duck.ai "
+"อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ "
+"ที่ชัดเจนพร้อมชื่อหัวข้อ โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น "
+"ง่าย และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24346,6 +24524,14 @@ msgid "Without zero provider visibility"
 msgstr "ไม่มีการมองเห็นผู้ให้บริการเป็นศูนย์"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -24633,9 +24819,7 @@ msgstr "คุณสามารถเข้าถึง DuckDuckGo AI Chat ไ�
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน "
-"%2$sการตั้งค่าการค้นหา%3$s"
+msgstr "คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน %2$sการตั้งค่าการค้นหา%3$s"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24644,8 +24828,7 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน "
-"%1$sการตั้งค่าการค้นหา%2$s"
+"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน %1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
@@ -24784,9 +24967,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s "
-"คุณต้องเลิกบล็อกไซต์อื่นก่อน"
+msgstr "คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s คุณต้องเลิกบล็อกไซต์อื่นก่อน"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24837,14 +25018,21 @@ msgid "You have 1 attempt left."
 msgstr "คุณลองได้อีก 1 ครั้ง"
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, "
-"และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า"
+"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 "
+"เท่า"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24919,8 +25107,7 @@ msgid ""
 "browse privately too. It’s already installed and can:"
 msgstr ""
 "ตอนนี้คุณกำลังค้นหาแบบเป็นส่วนตัวใน Chrome ใช้แอปของเราแทน Chrome "
-"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน "
-"แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
+"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24933,8 +25120,7 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว "
-"%1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
+"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว %1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25010,8 +25196,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว "
-"ลบแชทที่เก่าที่สุด %1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว ลบแชทที่เก่าที่สุด "
+"%1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25021,9 +25207,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท "
-"%1$s รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ "
-"แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท %1$s "
+"รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25037,8 +25222,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน "
-"การดูวิดีโอ YouTube ที่นี่จะถูกติดตามโดย YouTube/Google"
+"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน การดูวิดีโอ YouTube "
+"ที่นี่จะถูกติดตามโดย YouTube/Google"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25050,6 +25235,23 @@ msgstr "คำเตือนความเป็นส่วนตัว YouTu
 msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "มาตรฐาน YouTube"
+
+# smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25073,6 +25275,14 @@ msgstr "ตำแหน่งที่ตั้งจริงของคุณ
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "ตำแหน่งจริงของคุณยังคงเป็นส่วนตัว"
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25121,17 +25331,14 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo "
-"ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
+"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo "
-"ไม่เคยเข้าถึงข้อมูลนี้"
+msgstr "เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo ไม่เคยเข้าถึงข้อมูลนี้"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25179,8 +25386,7 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
-"เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25188,8 +25394,7 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
-"เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25289,8 +25494,7 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า "
-"%1$sSHA-2%2$s "
+"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า %1$sSHA-2%2$s "
 "เฉพาะคีย์และไฟล์การตั้งค่าที่เกี่ยวข้องเท่านั้นที่ออกจากเบราว์เซอร์ของคุณ "
 "เราบันทึกไฟล์การตั้งค่าโดยใช้คีย์เป็นชื่อ DuckDuckGo จะไม่ทราบรหัสผ่านของคุณ"
 
@@ -25307,8 +25511,7 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo "
-"และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
+"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
 "เพื่อให้ผู้ให้บริการโมเดลไม่สามารถเชื่อมโยงการสนทนาของคุณกลับไปยังคุณ"
 
 # smartling.placeholder_format=C
@@ -25354,8 +25557,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะรีเซ็ตการตั้งค่าเหล่านั้น "
-"เปิดใช้งานส่วนขยาย %1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร"
+"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะรีเซ็ตการตั้งค่าเหล่านั้น เปิดใช้งานส่วนขยาย "
+"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25364,10 +25567,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"การตั้งค่าของคุณถูกบันทึกไว้แล้ว "
-"แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
-"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร "
-"%3$sศึกษาเพิ่มเติม%4$s"
+"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
+"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25730,9 +25931,7 @@ msgstr "เว็บไซต์อย่างเป็นทางการ"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s "
-"ตัวที่เข้ารหัสแล้ว)"
+msgstr "หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s ตัวที่เข้ารหัสแล้ว)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: th_TH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (อุปกรณ์นี้)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -191,7 +191,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
+"Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -202,7 +203,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
+"Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -219,7 +221,8 @@ msgid ""
 "model."
 msgstr ""
 "%1$s สามารถใช้ได้เฉพาะกับการสมัครใช้งาน DuckDuckGo เท่านั้น "
-"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
+"หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -227,7 +230,9 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$s ไม่สามารถใช้งานได้ชั่วคราว โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
+msgstr ""
+"%1$s ไม่สามารถใช้งานได้ชั่วคราว "
+"โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -325,6 +330,7 @@ msgid ""
 "their servers."
 msgstr ""
 "%1$s ทํางานในสภาพแวดล้อมการดําเนินการที่เชื่อถือได้ "
+""
 "นี่หมายความว่าแม้แต่ผู้ให้บริการโมเดลก็ไม่สามารถดูคำแนะนำของคุณหรือการตอบสนองของโมเดล "
 "หรือบันทึกการแชทนี้บนเซิร์ฟเวอร์ของพวกเขา"
 
@@ -412,7 +418,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น "
+"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -422,7 +429,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+msgstr ""
+"%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น "
+"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -442,7 +451,8 @@ msgstr "%1$sคลิก%2$sเพิ่ม%3$sเลือก%4$sอนุญ�
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s จากนั้นคลิก%8$sตกลง%9$s"
+"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s "
+"จากนั้นคลิก%8$sตกลง%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -486,7 +496,7 @@ msgstr "%1$sเรียนรู้วิธีที่เรารักษ�
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -494,13 +504,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
+"%1$sเรียนรู้เพิ่มเติม%2$s "
+"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
+msgstr ""
+"%1$sเรียนรู้เพิ่มเติม%2$s "
+"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -779,7 +792,7 @@ msgstr "อันดับ 2 ของกลุ่ม %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "ความเห็นที่ 2"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -984,8 +997,9 @@ msgid ""
 "aichat%s."
 msgstr ""
 "AI Chat ช่วยให้คุณสนทนาแบบไม่ต้องระบุชื่อด้วยโมเดลแชท AI ของบริษัทอื่น "
-"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search คุณยังคงสามารถเข้าถึง AI Chat "
-"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$sduckduckgo.com/aichat%2$s"
+"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search "
+"คุณยังคงสามารถเข้าถึง AI Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
+"%1$sduckduckgo.com/aichat%2$s"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1048,7 +1062,8 @@ msgid ""
 msgstr ""
 "คำตอบที่ได้รับความช่วยเหลือจาก AI ขณะนี้ยังไม่รองรับคำถามที่ถามต่อโดยตรง "
 "แต่เรามีและมักจะเชื่อมโยงไปยัง %1$sDuck.ai%2$s สำหรับคำถามที่ถามต่อ "
-"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic และอีกมากมาย"
+"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic "
+"และอีกมากมาย"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1233,7 +1248,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
+"หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1268,7 +1284,9 @@ msgstr "โฆษณา"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr "การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+msgstr ""
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1276,7 +1294,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1458,7 +1477,7 @@ msgstr "เพิ่มไปที่หน้าจอหลัก"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "เพิ่มในแชทของฉัน"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1611,7 +1630,9 @@ msgstr "หลังจากดาวน์โหลดและเปิด �
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
+msgstr ""
+"หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย "
+"ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1748,7 +1769,8 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "การแชททั้งหมดจะถูกทำให้ไม่ระบุชื่อโดย DuckDuckGo "
-"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo หรือผู้ให้บริการโมเดล"
+"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo "
+"หรือผู้ให้บริการโมเดล"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1795,8 +1817,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ "
-"AI"
+"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) "
+"จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ AI"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1821,7 +1843,7 @@ msgstr "ทุกประเภท"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "อุปกรณ์ทั้งหมดของคุณถูกตัดการเชื่อมต่อจาก Sync แล้ว"
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1867,8 +1889,10 @@ msgid ""
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
 "อนุญาตให้ %1$s ค้นหาเว็บเพื่อปรับปรุงการตอบสนองต่อข้อความแจ้งที่เกี่ยวข้อง "
-"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
-"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี %3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
+"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI "
+"ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
+"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี "
+"%3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2013,7 +2037,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
+"%4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2022,7 +2047,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
+"%4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2036,8 +2062,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ เลือกความถี่ที่คุณต้องการให้แสดง "
-"หรือปิดการใช้งานโดยสมบูรณ์"
+"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ "
+"เลือกความถี่ที่คุณต้องการให้แสดง หรือปิดการใช้งานโดยสมบูรณ์"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2084,7 +2110,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
+"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น "
+"บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2204,7 +2231,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด รวมถึงแชทที่ปักหมุดไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด "
+"รวมถึงแชทที่ปักหมุดไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2213,7 +2241,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด "
+"การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2251,8 +2280,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ ด้วยตนเอง "
-"การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
+"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ "
+"ด้วยตนเอง การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2336,7 +2365,7 @@ msgstr "ถามอะไรก็ได้แบบส่วนตัว"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "ถามอะไรก็ได้แบบส่วนตัว"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2395,12 +2424,16 @@ msgid ""
 "answers are only available in the U.S. (English) region."
 msgstr ""
 "Assist สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
+""
 "โดยไม่ระบุตัวตนให้กับการค้นหาบางรายการโดยอิงจากการสรุปเนื้อหาเว็บที่เกี่ยวข้อง "
-"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ Assist UI "
-"ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อคุณคลิกปุ่ม Assist), บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
-"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
+"Assist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
+"(แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI เมื่อคุณคลิกปุ่ม Assist), "
+"บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
+"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา "
+"(ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2412,9 +2445,14 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
-"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ "
+"Assist "
+""
+"เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก "
+"AI สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ "
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
+"ตามข้อมูลที่เกี่ยวข้องที่พบ "
+""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -2442,8 +2480,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"ที่คาเฟ่ สนามบิน หรือโรงแรม DuckDuckGo VPN จะเข้ารหัสการเชื่อมต่อของคุณและซ่อนที่อยู่ IP "
-"ของคุณเมื่อใช้ Wi‑Fi"
+"ที่คาเฟ่ สนามบิน หรือโรงแรม DuckDuckGo VPN "
+"จะเข้ารหัสการเชื่อมต่อของคุณและซ่อนที่อยู่ IP ของคุณเมื่อใช้ Wi‑Fi"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2590,8 +2628,8 @@ msgid ""
 "Assist is only available in English regions."
 msgstr ""
 "แสดง Assist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง Assist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ Assist "
-"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
+"Assist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2601,8 +2639,8 @@ msgid ""
 "For now, DuckAssist is only available in English regions."
 msgstr ""
 "แสดง DuckAssist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง DuckAssist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ DuckAssist "
-"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
+"DuckAssist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2808,8 +2846,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ PII เช่น ชื่อ "
-"ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
+"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ "
+"PII เช่น ชื่อ ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3200,15 +3238,17 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ เรารวมเครื่องมือค้นหา "
-"เครื่องมือบล็อกตัวติดตาม และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
+"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ "
+"เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม "
 "และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
@@ -3217,8 +3257,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private "
-"Search, การบล็อกตัวติดตาม และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง "
+"ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private Search, การบล็อกตัวติดตาม "
+"และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3325,9 +3366,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"ตามค่าเริ่มต้น การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
+"ตามค่าเริ่มต้น "
+"การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
 "(ในเบราว์เซอร์ของคุณ) คุณสามารถใช้ Cloud Save "
-"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ (บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
+"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ "
+"(บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวตนได้บนระบบคลาวด์และรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
 
 # smartling.placeholder_format=C
@@ -3336,8 +3379,9 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
-"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง "
+"คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู "
+"%1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3346,8 +3390,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
-"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง "
+"OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3834,7 +3878,8 @@ msgstr ""
 "Chat (ผ่านบริการ Duck.ai ของเรา) ให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI "
 "ของบุคคลที่สาม ซึ่งรองรับโมเดลจาก OpenAI, Anthropic และอีกมากมาย "
 "การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม "
-"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
+"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
+"%1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3965,8 +4010,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo หรือเซิร์ฟเวอร์ระยะไกล "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
+"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo "
+"หรือเซิร์ฟเวอร์ระยะไกล การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3979,9 +4024,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "แชทจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
+"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4004,7 +4051,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน Duck.ai "
+"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน "
+"Duck.ai "
 "จะได้รับการตรวจสอบโดยไม่ระบุชื่อโดยผู้ให้บริการกลั่นกรองเนื้อหาสำหรับ %2$s"
 
 # smartling.placeholder_format=C
@@ -4065,7 +4113,9 @@ msgstr "ตรวจสอบการสะกดคำ"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "ตรวจสอบ subreddit ของ DuckDuckGo เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
+msgstr ""
+"ตรวจสอบ subreddit ของ DuckDuckGo "
+"เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4168,7 +4218,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"เลือกจากตำแหน่งเซิร์ฟเวอร์กว่า 40 แห่งทั่วโลกเพื่อช่วยบล็อกเว็บไซต์ที่เป็นอันตรายและการหลอกลวง"
+"เลือกจากตำแหน่งเซิร์ฟเวอร์กว่า 40 "
+"แห่งทั่วโลกเพื่อช่วยบล็อกเว็บไซต์ที่เป็นอันตรายและการหลอกลวง"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4367,8 +4418,9 @@ msgid ""
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชท "
-"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน AI "
-"Chat เป็นเวลา 7 วันขึ้นไป"
+""
+"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน "
+"AI Chat เป็นเวลา 7 วันขึ้นไป"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4379,8 +4431,8 @@ msgid ""
 "on your browser."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชทล่าสุด "
-"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 วันหากไม่ได้ใช้ Duck.ai "
-"ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
+"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 "
+"วันหากไม่ได้ใช้ Duck.ai ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4389,7 +4441,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
+"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ "
+"บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4398,8 +4451,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s บริการแชท AI "
-"ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
+"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s "
+"บริการแชท AI ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4441,7 +4494,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน Mac)"
+"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน "
+"Mac)"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4472,7 +4526,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
+"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows "
+"ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4564,7 +4619,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
 "คลิกหรือแตะ %1$sลบข้อมูลของฉัน%2$s การดำเนินการนี้จะลบข้อมูลออกจากระบบคลาวด์ "
-"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ %3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
+"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ "
+"%3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4645,7 +4701,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก %3$sDuckDuckGo%4$s"
+"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก "
+"%3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4853,7 +4910,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
+"Cloud Save "
+"ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
 "ซึ่งเป็นการดำเนินการที่ไม่บังคับ"
 
 # smartling.placeholder_format=C
@@ -5232,7 +5290,7 @@ msgstr "คัดลอก"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "คัดลอก"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5281,13 +5339,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "คัดลอกลิงก์ที่แชร์"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "คัดลอกรหัสจากอุปกรณ์อื่น"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5296,6 +5354,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"คัดลอกรหัสจากอุปกรณ์อื่น ไปที่ %1$sDuck.ai Settings › Chats › Sync & Backup "
+"› Sync With Another Device%2$s แล้วลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5976,7 +6036,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "ลบลิงก์ที่แชร์"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -5997,6 +6057,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"การลบลิงก์จะทำให้ลิงก์ใช้งานไม่ได้ "
+"ผู้ที่เคยเปิดและเพิ่มการสนทนาลงในแชทของตนเองแล้วจะยังคงมีสำเนาของตนเองอยู่"
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6258,7 +6320,7 @@ msgstr "ปิด"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "ปิด"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6432,8 +6494,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ AI "
-"ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ "
+"AI ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6442,8 +6504,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s เพื่อค้นหาโดยไม่มีฟีเจอร์ AI "
-"และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s "
+"เพื่อค้นหาโดยไม่มีฟีเจอร์ AI และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6727,7 +6789,8 @@ msgid ""
 "pages automatically in Settings."
 msgstr ""
 "ตอนนี้ Duck.ai สามารถช่วยตอบคําถามเกี่ยวกับหน้าเว็บที่คุณกำลังดูอยู่ได้แล้ว "
-"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
+"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน "
+"ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6778,8 +6841,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://"
-"duck.ai"
+"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo "
+"แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6794,7 +6857,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
+"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
+"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6815,8 +6879,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai "
-"แต่คุณยังสามารถไปที่ %1$sduck.ai%2$s โดยตรง"
+"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม "
+"การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai แต่คุณยังสามารถไปที่ "
+"%1$sduck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6827,10 +6892,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม รวมถึงโมเดลจาก "
-"OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo "
-"Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://"
-"duck.ai%2$s โดยตรง"
+"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม "
+"รวมถึงโมเดลจาก OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat "
+"และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai "
+"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6891,9 +6956,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI แบบไม่ระบุตัวตน, แชท "
-"AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, โมเดล AI โอเพนซอร์ส, AI "
-"ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
+"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI "
+"แบบไม่ระบุตัวตน, แชท AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, "
+"โมเดล AI โอเพนซอร์ส, AI ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6922,10 +6987,12 @@ msgid ""
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
 "DuckAssist สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง "
-"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ DuckAssist "
-"UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
-"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) "
-"สำหรับตอนนี้ DuckAssist มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
+"DuckAssist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
+"(แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
+"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) สำหรับตอนนี้ DuckAssist "
+"มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6934,9 +7001,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo AI "
-"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก OpenAI, Anthropic "
-"และอื่นๆ อีกมากมาย"
+"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo "
+"AI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก "
+"OpenAI, Anthropic และอื่นๆ อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6945,9 +7012,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo %1$sAI "
-"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ที่รองรับโมเดลการแชทจาก OpenAI และ "
-"Anthropic"
+"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo "
+"%1$sAI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ที่รองรับโมเดลการแชทจาก OpenAI และ Anthropic"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6960,8 +7027,10 @@ msgid ""
 "checked for accuracy."
 msgstr ""
 "DuckAssist "
+""
 "เป็นคุณลักษณะใหม่ในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia "
+"และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
 "จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ขับเคลื่อนด้วย AI เพื่อสร้างข้อมูลสรุป "
 "โปรดทราบว่าขณะนี้คำตอบนั้นอิงจาก Wikipedia และเนื้อหาที่เกี่ยวข้อง "
 "และไม่ได้มีการตรวจสอบความถูกต้อง"
@@ -6979,11 +7048,16 @@ msgid ""
 "sources and based on %scrawling the web%s."
 msgstr ""
 "DuckAssist "
+""
 "เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ "
-"AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
-"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ โดยอ้างอิงแหล่งที่มาของคำตอบ "
+"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
+"ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
+"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ "
+"โดยอ้างอิงแหล่งที่มาของคำตอบ "
+""
 "เพื่อให้คุณสามารถไปยังแหล่งข้อมูลเพื่อดูข้อมูลโดยละเอียดเพิ่มเติมได้อย่างง่ายดาย "
+""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -6993,7 +7067,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"คำตอบ DuckAssist สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
+"คำตอบ DuckAssist "
+"สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7001,7 +7076,9 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr "DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว โปรดแชทต่อในวันพรุ่งนี้"
+msgstr ""
+"DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว "
+"โปรดแชทต่อในวันพรุ่งนี้"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7010,8 +7087,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
-"%2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7020,8 +7097,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
-"%2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7038,8 +7115,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ "
-"%1$s ไปที่ %2$s"
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
+"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7047,7 +7124,9 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
+msgstr ""
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว "
+"โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7086,7 +7165,7 @@ msgstr "เบราว์เซอร์ DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "หน้าช่วยเหลือ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7203,8 +7282,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น ชื่อ ที่อยู่อีเมล "
-"หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
+"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น "
+"ชื่อ ที่อยู่อีเมล หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7212,7 +7291,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s ของ Duck.ai"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s "
+"ของ Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7221,7 +7301,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ %2$s ของเรา"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ "
+"%2$s ของเรา"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7230,8 +7311,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google "
-"และ Facebook ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
+"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม "
+"รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google และ Facebook "
+"ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7243,9 +7325,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
+"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ "
+"เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
 "ข้อมูลดังกล่าวจะได้รับการจัดเก็บไว้บนอุปกรณ์ของคุณเท่านั้น เมื่อคุณค้นหา "
-"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
+"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา "
+"ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
 "จากนั้นเราจะทิ้งข้อมูลดังกล่าวในทันทีเพื่อให้ไม่มีการระบุตัวตนของคุณได้ "
 "%1$sดูข้อมูลเพิ่มเติมเกี่ยวกับวิธีที่เราออกแบบเทคโนโลยีนี้เพื่อปกป้องความเป็นส่วนตัวของคุณ%2$s"
 
@@ -7267,8 +7351,9 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น "
-"และใกล้คุณมากขึ้น %1$sดูข้อมูลเพิ่มเติม%2$s"
+"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ "
+"ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น และใกล้คุณมากขึ้น "
+"%1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7360,8 +7445,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo "
-"จากนั้นเราจะสุ่มคำ 4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
+"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน "
+"เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo จากนั้นเราจะสุ่มคำ "
+"4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
 "เพื่อให้มั่นใจว่ารหัสผ่านมีความยาวอักขระอย่างน้อย 18-20 ตัว"
 
 # smartling.placeholder_format=C
@@ -7569,7 +7655,9 @@ msgstr "เปิดใช้งานการค้นหาเว็บ"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr "เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น คุณสามารถเปลี่ยนใจได้ในภายหลัง"
+msgstr ""
+"เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น "
+"คุณสามารถเปลี่ยนใจได้ในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7775,7 +7863,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
+"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s "
+"การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7801,7 +7890,8 @@ msgstr "ป้อนข้อความ"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s นามแฝง%6$s: d%7$s"
+"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s "
+"นามแฝง%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7908,7 +7998,7 @@ msgstr "ผลิตภัณฑ์ที่ผลิตขึ้นอย่า
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "หมดอายุ"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7922,7 +8012,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "หมดอายุ %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8201,7 +8291,9 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
+msgstr ""
+"โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง "
+"จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8290,7 +8382,9 @@ msgstr "กรองภาพที่สร้างโดย AI จากผ�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr "กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ %1$sดูข้อมูลเพิ่มเติม%2$s"
+msgstr ""
+"กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ "
+"%1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8562,7 +8656,7 @@ msgstr "แก้ไข แชร์ และใช้ได้อย่าง�
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์"
+msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์ ได้อย่างอิสระ"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -8662,7 +8756,8 @@ msgid ""
 "strong>."
 msgstr ""
 "จากแถบเมนูแอปบน Mac ให้เลือก <strong>DuckDuckGo</strong> &gt; "
-"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก <strong>ติดตั้งการอัปเดต</strong>"
+"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก "
+"<strong>ติดตั้งการอัปเดต</strong>"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8948,8 +9043,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"รับ DuckDuckGo VPN, Duck.ai ขั้นสูง, บริการลบข้อมูลส่วนบุคคล และ Identity Theft "
-"Restoration"
+"รับ DuckDuckGo VPN, Duck.ai ขั้นสูง, บริการลบข้อมูลส่วนบุคคล และ Identity "
+"Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9014,7 +9109,9 @@ msgstr "เริ่ม"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ เพียงครั้งเดียว"
+msgstr ""
+"รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ "
+"เพียงครั้งเดียว"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9035,8 +9132,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน, แชท AI ขั้นสูง (ทางเลือก), บริการ Personal "
-"Info Removal และ Identity Theft Restoration"
+"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน, แชท AI ขั้นสูง (ทางเลือก), "
+"บริการ Personal Info Removal และ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9045,8 +9142,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน (no-log), แชท AI ขั้นสูงที่เป็นตัวเลือกเสริม "
-"และบริการ Identity Theft Restoration"
+"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน (no-log), แชท AI "
+"ขั้นสูงที่เป็นตัวเลือกเสริม และบริการ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9055,8 +9152,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
-"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo "
+"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9067,8 +9164,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
-"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo "
+"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9112,8 +9209,9 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"รับ VPN ที่รวดเร็ว ไม่เก็บบันทึกการใช้งานของเรา, ตัวเลือกในการเข้าถึงโมเดล AI "
-"ขั้นสูงพร้อมขีดจำกัดการแชทที่สูงขึ้น และการป้องกันระดับพรีเมียมอื่นๆ อีกมากมาย"
+"รับ VPN ที่รวดเร็ว ไม่เก็บบันทึกการใช้งานของเรา, ตัวเลือกในการเข้าถึงโมเดล "
+"AI ขั้นสูงพร้อมขีดจำกัดการแชทที่สูงขึ้น และการป้องกันระดับพรีเมียมอื่นๆ "
+"อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9122,8 +9220,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"รับ VPN ที่ปลอดภัยและไม่เก็บบันทึกของเรา, Duck.ai ขั้นสูง, Personal Information Removal "
-"และ Identity Theft Restoration"
+"รับ VPN ที่ปลอดภัยและไม่เก็บบันทึกของเรา, Duck.ai ขั้นสูง, Personal "
+"Information Removal และ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9131,8 +9229,8 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"รับ VPN แบบไม่บันทึกกิจกรรมที่ปลอดภัย, Duck.ai ขั้นสูง และ Identity Theft Restoration "
-"ของเรา"
+"รับ VPN แบบไม่บันทึกกิจกรรมที่ปลอดภัย, Duck.ai ขั้นสูง และ Identity Theft "
+"Restoration ของเรา"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9232,8 +9330,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device › Copy Text Code%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device › Copy Text "
+"Code%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9242,8 +9341,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9253,8 +9352,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device%4$s แล้วสแกนรหัสนี้:"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
+"แล้วสแกนรหัสนี้:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9264,9 +9364,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device%4$s หรือสแกนคิวอาร์บน PDF "
-"การกู้คืนของคุณ"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9275,6 +9375,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
+"Another Device%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9290,7 +9392,8 @@ msgid ""
 "“Location Services” is turned on."
 msgstr ""
 "ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
-"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" เปิดอยู่"
+"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" "
+"เปิดอยู่"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9299,8 +9402,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการหาตําแหน่งที่ตั้ง%2$s "
-"แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
+"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
+"บริการหาตําแหน่งที่ตั้ง%2$s แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9390,7 +9493,7 @@ msgstr "เข้าใจแล้ว"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "เข้าใจแล้ว"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9988,7 +10091,9 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr "เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
+msgstr ""
+"เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist "
+"เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10081,7 +10186,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10223,6 +10329,7 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
+""
 "ฉันจะบอกเพื่อนร่วมงานอย่างมีไหวพริบเกี่ยวกับการเคาะดินสออย่างต่อเนื่องได้อย่างไร "
 "และฉันควรจะพูดว่าอะไร"
 
@@ -10345,7 +10452,9 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr "ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ ที่คล้ายกันหรือไม่และเพราะเหตุใด"
+msgstr ""
+"ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ "
+"ที่คล้ายกันหรือไม่และเพราะเหตุใด"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10380,8 +10489,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > ทั่วไป > รีเซ็ต > "
-"\"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > "
+"ทั่วไป > รีเซ็ต > \"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10391,9 +10500,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ ให้ไปที่ %1$s⋮ > เมนู > "
-"การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s และตรวจสอบว่า DuckDuckGo "
-"ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ "
+"ให้ไปที่ %1$s⋮ > เมนู > การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s "
+"และตรวจสอบว่า DuckDuckGo ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10428,7 +10537,8 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
+"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
+"คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
 "คุณสามารถบันทึกโค้ดนี้ลงในอุปกรณ์ของคุณเป็นไฟล์ข้อความได้"
 
 # smartling.placeholder_format=C
@@ -10445,7 +10555,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ %2$s ของเรา"
+"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ "
+"%2$s ของเรา"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10453,7 +10564,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" (เปิดด้วย)"
+"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" "
+"(เปิดด้วย)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10595,6 +10707,7 @@ msgid ""
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
 "ในเบราว์เซอร์เก่ากว่าบางรายการ "
+""
 "เราจำเป็นต้องเปลี่ยนเส้นทางการคลิกของคุณผ่านเซิร์ฟเวอร์ของเราเพื่อป้องกันการรั่วไหลของข้อมูลการค้นหา "
 "%1$sดูข้อมูลเพิ่มเติม%2$s"
 
@@ -11030,9 +11143,11 @@ msgid ""
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
 "รายการต่างๆ "
+""
 "ได้รับการจัดลำดับตามความเกี่ยวข้องกับข้อความค้นหาของคุณและจัดส่งผ่านเครือข่ายโฆษณาของ "
-"Microsoft การคลิกนำไปสู่หน้า Landing Page ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา "
-"DuckDuckGo ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
+"Microsoft การคลิกนำไปสู่หน้า Landing Page "
+"ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา DuckDuckGo "
+"ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11041,7 +11156,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว และมีความปลอดภัยมากกว่า"
+"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว "
+"และมีความปลอดภัยมากกว่า"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11114,7 +11230,8 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
 msgstr ""
-"รักษาความเป็นส่วนตัวของแอปและกิจกรรมออนไลน์ทั้งหมดของคุณบนอุปกรณ์สูงสุด 5 เครื่องพร้อมกัน"
+"รักษาความเป็นส่วนตัวของแอปและกิจกรรมออนไลน์ทั้งหมดของคุณบนอุปกรณ์สูงสุด 5 "
+"เครื่องพร้อมกัน"
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11351,7 +11468,7 @@ msgstr "เรียนรู้%1$sเพิ่มเติม%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "ศึกษาเพิ่มเติม"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11987,7 +12104,7 @@ msgstr "จัดการ"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "จัดการ"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12244,7 +12361,7 @@ msgstr "เมนู"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "ข้อความหลังจากนี้จะมองเห็นได้เฉพาะคุณเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12616,7 +12733,7 @@ msgstr "ข้อมูลเพิ่มเติมเกี่ยวกับ
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "การดำเนินการอื่นๆ"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12816,7 +12933,7 @@ msgstr "แดงเรียบ"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "อุปกรณ์ของฉัน"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13058,9 +13175,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
+"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13882,8 +14001,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows %3$sให้คลิกไอคอน %4$s "
-"> การตั้งค่า%5$s"
+"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows "
+"%3$sให้คลิกไอคอน %4$s > การตั้งค่า%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -13892,6 +14011,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup "
+"› Sync With Another Device%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -13900,6 +14021,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup "
+"› Sync With Another Device%4$s แล้วสแกนรหัสนี้:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -13908,6 +14031,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup "
+"› Sync With Another Device%4$s หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13935,7 +14060,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
+"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ "
+"โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13961,7 +14087,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
+msgstr ""
+"เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น "
+"มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14298,7 +14426,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"เครื่องมือค้นหาอื่นๆ จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
+"เครื่องมือค้นหาอื่นๆ "
+"จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
 "แต่เราไม่ติดตามคุณอย่างแน่นอน"
 
 # smartling.placeholder_format=C
@@ -14314,8 +14443,8 @@ msgid ""
 "more premium protections. All in one subscription."
 msgstr ""
 "VPN แบบไม่บันทึกกิจกรรมที่รวดเร็วของเรามาพร้อมกับการแชท AI "
-"ที่ชาญฉลาดยิ่งขึ้นพร้อมขีดจำกัดที่สูงขึ้น รวมถึงการป้องกันระดับพรีเมียมอื่นๆ อีกมากมาย "
-"การสมัครสมาชิกแบบครบวงจรในที่เดียว"
+"ที่ชาญฉลาดยิ่งขึ้นพร้อมขีดจำกัดที่สูงขึ้น รวมถึงการป้องกันระดับพรีเมียมอื่นๆ "
+"อีกมากมาย การสมัครสมาชิกแบบครบวงจรในที่เดียว"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14323,7 +14452,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
+"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: "
+"เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14331,8 +14461,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
-"เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย พร้อมใช้งานบน %1$siOS และ Android%2$s"
+"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย "
+"พร้อมใช้งานบน %1$siOS และ Android%2$s"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14585,8 +14716,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, ลายนิ้วมือจากเบราว์เซอร์ "
-"หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
+"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, "
+"ลายนิ้วมือจากเบราว์เซอร์ หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14656,7 +14787,7 @@ msgstr "ปีก่อนหน้า"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "วาง"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14674,7 +14805,7 @@ msgstr "วางรหัสซิงค์"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "วางไว้ด้านล่าง"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14733,7 +14864,7 @@ msgstr "เปอร์เซีย"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14742,6 +14873,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal "
+"ค้นหาข้อมูลของคุณบนเว็บไซต์นายหน้าข้อมูลที่ขายข้อมูลนั้น "
+"จากนั้นเราดำเนินการเพื่อให้ข้อมูลนั้นถูกลบออกแทนคุณ"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14812,9 +14946,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
+""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้คำตอบที่ได้รับความช่วยเหลือจาก "
-"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
-"ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
+"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
+"หากต้องการปิดและซ่อนปุ่ม Assist ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14824,8 +14959,9 @@ msgid ""
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด "
-"ให้ไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า "
+"หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด ให้ไปที่%1$sการตั้งค่า "
+"DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14836,8 +14972,8 @@ msgid ""
 "Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
-"โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
+"หากต้องการปิดและซ่อนปุ่ม Assist โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14885,7 +15021,9 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ DuckDuckGo"
+msgstr ""
+"เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ "
+"DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15810,7 +15948,9 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น [แทรกข้อความของคุณเองที่นี่]"
+msgstr ""
+"ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น "
+"[แทรกข้อความของคุณเองที่นี่]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15985,7 +16125,7 @@ msgstr "กำลังอ่านเว็บไซต์…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "พร้อมสำหรับสุริยุปราคาแล้วหรือยัง?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16105,8 +16245,9 @@ msgid ""
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
 "การแชทล่าสุดจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16180,7 +16321,7 @@ msgstr "รหัสการกู้คืน"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "รหัสการกู้คืน"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16388,8 +16529,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ &quot;"
-"รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
+"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ "
+"&quot;รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16435,7 +16576,7 @@ msgstr "ลบ %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "ลบอุปกรณ์"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16483,13 +16624,13 @@ msgstr "ลบเครื่องหมายวรรคตอนที่ไ
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "ลบข้อมูลของคุณออกจากอินเทอร์เน็ต"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "ลบข้อมูลของคุณทางออนไลน์"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16497,7 +16638,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"ถาม\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"ถาม\" ออก "
+"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -16506,7 +16648,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"สร้าง\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"สร้าง\" ออก "
+"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -16565,8 +16708,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo เพื่อช่วยปรับปรุงบริการค้นหาของเรา "
-"ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ %1$s เพื่อช่วยปรับปรุงบริการ"
+"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo "
+"เพื่อช่วยปรับปรุงบริการค้นหาของเรา ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ "
+"%1$s เพื่อช่วยปรับปรุงบริการ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16574,8 +16718,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ "
-"ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ "
+"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16584,8 +16728,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ "
-"และจะไม่ระบุตัวตน โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo "
+"รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ และจะไม่ระบุตัวตน "
+"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16677,8 +16822,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
 "%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -16688,8 +16834,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
 "อยู่ภายใต้%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -16700,10 +16847,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่น ๆ "
-"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search Assist อยู่ภายใต้ "
-"%1$sข้อกำหนดการให้บริการ%2$sของเรา"
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่น ๆ "
+"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search "
+"Assist อยู่ภายใต้ %1$sข้อกำหนดการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17178,7 +17326,7 @@ msgstr "ขอแนะนำ Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "ขอแนะนำ Duck.ai – แชท AI ฟรีและเป็นส่วนตัวโดย DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17296,7 +17444,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ%5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s "
+"(หรือ%5$sเพิ่มใหม่%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17305,7 +17454,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ %5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ "
+"%5$sเพิ่มใหม่%6$s)"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17384,10 +17534,11 @@ msgid ""
 "subset of English speaking regions."
 msgstr ""
 "Search Assist สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการดำเนินการนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
-"คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ (เฉพาะเมื่อคลิก "
-"Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ "
-"Search Assist มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น "
+"ๆ คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ "
+"(เฉพาะเมื่อคลิก Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ Search Assist "
+"มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17395,7 +17546,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ ลองค้นหาอีกครั้ง"
+"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ "
+"ลองค้นหาอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17404,9 +17556,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการทำเช่นนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
-"ตามข้อมูลที่พบ"
+"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ "
+"ในการทำเช่นนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ "
+"AI เพื่อสร้างคำตอบสั้น ๆ ตามข้อมูลที่พบ"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17527,8 +17679,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" โดยตรงบน "
-"Wikipedia"
+"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" "
+"โดยตรงบน Wikipedia"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17548,8 +17700,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "ค้นหาอย่างเป็นส่วนตัวด้วยแอปหรือส่วนขยายของเรา "
-"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ %1$sduckduckgo."
-"com%2$s"
+"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ "
+"%1$sduckduckgo.com%2$s"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17568,8 +17720,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
+""
 "การตั้งค่าการค้นหาจะถูกเก็บไว้ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคลและที่เก็บข้อมูลภายในในเบราว์เซอร์ของคุณ "
 "แต่คุณยังสามารถใช้ Cloud Save "
+""
 "เพื่อจัดเก็บการตั้งค่าของคุณโดยไม่ระบุตัวตนบนเซิร์ฟเวอร์ระยะไกลในคลาวด์ได้อีกด้วย "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวบุคคลได้บนระบบคลาวด์ "
 "และวลีรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
@@ -17691,6 +17845,7 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
+""
 "จัดเก็บแชทได้เกือบไม่จำกัดบนเซิร์ฟเวอร์ของเราอย่างปลอดภัยด้วยการเข้ารหัสแบบครบวงจร "
 "และเข้าถึงได้จากอุปกรณ์ที่ซิงค์ทั้งหมดของคุณ"
 
@@ -17869,7 +18024,8 @@ msgstr "เลือก %1$s\"การตั้งค่าสำหรับ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s ลงในช่องการป้อนข้อมูล"
+"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s "
+"ลงในช่องการป้อนข้อมูล"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17934,7 +18090,8 @@ msgstr "เลือก%1$sจัดการส่วนเสริม%2$sจ�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน "
+"Windows)"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17942,7 +18099,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน "
+"Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18006,7 +18164,9 @@ msgstr "เลือก%1$sการตั้งค่า%2$s จากนั้
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr "เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ ตามต้องการ)"
+msgstr ""
+"เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ "
+"ตามต้องการ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18128,7 +18288,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ส่งพรอมต์ไปยังโมเดล AI พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
+"ส่งพรอมต์ไปยังโมเดล AI "
+"พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
 "คำแนะนำเหล่านี้จะใช้กับการสนทนาทั้งหมดของคุณต่อไป"
 
 # smartling.placeholder_format=C
@@ -18156,7 +18317,7 @@ msgstr "เซอร์เบีย (ละติน)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "ลบข้อมูลเซิร์ฟเวอร์แล้ว"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18252,13 +18413,16 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ตั้งค่า Sync & Backup หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
+"ตั้งค่า Sync & Backup "
+"หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
+msgstr ""
+"ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง "
+"หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18315,7 +18479,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "แชร์"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18469,13 +18633,13 @@ msgstr "แบ่งปันความคิดของคุณในช่
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "ลิงก์แชทที่แชร์"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "ลิงก์แชทที่แชร์"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18891,7 +19055,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ DuckDuckGo"
+"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ "
+"DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19151,7 +19316,7 @@ msgstr "เกิดข้อผิดพลาดบางอย่าง"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "เกิดข้อผิดพลาดบางอย่างในการโหลดแชทที่แชร์นี้"
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19253,7 +19418,9 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s เพื่อลองอีกครั้ง"
+msgstr ""
+"ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s "
+"เพื่อลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -19732,7 +19899,9 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
+msgstr ""
+"เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ "
+"สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19989,7 +20158,7 @@ msgstr "เปลี่ยนโมเดล"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "เปลี่ยนโมเดล"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20171,8 +20340,9 @@ msgid ""
 msgstr ""
 "รหัสกู้คืนการซิงค์\n"
 "\n"
-"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท Duck.ai "
-"ของคุณระหว่างอุปกรณ์หลายเครื่อง และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
+"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท "
+"Duck.ai ของคุณระหว่างอุปกรณ์หลายเครื่อง "
+"และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
 "\n"
 "เก็บรักษาข้อมูลนี้ให้ปลอดภัย\n"
 "ทุกคนที่มีสิทธิ์เข้าถึงรหัสนี้สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณ\n"
@@ -20182,9 +20352,11 @@ msgstr ""
 "วิธีการทำงานของโค้ดนี้คืออะไร?\n"
 "1. ไปที่ Duck.ai ในเบราว์เซอร์ของคุณ แล้วเปิดการตั้งค่า Duck.ai\n"
 "2. เลือก \"เปิดใช้งาน Sync & Backup\" จากนั้นเลือก \"Recover Synced Data\"\n"
-"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code here\"\n"
+"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code "
+"here\"\n"
 "\n"
-"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
+"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup "
+"เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
 "ข้อมูลของคุณจะถูกลบออกจากเซิร์ฟเวอร์และไม่สามารถกู้คืนได้"
 
 # smartling.placeholder_format=C
@@ -20246,7 +20418,7 @@ msgstr "อุปกรณ์ที่ซิงค์แล้ว"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "ซิงค์เมื่อ %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20284,7 +20456,7 @@ msgstr "ทีวี"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "ตาราง"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20318,7 +20490,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"พก Duck.ai ไปกับคุณได้ทุกที่ รับแบบรวมอยู่ในแอปฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
+"พก Duck.ai ไปกับคุณได้ทุกที่ "
+"รับแบบรวมอยู่ในแอปฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
 "ไม่ว่าคุณจะอยู่ที่ไหน"
 
 # smartling.placeholder_format=C
@@ -20328,7 +20501,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"พก Duck.ai ไปกับคุณทุกที่ รับแบบที่รวมอยู่ในเบราว์เซอร์ฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
+"พก Duck.ai ไปกับคุณทุกที่ "
+"รับแบบที่รวมอยู่ในเบราว์เซอร์ฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
 "ไม่ว่าคุณจะท่องเว็บอยู่ที่ไหน"
 
 # smartling.placeholder_format=C
@@ -20352,7 +20526,9 @@ msgstr "ควบคุมข้อมูลส่วนบุคคลของ
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai ดีขึ้นได้อย่างไรบ้าง"
+msgstr ""
+"ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai "
+"ดีขึ้นได้อย่างไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20573,6 +20749,7 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
+""
 "นั่นหมายความว่าข้อมูลที่ส่งระหว่างอุปกรณ์ของคุณกับหน้าเว็บเบื้องหลังลิงก์นี้มีความเสี่ยงมากขึ้นต่อการถูกดักข้อมูลโดยบุคคลที่สาม "
 "ในบางกรณีซึ่งเกิดขึ้นไม่บ่อย ข้อมูลนี้รวมถึงรหัสผ่านหรือรายละเอียดการชำระเงิน"
 
@@ -20614,6 +20791,7 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
+""
 "คีย์การเข้ารหัสจะถูกบันทึกไว้เฉพาะในที่เก็บข้อมูลในเครื่องของเบราว์เซอร์ของคุณ "
 "และมีเพียงคุณเท่านั้นที่สามารถเข้าถึงได้"
 
@@ -20636,7 +20814,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ บนเซิร์ฟเวอร์ของเขา"
+msgstr ""
+"ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ "
+"บนเซิร์ฟเวอร์ของเขา"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20729,6 +20909,7 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
+""
 "สิทธิ์ของเบราว์เซอร์เหล่านี้ใช้เพื่อเพิ่มการปกป้องความเป็นส่วนตัวบนเว็บไซต์ที่คุณเยี่ยมชมโดยการบล็อกตัวติดตามที่ซ่อนอยู่ "
 "การเข้ารหัสการเชื่อมต่อเมื่อสามารถทำได้ และการตั้งค่าให้ DuckDuckGo "
 "เป็นเครื่องมือค้นหาเริ่มต้นของคุณ"
@@ -20776,7 +20957,9 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr "เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
+msgstr ""
+"เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป "
+"ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20847,14 +21030,15 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s แชท AI "
-"อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s สำหรับข้อมูลเพิ่มเติม)"
+"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s "
+"แชท AI อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s "
+"สำหรับข้อมูลเพิ่มเติม)"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "อุปกรณ์นี้"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -20865,6 +21049,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"อุปกรณ์นี้จะไม่สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณบนอุปกรณ์อื่นได้อีกต่อไป แชท "
+"%1$s ครั้งสุดท้ายจะยังคงมีอยู่ในที่เก็บข้อมูลท้องถิ่น"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20953,7 +21139,7 @@ msgstr "ข้อมูลนี้ไม่เป็นประโยชน์
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "นี่คือสำเนาของแชทที่แชร์"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -20962,8 +21148,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"นี่เป็นเพียงตัวอย่างแชทเท่านั้น เปิดเมนูของแชทนี้ (จุดสามจุด) จากนั้นเลือก ปักหมุด "
-"เพื่อให้อยู่ที่ด้านบนสุดของแชท!"
+"นี่เป็นเพียงตัวอย่างแชทเท่านั้น เปิดเมนูของแชทนี้ (จุดสามจุด) จากนั้นเลือก "
+"ปักหมุด เพื่อให้อยู่ที่ด้านบนสุดของแชท!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20992,8 +21178,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน ผู้ให้บริการโมเดลอื่นๆ "
-"เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
+"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน "
+"ผู้ให้บริการโมเดลอื่นๆ เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21002,8 +21188,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ ผู้ให้บริการโมเดลอื่นๆ "
-"ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
+"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ "
+"ผู้ให้บริการโมเดลอื่นๆ ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21040,6 +21226,7 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
+""
 "การดำเนินการนี้จะบันทึกการแชทของคุณด้วยการเข้ารหัสแบบครบวงจรบนเซิร์ฟเวอร์ที่ปลอดภัยของ "
 "DuckDuckGo ซึ่งต่อมาสามารถเข้าถึงได้จากเบราว์เซอร์ใดก็ตาม"
 
@@ -21050,8 +21237,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
-"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
+"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
+"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21061,21 +21249,22 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
-"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
+"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
+"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
 "เรามีหน้าเริ่มต้นที่ไม่แสดงคำตอบที่ได้รับความช่วยเหลือจาก AI ด้วยที่ %1$s"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "ไม่สามารถเปิดแชทที่แชร์นี้ได้ ลิงก์อาจไม่สมบูรณ์"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "ลิงก์แชทที่แชร์นี้ไม่มีให้ใช้งานอีกต่อไป"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21114,8 +21303,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ Sync & Backup "
-"คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ ที่เชื่อมต่อกับ Sync & Backup"
+"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ "
+"Sync & Backup คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ "
+"ที่เชื่อมต่อกับ Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21124,8 +21314,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ เว้นแต่ว่าจะมีการปักหมุดไว้ "
-"การกระทำนี้ย้อนกลับไม่ได้"
+"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ "
+"เว้นแต่ว่าจะมีการปักหมุดไว้ การกระทำนี้ย้อนกลับไม่ได้"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21143,7 +21333,9 @@ msgstr "การตั้งค่าทั้งหมดของคุณจ
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น ดำเนินการต่อหรือไม่"
+msgstr ""
+"การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น "
+"ดำเนินการต่อหรือไม่"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21262,9 +21454,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"วิธีการพิมพ์เส้นทาง:"
-"%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
+msgstr "วิธีการพิมพ์เส้นทาง:%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21274,7 +21464,8 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
+"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ "
+"คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
 "รหัสนี้อาจถูกบันทึกเป็น PDF บนอุปกรณ์ที่คุณใช้ตั้งค่าการซิงค์ในตอนแรก"
 
 # smartling.placeholder_format=C
@@ -21536,7 +21727,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr ""
+"แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: "
+"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21544,7 +21737,9 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr ""
+"แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: "
+"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21709,7 +21904,7 @@ msgstr "ลองใช้ฟรี"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "ลองใช้ฟรี!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21828,7 +22023,7 @@ msgstr "ลองใช้ฟรี"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "ลองใช้ฟรี!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22022,8 +22217,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา %1$sDuckDuckGo No "
-"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา "
+"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22032,8 +22227,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา %1$sDuckDuckGo No "
-"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา "
+"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22075,7 +22270,7 @@ msgstr "เติร์กเมนิสถาน"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "ปิด"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22093,7 +22288,7 @@ msgstr "ปิด Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "ปิด Sync & Backup และลบข้อมูลเซิร์ฟเวอร์?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22365,7 +22560,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s "
+"จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22373,7 +22569,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: https://duckduckgo.com"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22489,8 +22686,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า "
-"โดยการอัปเกรดเป็น Pro"
+"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus "
+"ถึง 2 เท่า โดยการอัปเกรดเป็น Pro"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22568,7 +22765,7 @@ msgstr "เปิดเสียง"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "แชทไม่มีชื่อ"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22609,7 +22806,7 @@ msgstr "อัปเดตเบราว์เซอร์"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "อัปเดต Duck.ai เพื่อดูแชทที่แชร์นี้"
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22648,7 +22845,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai และเข้าถึงโมเดลขั้นสูง"
+"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai "
+"และเข้าถึงโมเดลขั้นสูง"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22876,8 +23074,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ นักต้มตุ๋น "
-"และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย ไม่จำเป็นต้องมีบัญชี"
+"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ "
+"นักต้มตุ๋น และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย "
+"ไม่จำเป็นต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22931,7 +23130,9 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr "ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ เก็บรักษาไว้ให้ปลอดภัย"
+msgstr ""
+"ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
+"เก็บรักษาไว้ให้ปลอดภัย"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23110,7 +23311,9 @@ msgstr "หมู่เกาะเวอร์จิน"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr "ไปที่ %1$sการตั้งค่า Assist%2$s เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
+msgstr ""
+"ไปที่ %1$sการตั้งค่า Assist%2$s "
+"เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23118,7 +23321,9 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr "ไปที่ %1$sการตั้งค่า DuckAssist%2$s เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
+msgstr ""
+"ไปที่ %1$sการตั้งค่า DuckAssist%2$s "
+"เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23141,8 +23346,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s > %3$sSync "
-"& Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s "
+"> %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another "
+"Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23152,8 +23358,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก \"เปิด\" ภายใต้ Sync "
-"& Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก "
+"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23163,9 +23370,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ %1$sDuck.ai "
-"Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync "
-"With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ "
+"%1$sDuck.ai Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s "
+"จากนั้นเลือก %7$sSync With Another Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23175,9 +23382,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า Duck.ai เลือก "
-"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF "
-"การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า "
+"Duck.ai เลือก \"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23229,7 +23436,10 @@ msgstr "แชทด้วยเสียงสิ้นสุดลง"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล AI"
+msgstr ""
+""
+"เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล "
+"AI"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23394,8 +23604,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ เพราะเราต้องสตรีมเนื้อหาจากที่นั่น "
-"DuckDuckGo เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
+"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ "
+"เพราะเราต้องสตรีมเนื้อหาจากที่นั่น DuckDuckGo "
+"เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube "
+"ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23407,7 +23619,9 @@ msgstr "เราทำให้ไม่ระบุตัวตน"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
+msgstr ""
+"เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s "
+"แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23419,8 +23633,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
-"โปรดแชร์การสนทนานี้กับ DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
+"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย โปรดแชร์การสนทนานี้กับ "
+"DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23432,7 +23647,8 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
+"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
 "โปรดแชร์คำแนะนำและการตอบสนองของคุณเพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
@@ -23446,7 +23662,9 @@ msgstr "เราสามารถใช้%1$sตำแหน่งที่�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "เราไม่สามารถอ่านไฟล์ที่แนบมาได้ เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
+msgstr ""
+"เราไม่สามารถอ่านไฟล์ที่แนบมาได้ "
+"เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23474,7 +23692,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ เราไม่ติดตามคุณ อย่างแน่นอน"
+"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ "
+"เราไม่ติดตามคุณ อย่างแน่นอน"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23487,7 +23706,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
+msgstr ""
+"เนื่องจากเราไม่ได้ติดตามคุณ "
+"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23496,7 +23717,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
+"เนื่องจากเราไม่ได้ติดตามคุณ "
+"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23563,6 +23785,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"เราค้นหาและลบข้อมูลส่วนตัวของคุณออกจากเว็บไซต์นายหน้าข้อมูล นอกจากนี้ยังรับ "
+"VPN และอื่นๆ"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23571,7 +23795,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"เรามีข้อตกลงกับผู้ให้บริการ AI ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
+"เรามีข้อตกลงกับผู้ให้บริการ AI "
+"ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23606,6 +23831,7 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
+""
 "เราใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนของคุณเพียงเพื่อให้ได้ผลลัพธ์ที่แม่นยำยิ่งขึ้นและใกล้คุณมากขึ้นเท่านั้น "
 "คุณสามารถเปลี่ยนใจได้เสมอในภายหลัง"
 
@@ -23616,12 +23842,16 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"เราสแกนเว็บไซต์นายหน้าข้อมูลอย่างสม่ำเสมอเพื่อค้นหาข้อมูลส่วนบุคคลของคุณ "
+"และเราแชร์ความคืบหน้ากับคุณในแดชบอร์ดที่ใช้งานง่าย"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo ให้ดียิ่งขึ้นสำหรับทุกคน"
+msgstr ""
+"เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo "
+"ให้ดียิ่งขึ้นสำหรับทุกคน"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23657,6 +23887,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"เราจะสแกนเว็บไซต์นายหน้าข้อมูลเพื่อค้นหาอีเมล ชื่อ ที่อยู่ และข้อมูลอื่นๆ "
+"ของคุณ และดำเนินการเพื่อให้ทุกสิ่งที่เราพบเกี่ยวกับคุณถูกลบออก"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23665,7 +23897,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
+"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ "
+"ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23698,7 +23931,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
+"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล "
+"เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23806,7 +24040,9 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
+msgstr ""
+"ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว "
+"คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23820,7 +24056,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
+"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว "
+"เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23841,7 +24078,8 @@ msgid ""
 "to train AI models."
 msgstr ""
 "ยินดีต้อนรับสู่ DuckDuckGo AI Chat! เซสชันแชทนี้ขับเคลื่อนโดย %2$s ของ %1$s "
-"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo หรือใช้เพื่อฝึกโมเดล AI"
+"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo "
+"หรือใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23948,7 +24186,9 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ \"เราต้องทำให้ได้ดีกว่านี้\""
+msgstr ""
+"มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ "
+"\"เราต้องทำให้ได้ดีกว่านี้\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23960,7 +24200,7 @@ msgstr "ข้อดีและข้อเสียของเงินรา
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Duck.ai มีประโยชน์อะไรบ้าง?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -23973,10 +24213,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo สำหรับผู้ที่สนใจใช้ Duck.ai "
-"อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ "
-"ที่ชัดเจนพร้อมชื่อหัวข้อ โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น "
-"ง่าย และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
+"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo "
+"สำหรับผู้ที่สนใจใช้ Duck.ai อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ "
+"DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ ที่ชัดเจนพร้อมชื่อหัวข้อ "
+"โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น ง่าย "
+"และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24530,6 +24771,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"ทำงานโดยตรงจากอุปกรณ์ของคุณเพื่อลบอีเมล ชื่อ ที่อยู่ และข้อมูลอื่นๆ "
+"ของคุณออกจากเว็บไซต์นายหน้าข้อมูล"
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24819,7 +25062,9 @@ msgstr "คุณสามารถเข้าถึง DuckDuckGo AI Chat ไ�
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr "คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน %2$sการตั้งค่าการค้นหา%3$s"
+msgstr ""
+"คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน "
+"%2$sการตั้งค่าการค้นหา%3$s"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24828,7 +25073,8 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน %1$sการตั้งค่าการค้นหา%2$s"
+"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน "
+"%1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
@@ -24967,7 +25213,9 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr "คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s คุณต้องเลิกบล็อกไซต์อื่นก่อน"
+msgstr ""
+"คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s "
+"คุณต้องเลิกบล็อกไซต์อื่นก่อน"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25022,7 +25270,7 @@ msgstr "คุณลองได้อีก 1 ครั้ง"
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "คุณไม่มีลิงก์แชทที่แชร์"
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25031,8 +25279,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 "
-"เท่า"
+"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, "
+"และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25107,7 +25355,8 @@ msgid ""
 "browse privately too. It’s already installed and can:"
 msgstr ""
 "ตอนนี้คุณกำลังค้นหาแบบเป็นส่วนตัวใน Chrome ใช้แอปของเราแทน Chrome "
-"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
+"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน "
+"แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25120,7 +25369,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว %1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
+"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว "
+"%1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25196,8 +25446,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว ลบแชทที่เก่าที่สุด "
-"%1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว "
+"ลบแชทที่เก่าที่สุด %1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25207,8 +25457,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท %1$s "
-"รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท "
+"%1$s รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ "
+"แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25222,8 +25473,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน การดูวิดีโอ YouTube "
-"ที่นี่จะถูกติดตามโดย YouTube/Google"
+"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน "
+"การดูวิดีโอ YouTube ที่นี่จะถูกติดตามโดย YouTube/Google"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25245,13 +25496,15 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
+"การแชทล่าสุด %1$s "
+"รายการของคุณจะพร้อมใช้งานในที่เก็บข้อมูลในเครื่องบนเบราว์เซอร์เหล่านี้:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "การแชท Duck.ai ของคุณกำลังถูกซิงค์ด้วยการเข้ารหัสแบบครบวงจร"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25283,6 +25536,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"ข้อมูลสำรองของคุณจะถูกลบออกจากเซิร์ฟเวอร์ของ DuckDuckGo "
+"อุปกรณ์ทั้งหมดจะถูกตัดการเชื่อมต่อจากการซิงค์"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25331,14 +25586,17 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
+"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo "
+"ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr "เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo ไม่เคยเข้าถึงข้อมูลนี้"
+msgstr ""
+"เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo "
+"ไม่เคยเข้าถึงข้อมูลนี้"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25386,7 +25644,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
+"เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25394,7 +25653,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
+"เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25494,7 +25754,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า %1$sSHA-2%2$s "
+"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า "
+"%1$sSHA-2%2$s "
 "เฉพาะคีย์และไฟล์การตั้งค่าที่เกี่ยวข้องเท่านั้นที่ออกจากเบราว์เซอร์ของคุณ "
 "เราบันทึกไฟล์การตั้งค่าโดยใช้คีย์เป็นชื่อ DuckDuckGo จะไม่ทราบรหัสผ่านของคุณ"
 
@@ -25511,7 +25772,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
+"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo "
+"และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
 "เพื่อให้ผู้ให้บริการโมเดลไม่สามารถเชื่อมโยงการสนทนาของคุณกลับไปยังคุณ"
 
 # smartling.placeholder_format=C
@@ -25557,8 +25819,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะรีเซ็ตการตั้งค่าเหล่านั้น เปิดใช้งานส่วนขยาย "
-"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร"
+"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะรีเซ็ตการตั้งค่าเหล่านั้น "
+"เปิดใช้งานส่วนขยาย %1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25567,8 +25829,10 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
-"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร %3$sศึกษาเพิ่มเติม%4$s"
+"การตั้งค่าของคุณถูกบันทึกไว้แล้ว "
+"แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
+"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร "
+"%3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25931,7 +26195,9 @@ msgstr "เว็บไซต์อย่างเป็นทางการ"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s ตัวที่เข้ารหัสแล้ว)"
+msgstr ""
+"หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s "
+"ตัวที่เข้ารหัสแล้ว)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/tl_PH/LC_MESSAGES/duckduckgo.po
+++ b/locales/tl_PH/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr "Idagdag sa %s"
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Mga add-on"
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4195,6 +4229,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4227,6 +4266,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4787,6 +4845,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4795,6 +4860,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5001,6 +5073,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5648,6 +5726,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6310,9 +6394,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7405,6 +7502,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7489,6 +7593,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9077,6 +9186,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "Matuto Nang %sHigit Pa%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9594,6 +9708,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9799,6 +9919,11 @@ msgstr "Talaan"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10101,6 +10226,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Higit pa sa"
@@ -10258,6 +10388,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Kulay pula na hindi matingkad"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11135,6 +11270,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11739,6 +11895,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11747,6 +11908,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11791,6 +11957,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12805,6 +12983,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12954,6 +13137,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13161,6 +13349,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13194,6 +13387,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13742,6 +13945,11 @@ msgstr "I-save ang iyong mga setting habang nakabalatkayo sa cloud."
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14508,6 +14716,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14632,6 +14846,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14751,6 +14972,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15298,6 +15529,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15987,6 +16223,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16184,6 +16425,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16208,6 +16455,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16661,6 +16913,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16729,6 +16995,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16812,6 +17083,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17326,6 +17607,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17418,6 +17704,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17617,6 +17908,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17625,6 +17921,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18002,6 +18303,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18029,6 +18335,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18795,6 +19106,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18829,6 +19147,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18853,6 +19178,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19097,6 +19429,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19559,6 +19896,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19963,6 +20307,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20129,6 +20479,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20146,6 +20511,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
@@ -44,6 +44,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -396,6 +403,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -630,6 +643,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1183,6 +1201,11 @@ msgstr "o wan tawa ijo %s"
 msgid "Add to Home Screen"
 msgstr "pali e ona tawa ilo tawa lukin tomo"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "namako"
@@ -1475,6 +1498,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1886,6 +1915,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4210,6 +4244,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4242,6 +4281,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4802,6 +4860,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4810,6 +4875,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5016,6 +5088,12 @@ msgstr "lukin ala"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5664,6 +5742,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6326,9 +6410,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7424,6 +7521,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7508,6 +7612,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9102,6 +9211,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "sona %ssin%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9619,6 +9733,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9825,6 +9945,11 @@ msgstr "lipu ijo mute"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "lipu ijo mute"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10126,6 +10251,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "ijo sin lon"
@@ -10283,6 +10413,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "loje lili"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11162,6 +11297,27 @@ msgstr ""
 "lon ilo Mac, %spali ”Maxthon” > ”Preferences”%s. lon ilo Windows, %spali e "
 "sitelen %s > ”Settings”%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11770,6 +11926,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11778,6 +11939,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11822,6 +11988,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12837,6 +13015,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12986,6 +13169,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13193,6 +13381,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13226,6 +13419,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13775,6 +13978,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14552,6 +14760,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14676,6 +14890,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14795,6 +15016,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15342,6 +15573,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16031,6 +16267,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16228,6 +16469,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16253,6 +16500,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "ilo tawa lukin"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16707,6 +16959,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16775,6 +17041,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16858,6 +17129,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17374,6 +17655,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17466,6 +17752,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17665,6 +17956,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17673,6 +17969,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18054,6 +18355,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18081,6 +18387,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18853,6 +19164,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18887,6 +19205,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18911,6 +19236,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19155,6 +19487,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19619,6 +19956,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20023,6 +20367,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20192,6 +20542,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "nasin lipu YouTube"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20209,6 +20574,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
+++ b/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr ""
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Kisim mo."
@@ -1469,6 +1492,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1879,6 +1908,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4193,6 +4227,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4225,6 +4264,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4785,6 +4843,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4793,6 +4858,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -4999,6 +5071,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5646,6 +5724,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6308,9 +6392,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7401,6 +7498,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7485,6 +7589,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9069,6 +9178,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr ""
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9586,6 +9700,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9791,6 +9911,11 @@ msgstr ""
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10093,6 +10218,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr ""
@@ -10249,6 +10379,11 @@ msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
+msgstr ""
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
 msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -11127,6 +11262,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11731,6 +11887,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11739,6 +11900,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11783,6 +11949,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12797,6 +12975,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12946,6 +13129,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13153,6 +13341,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13186,6 +13379,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13734,6 +13937,11 @@ msgstr ""
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14498,6 +14706,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14622,6 +14836,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14741,6 +14962,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15288,6 +15519,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15977,6 +16213,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16174,6 +16415,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16198,6 +16445,11 @@ msgid "TBD"
 msgstr ""
 
 msgid "TV"
+msgstr ""
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
 msgstr ""
 
 #. The name of the Tahitian language
@@ -16651,6 +16903,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16719,6 +16985,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16802,6 +17073,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17316,6 +17597,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17408,6 +17694,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17607,6 +17898,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17615,6 +17911,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -17992,6 +18293,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18019,6 +18325,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18785,6 +19096,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18819,6 +19137,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18843,6 +19168,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19087,6 +19419,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19549,6 +19886,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19949,6 +20293,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20113,6 +20463,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20130,6 +20495,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Bu cihaz)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -380,8 +380,7 @@ msgstr "%1$s kullanıldı"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s, limitleri temel modellere göre 2-5 kata kadar daha hızlı tüketir %2$s"
+msgstr "%1$s, limitleri temel modellere göre 2-5 kata kadar daha hızlı tüketir %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -504,7 +503,7 @@ msgstr "%1$sKonumunuzu nasıl gizli tuttuğumuzu öğrenin%2$s."
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sDaha fazla bilgi%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -802,7 +801,7 @@ msgstr "%1$s Grubu'nda 2."
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "2. görüş"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -968,8 +967,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
+msgstr "Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1495,7 +1493,7 @@ msgstr "Ana Ekrana Ekle"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Sohbetlerime Ekle"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1652,8 +1650,7 @@ msgstr "İndirdikten ve açtıktan sonra %1$sYükle%2$s seçeneğine tıklayın"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
+msgstr "İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1866,7 +1863,7 @@ msgstr "Tüm biçimler"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Tüm cihazlarının Sync bağlantısı kesildi."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1956,8 +1953,7 @@ msgstr "Zaten senkronize edildi."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
+msgstr "Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2247,8 +2243,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
+msgstr "Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2398,7 +2393,7 @@ msgstr "Gizli bir şekilde her şeyi sorabilirsiniz"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Gizli bir şekilde her şeyi sorabilirsiniz"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2507,8 +2502,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"Kafede, havaalanında veya otelde DuckDuckGo VPN, bağlantınızı şifreler ve Wi-"
-"Fi üzerindeki IP adresinizi gizler."
+"Kafede, havaalanında veya otelde DuckDuckGo VPN, bağlantınızı şifreler ve "
+"Wi-Fi üzerindeki IP adresinizi gizler."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2571,15 +2566,13 @@ msgstr "Ses"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -3037,8 +3030,7 @@ msgstr "Bu siteyi tüm sonuçlarda engelleyin"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
+msgstr "Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3465,8 +3457,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
+msgstr "Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -4534,8 +4525,7 @@ msgstr "%1$sEkle%2$s seçeneğine tıklayın"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr ""
-"%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
+msgstr "%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -4648,15 +4638,13 @@ msgstr "Açılır menüden %1$sArama Ayarlarını Değiştir%2$s seçeneğine t�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sSet as Default%s towards the bottom"
-msgstr ""
-"Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
+msgstr "Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
+msgstr "Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4737,8 +4725,7 @@ msgstr "Adres çubuğundaki %1$sizinler simgesine%2$s tıklayın"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
+msgstr "Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4790,8 +4777,7 @@ msgstr "Arama çubuğundaki büyüteç simgesine tıklayın"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
+msgstr "Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5358,7 +5344,7 @@ msgstr "Kopyala"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Kopyala"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5409,13 +5395,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Paylaşılan Bağlantıyı Kopyala"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Kodu başka bir cihazdan kopyalayın"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5424,6 +5410,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Kodu başka bir cihazdan kopyalayın. %1$sDuck.ai Ayarları › Sohbetler › Sync "
+"& Backup › Başka Bir Cihazla Senkronize Et%2$s bölümüne gidin ve tekrar "
+"deneyin."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5809,8 +5798,7 @@ msgstr "Günlük limit doldu"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr "Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6111,7 +6099,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Paylaşılan Bağlantıyı Sil"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6132,6 +6120,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Bir bağlantı silinirse artık çalışmayacaktır. Bağlantıyı açıp konuşmayı "
+"kendi sohbetlerine ekleyen kişiler kendi kopyalarını saklamaya devam eder."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6395,7 +6385,7 @@ msgstr "Kapat"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Kapat"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6531,8 +6521,7 @@ msgstr "DuckDuckGo'yu listede göremiyor musunuz?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
+msgstr "Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6963,8 +6952,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
+msgstr "Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7020,8 +7008,7 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr ""
-"Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
+msgstr "Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -7045,8 +7032,7 @@ msgstr "Duck.ai aboneliği yükseltildi!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
+msgstr "Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7265,7 +7251,7 @@ msgstr "DuckDuckGo Tarayıcı %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo Yardım Sayfaları"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7770,8 +7756,7 @@ msgstr "Duck.ai'da sesli dikte özelliğini etkinleştir"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
+msgstr "Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7880,8 +7865,7 @@ msgstr "Duck.ai'ı beğeniyor musunuz?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
+msgstr "'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8102,7 +8086,7 @@ msgstr "Gizliliğe gerçekten önem verenler için ustalıkla hazırlanmış ür
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Süresi doldu"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8116,7 +8100,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "%1$s tarihinde süresi doluyor"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8524,8 +8508,7 @@ msgstr "Finansal danışman"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
+msgstr "%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8576,8 +8559,7 @@ msgstr "Size daha yakın sonuçlar bulun."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
+msgstr "Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8759,8 +8741,7 @@ msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
+msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8772,8 +8753,7 @@ msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Kullanılabilen"
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr ""
-"Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
+msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -9498,6 +9478,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"%1$sDuck.ai Ayarları%2$s › %3$sSohbetler › Sync & Backup › Başka Bir Cihazla "
+"Senkronize Et%4$s bölümüne gidin."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9613,7 +9595,7 @@ msgstr "Anladım"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Anladım"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9979,8 +9961,7 @@ msgstr "DuckDuckGo'yu geliştirmemize yardımcı olun"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
+msgstr "Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10038,8 +10019,7 @@ msgstr "Arkadaşlarınızın ve ailenizin Duck Side'a katılmalarına yardımcı
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
+msgstr "Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10176,8 +10156,7 @@ msgstr "E-posta adresinizi gizleyin"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
+msgstr "Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10425,8 +10404,7 @@ msgstr "Yapay zeka destekli cevapların ne kadar görünmesini istiyorsun?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
+msgstr "Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10576,15 +10554,14 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi kitaplar/"
-"diziler nelerdir ve neden?"
+"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi "
+"kitaplar/diziler nelerdir ve neden?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
+msgstr "Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -11597,7 +11574,7 @@ msgstr "%1$sDaha Fazla%2$s Bilgi Edinin"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Daha Fazla Bilgi"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11866,8 +11843,7 @@ msgstr "Bağlantılar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
+msgstr "Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12240,7 +12216,7 @@ msgstr "Yönet"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Yönet"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12497,7 +12473,7 @@ msgstr "Menü"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Bu noktadan sonraki mesajları yalnızca siz görebilirsiniz."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12760,8 +12736,7 @@ msgstr "Aylık limit doldu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr "Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12872,7 +12847,7 @@ msgstr "Duck.ai hakkında daha fazla bilgi"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Daha fazla işlem"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12923,8 +12898,7 @@ msgstr "Daha fazla bilgiyi %1$s %2$s makalesinde bulabilirsiniz."
 # smartling.placeholder_format=C
 #. Source (section, article and site) of the answer generated by duckassist (an instant answer based on generative AI)
 msgid "More info in the %s section of the %s %s article."
-msgstr ""
-"Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
+msgstr "Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
 
 # smartling.placeholder_format=C
 msgctxt ""
@@ -13073,7 +13047,7 @@ msgstr "Yumuşak kırmızı"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Cihazlarım"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14151,6 +14125,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"Başka bir cihazda %1$sDuck.ai Ayarları%2$s › %3$sSohbetler › Sync & Backup › "
+"Başka Bir Cihazla Senkronize Et%4$s bölümüne gidin"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14159,6 +14135,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"Başka bir cihazda %1$sDuck.ai Ayarları%2$s › %3$sSohbetler › Sync & Backup › "
+"Başka Bir Cihazla Senkronize Et%4$s bölümüne gidin ve bu kodu taratın:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14167,6 +14145,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"Başka bir cihazda %1$sDuck.ai Ayarları%2$s › %3$sSohbetler › Sync & Backup › "
+"Başka Bir Cihazla Senkronize Et%4$s bölümüne gidin. Alternatif olarak, "
+"Kurtarma PDF'inizdeki QR kodunu tarayın."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14922,7 +14903,7 @@ msgstr "Geçen yıl"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Yapıştır"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14940,7 +14921,7 @@ msgstr "Senkronizasyon Kodunu Yapıştır"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Aşağıya yapıştır"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14999,7 +14980,7 @@ msgstr "Farsça"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -15008,6 +14989,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal, bilgilerinizi satan veri aracısı sitelerinde "
+"bulur. Ardından da sizin adınıza kaldırılması için çalışırız."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15479,16 +15462,14 @@ msgstr "Lütfen bekleyin..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr ""
-"DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
+msgstr "DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
+msgstr "Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -16061,8 +16042,7 @@ msgstr "Bana sor"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
+msgstr "Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16283,7 +16263,7 @@ msgstr "Web sitesi okunuyor…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Güneş tutulmasına hazır mısınız?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16483,7 +16463,7 @@ msgstr "Kurtarma Kodu"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Kurtarma Kodu"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16693,8 +16673,9 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya &quot;"
-"Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden yükleyin."
+"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya "
+"&quot;Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden "
+"yükleyin."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16742,7 +16723,7 @@ msgstr "Kaldır: %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Cihazı Kaldır"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16790,13 +16771,13 @@ msgstr "Gereksiz noktalama işaretlerini kaldır"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Bilgilerinizi internetten kaldırın"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Bilgilerinizi internetten kaldırın"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17090,8 +17071,7 @@ msgstr "Sonuçlar, engellenmiş sitelerden gelen bilgileri içermez."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
+msgstr "Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17454,8 +17434,7 @@ msgstr "En son 30 sohbetinizi cihazınıza yerel olarak kaydedin."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
+msgstr "Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17491,7 +17470,7 @@ msgstr "Duck.ai'a merhaba deyin!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Duck.ai'a merhaba deyin – DuckDuckGo'dan ücretsiz, gizli yapay zeka sohbeti."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17674,8 +17653,7 @@ msgstr "Ara"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr ""
-"Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
+msgstr "Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
 
 # smartling.placeholder_format=C
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
@@ -17947,8 +17925,7 @@ msgstr "DuckDuckGo ile Ara"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
+msgstr "Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -18177,8 +18154,7 @@ msgstr "En son güncellemelerimizden bazılarını gör"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
+msgstr "Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18247,8 +18223,7 @@ msgstr "Varsayılan Arama Motoru açılır menüsünden %1$sDuckDuckGo%2$s'yu se
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr "Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18314,8 +18289,7 @@ msgstr "%1$sArama Motoru%2$s bölümünü seçin"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
+msgstr "%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18340,8 +18314,7 @@ msgstr "Açılır menüden %1$sSeçenekler%2$s ögesini seçin."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
+msgstr "%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18371,8 +18344,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr "Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18517,7 +18489,7 @@ msgstr "Sırpça (Latin)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Sunucu verileri silindi"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18679,7 +18651,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Paylaş"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18836,13 +18808,13 @@ msgstr "Arama kutusu hakkındaki düşüncelerini paylaşın."
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Paylaşılan Sohbet Bağlantıları"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Paylaşılan sohbet bağlantıları"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18972,8 +18944,7 @@ msgstr "DuckAssist <sup>BETA'</sup>yı göster"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
+msgstr "DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19090,8 +19061,7 @@ msgstr "Tüm sonuçları gösterin"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
+msgstr "Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19157,8 +19127,7 @@ msgstr "Kenar çubuğunu göster"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Duck.ai'dan en iyi şekilde yararlanmak için adım adım ipuçlarını gösterin."
+msgstr "Duck.ai'dan en iyi şekilde yararlanmak için adım adım ipuçlarını gösterin."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19252,14 +19221,12 @@ msgstr "En çok ziyaret edilen bağlantıları yeni sekme sayfasında gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr "Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr "Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19288,8 +19255,7 @@ msgstr "Siz yazarken arama kutusunun altında öneriler gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
+msgstr "Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19376,8 +19342,7 @@ msgstr "Site İsimleri"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
+msgstr "Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19529,7 +19494,7 @@ msgstr "Bir hata oluştu"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Bu paylaşılan sohbet yüklenirken bir sorun oluştu."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19613,8 +19578,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
+msgstr "Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19648,8 +19612,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
+msgstr "Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19703,8 +19666,7 @@ msgstr "Kaynak metin temizlendi"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
+msgstr "Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19964,8 +19926,7 @@ msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicileri engelleyin."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
+msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20383,14 +20344,13 @@ msgstr "Model değiştir"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Model değiştir"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr ""
-"Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
+msgstr "Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -20647,7 +20607,7 @@ msgstr "Senkronize Edilmiş Cihazlar"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "%1$s tarihinde senkronize edildi"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20685,7 +20645,7 @@ msgstr "TV"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Tablo"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -21029,8 +20989,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
+msgstr "Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21199,8 +21158,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
+msgstr "Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21275,7 +21233,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Bu Cihaz"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21286,6 +21244,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Bu cihaz artık diğer cihazlarınızdaki senkronize edilen verilerinize "
+"erişemeyecektir. Son %1$s sohbet yerel depolamada saklanmaya devam edecektir."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21378,7 +21338,7 @@ msgstr "Bu bilgi yararlı değil"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Bu, paylaşılan bir sohbetin kopyasıdır."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21396,8 +21356,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
-"Bu sadece bir örnek sohbet. Silmek için yan menüdeki Fire Button'ı kullanın!"
+msgstr "Bu sadece bir örnek sohbet. Silmek için yan menüdeki Fire Button'ı kullanın!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21496,13 +21455,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Bu paylaşılan sohbet açılamadı. Bağlantı eksik olabilir."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Bu paylaşılan sohbet bağlantısı artık kullanılamıyor."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21531,8 +21490,7 @@ msgstr "Bu video henüz burada izlenemiyor. %1$s üzerinden izleyebilirsiniz."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
+msgstr "Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21552,8 +21510,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
+msgstr "Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21571,8 +21528,7 @@ msgstr "Tüm ayarlarınız silinecek. Devam edilsin mi?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
+msgstr "Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21646,8 +21602,7 @@ msgstr "İpuçları"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
+msgstr "İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21679,8 +21634,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
+msgstr "Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -21936,8 +21890,7 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr ""
-"DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
+msgstr "DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -22104,8 +22057,7 @@ msgstr "Bu tür mesajları görmeyi durdurmak için %1$s'u deneyin."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
+msgstr "Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22156,7 +22108,7 @@ msgstr "Ücretsiz Deneyin"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Ücretsiz Deneyin!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22277,7 +22229,7 @@ msgstr "Ücretsiz Deneyin"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Ücretsiz deneyin!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22528,7 +22480,7 @@ msgstr "Türkmenistan"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Kapat"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22546,7 +22498,7 @@ msgstr "Sync & Backup'ı Kapat"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Sync & Backup Kapatılsın ve Sunucu Verileri Silinsin mi?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22617,8 +22569,7 @@ msgstr "Daha doğru sonuçlar için %1$sKesin Konum%2$s'u açın"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
+msgstr "YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22636,8 +22587,7 @@ msgstr "Daha doğru sonuçlar için \"Kesin Konum\"u açın."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
+msgstr "Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22843,8 +22793,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: https://duckduckgo."
-"com"
+"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22878,8 +22828,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
+msgstr "Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23040,7 +22989,7 @@ msgstr "Sesini açın"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Başlıksız sohbet"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23081,7 +23030,7 @@ msgstr "Tarayıcıyı Güncelle"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Bu paylaşılan sohbeti görüntülemek için Duck.ai'yi güncelle."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23365,8 +23314,7 @@ msgstr "DuckDuckGo Private Search'ü kullanın"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
+msgstr "iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23946,8 +23894,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
+msgstr "En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24049,8 +23996,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
+msgstr "Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24073,6 +24019,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Kişisel bilgilerinizi veri aracısı sitelerden bulur ve kaldırırız. Ayrıca "
+"bir VPN ve daha fazlasını edinin."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24127,6 +24075,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Kişisel bilgileriniz için veri aracısı sitelerini düzenli olarak tarar ve "
+"ilerlememizi kullanımı kolay bir panelde sizinle paylaşırız."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24145,8 +24095,7 @@ msgstr "Biz dahil hiç kimse arama geçmişinize ulaşamaz."
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr ""
-"Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
+msgstr "Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -24174,6 +24123,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"E-postan, adın, adresin ve daha fazlası için veri aracısı sitelerini "
+"tarayacak ve hakkında bulduğumuz her şeyi kaldırmak için çalışacağız."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24499,7 +24450,7 @@ msgstr "Yıllık gelirlerin bazı artıları ve eksileri nelerdir?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Duck.ai'ın faydaları nelerdir?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24879,8 +24830,7 @@ msgstr "<strong>%1$s</strong>Nerede İzlenir?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
+msgstr "Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25076,6 +25026,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"E-postanızı, adınızı, adresinizi ve daha fazlasını veri komisyoncusu "
+"sitelerinden kaldırmak için doğrudan cihazınızdan çalışır."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25420,8 +25372,7 @@ msgstr "Bunu istediğin zaman %1$sArama Ayarları%2$s'ndan değiştirebilirsin"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
+msgstr "Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25460,8 +25411,7 @@ msgstr "Aylık limiti kullanarak sohbet etmeye devam edebilirsiniz."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
+msgstr "Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25581,7 +25531,7 @@ msgstr "1 deneme hakkınız kaldı."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "Paylaşılan sohbet bağlantısı yok."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25748,8 +25698,7 @@ msgstr "Tek bir oturum için maksimum sesli sohbet süresine ulaştınız."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
+msgstr "Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25814,14 +25763,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
+msgstr "Son %1$s sohbetiniz şu tarayıcılarda yerel depolama alanında saklanacaktır:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Duck.ai sohbetleriniz uçtan uca şifreleme ile senkronize ediliyor."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25853,6 +25802,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Yedeklemeniz DuckDuckGo'nun sunucusundan silinecektir. Tüm cihazların "
+"senkronizasyon bağlantısı kesilecektir."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26004,8 +25955,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
+msgstr "Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26052,8 +26002,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
+msgstr "Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26190,8 +26139,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
+msgstr "Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26233,8 +26181,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
+msgstr "Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26317,8 +26264,7 @@ msgstr "(bir %1$s ürünü)"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
+msgstr "DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "Tam Aşılanmış Olanların Yüzdesi"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "Aşılanmış Olanların Yüzdesi"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -372,7 +380,8 @@ msgstr "%1$s kullanıldı"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s, limitleri temel modellere göre 2-5 kata kadar daha hızlı tüketir %2$s"
+msgstr ""
+"%1$s, limitleri temel modellere göre 2-5 kata kadar daha hızlı tüketir %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -489,6 +498,13 @@ msgstr "%1$sDaha fazla bilgi edinin%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sKonumunuzu nasıl gizli tuttuğumuzu öğrenin%2$s."
+
+# smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -783,6 +799,12 @@ msgid "2nd in Group %s"
 msgstr "%1$s Grubu'nda 2."
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -946,7 +968,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
+msgstr ""
+"Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1469,6 +1492,12 @@ msgid "Add to Home Screen"
 msgstr "Ana Ekrana Ekle"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Eklentiler"
@@ -1623,7 +1652,8 @@ msgstr "İndirdikten ve açtıktan sonra %1$sYükle%2$s seçeneğine tıklayın"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
+msgstr ""
+"İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1832,6 +1862,13 @@ msgid "All types"
 msgstr "Tüm biçimler"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1919,7 +1956,8 @@ msgstr "Zaten senkronize edildi."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
+msgstr ""
+"Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2209,7 +2247,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
+msgstr ""
+"Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2356,6 +2395,12 @@ msgid "Ask anything privately"
 msgstr "Gizli bir şekilde her şeyi sorabilirsiniz"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2462,8 +2507,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"Kafede, havaalanında veya otelde DuckDuckGo VPN, bağlantınızı şifreler ve "
-"Wi-Fi üzerindeki IP adresinizi gizler."
+"Kafede, havaalanında veya otelde DuckDuckGo VPN, bağlantınızı şifreler ve Wi-"
+"Fi üzerindeki IP adresinizi gizler."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2526,13 +2571,15 @@ msgstr "Ses"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr ""
+"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr ""
+"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2990,7 +3037,8 @@ msgstr "Bu siteyi tüm sonuçlarda engelleyin"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
+msgstr ""
+"Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3417,7 +3465,8 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
+msgstr ""
+"Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -4485,7 +4534,8 @@ msgstr "%1$sEkle%2$s seçeneğine tıklayın"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr "%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
+msgstr ""
+"%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -4598,13 +4648,15 @@ msgstr "Açılır menüden %1$sArama Ayarlarını Değiştir%2$s seçeneğine t�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sSet as Default%s towards the bottom"
-msgstr "Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
+msgstr ""
+"Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr "Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
+msgstr ""
+"Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4685,7 +4737,8 @@ msgstr "Adres çubuğundaki %1$sizinler simgesine%2$s tıklayın"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
+msgstr ""
+"Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4737,7 +4790,8 @@ msgstr "Arama çubuğundaki büyüteç simgesine tıklayın"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr "Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
+msgstr ""
+"Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5301,6 +5355,12 @@ msgid "Copy"
 msgstr "Kopyala"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5342,6 +5402,28 @@ msgstr "Bu kodu kopyala veya kaydet"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Kurtarma kodunu kopyala"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5727,7 +5809,8 @@ msgstr "Günlük limit doldu"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr ""
+"Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6023,6 +6106,14 @@ msgid "Delete recent chats?"
 msgstr "Son sohbetler silinsin mi?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6033,6 +6124,14 @@ msgstr "Bu sohbet silinsin mi?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Silinen sohbetler"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6292,6 +6391,13 @@ msgid "Dismiss"
 msgstr "Kapat"
 
 # smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
 msgctxt "duckassist"
 msgid "Dismiss"
@@ -6425,7 +6531,8 @@ msgstr "DuckDuckGo'yu listede göremiyor musunuz?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
+msgstr ""
+"Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6856,7 +6963,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr "Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
+msgstr ""
+"Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6912,7 +7020,8 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr "Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
+msgstr ""
+"Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -6936,7 +7045,8 @@ msgstr "Duck.ai aboneliği yükseltildi!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
+msgstr ""
+"Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7149,6 +7259,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo Tarayıcı %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7653,7 +7770,8 @@ msgstr "Duck.ai'da sesli dikte özelliğini etkinleştir"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
+msgstr ""
+"Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7762,7 +7880,8 @@ msgstr "Duck.ai'ı beğeniyor musunuz?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
+msgstr ""
+"'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7979,10 +8098,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "Gizliliğe gerçekten önem verenler için ustalıkla hazırlanmış ürünler."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Süresi doldu"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8390,7 +8524,8 @@ msgstr "Finansal danışman"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
+msgstr ""
+"%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8441,7 +8576,8 @@ msgstr "Size daha yakın sonuçlar bulun."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
+msgstr ""
+"Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8623,7 +8759,8 @@ msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
+msgstr ""
+"Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8635,7 +8772,8 @@ msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Kullanılabilen"
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
+msgstr ""
+"Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -9354,6 +9492,14 @@ msgstr ""
 "QR kodunu tarayın."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -9462,6 +9608,12 @@ msgstr "Anladım"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Anladım"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9827,7 +9979,8 @@ msgstr "DuckDuckGo'yu geliştirmemize yardımcı olun"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
+msgstr ""
+"Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9885,7 +10038,8 @@ msgstr "Arkadaşlarınızın ve ailenizin Duck Side'a katılmalarına yardımcı
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
+msgstr ""
+"Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10022,7 +10176,8 @@ msgstr "E-posta adresinizi gizleyin"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
+msgstr ""
+"Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10270,7 +10425,8 @@ msgstr "Yapay zeka destekli cevapların ne kadar görünmesini istiyorsun?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
+msgstr ""
+"Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10420,14 +10576,15 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi "
-"kitaplar/diziler nelerdir ve neden?"
+"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi kitaplar/"
+"diziler nelerdir ve neden?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
+msgstr ""
+"Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -11437,6 +11594,12 @@ msgid "Learn %sMore%s"
 msgstr "%1$sDaha Fazla%2$s Bilgi Edinin"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11703,7 +11866,8 @@ msgstr "Bağlantılar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
+msgstr ""
+"Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12072,6 +12236,13 @@ msgid "Manage"
 msgstr "Yönet"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12321,6 +12492,12 @@ msgstr "Menü"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menü"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12583,7 +12760,8 @@ msgstr "Aylık limit doldu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr ""
+"Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12691,6 +12869,12 @@ msgid "More about Duck.ai"
 msgstr "Duck.ai hakkında daha fazla bilgi"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Daha fazlası için:"
@@ -12739,7 +12923,8 @@ msgstr "Daha fazla bilgiyi %1$s %2$s makalesinde bulabilirsiniz."
 # smartling.placeholder_format=C
 #. Source (section, article and site) of the answer generated by duckassist (an instant answer based on generative AI)
 msgid "More info in the %s section of the %s %s article."
-msgstr "Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
+msgstr ""
+"Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
 
 # smartling.placeholder_format=C
 msgctxt ""
@@ -12883,6 +13068,12 @@ msgstr "Sessiz"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Yumuşak kırmızı"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13954,6 +14145,30 @@ msgstr ""
 "Ayarlar%5$s bölümüne tıklayın"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14704,6 +14919,12 @@ msgid "Past year"
 msgstr "Geçen yıl"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14714,6 +14935,12 @@ msgstr "Yapıştır"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Senkronizasyon Kodunu Yapıştır"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14767,6 +14994,20 @@ msgstr "Kalıcı olarak kapalı"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Farsça"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15238,14 +15479,16 @@ msgstr "Lütfen bekleyin..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr "DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
+msgstr ""
+"DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr "Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
+msgstr ""
+"Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15818,7 +16061,8 @@ msgstr "Bana sor"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
+msgstr ""
+"Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16036,6 +16280,12 @@ msgid "Reading website…"
 msgstr "Web sitesi okunuyor…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16228,6 +16478,12 @@ msgstr "Kurtarma"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Kurtarma Kodu"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16437,9 +16693,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya "
-"&quot;Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden "
-"yükleyin."
+"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya &quot;"
+"Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden yükleyin."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16484,6 +16739,12 @@ msgid "Remove %s"
 msgstr "Kaldır: %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16524,6 +16785,18 @@ msgstr "Metin seçimini kaldır"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Gereksiz noktalama işaretlerini kaldır"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16817,7 +17090,8 @@ msgstr "Sonuçlar, engellenmiş sitelerden gelen bilgileri içermez."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
+msgstr ""
+"Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17180,7 +17454,8 @@ msgstr "En son 30 sohbetinizi cihazınıza yerel olarak kaydedin."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
+msgstr ""
+"Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17211,6 +17486,12 @@ msgstr "Ayarlarınızı anonim olarak buluta kaydedin"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "Duck.ai'a merhaba deyin!"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17393,7 +17674,8 @@ msgstr "Ara"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr "Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
+msgstr ""
+"Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
 
 # smartling.placeholder_format=C
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
@@ -17665,7 +17947,8 @@ msgstr "DuckDuckGo ile Ara"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr "Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
+msgstr ""
+"Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -17894,7 +18177,8 @@ msgstr "En son güncellemelerimizden bazılarını gör"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
+msgstr ""
+"Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17963,7 +18247,8 @@ msgstr "Varsayılan Arama Motoru açılır menüsünden %1$sDuckDuckGo%2$s'yu se
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr ""
+"Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18029,7 +18314,8 @@ msgstr "%1$sArama Motoru%2$s bölümünü seçin"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
+msgstr ""
+"%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18054,7 +18340,8 @@ msgstr "Açılır menüden %1$sSeçenekler%2$s ögesini seçin."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
+msgstr ""
+"%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18084,7 +18371,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr ""
+"Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18223,6 +18511,13 @@ msgstr "Sırpça (Kiril)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Sırpça (Latin)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18379,6 +18674,14 @@ msgid "Share"
 msgstr "Paylaş"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18530,6 +18833,18 @@ msgid "Share your thoughts on the search box."
 msgstr "Arama kutusu hakkındaki düşüncelerini paylaşın."
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
@@ -18657,7 +18972,8 @@ msgstr "DuckAssist <sup>BETA'</sup>yı göster"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
+msgstr ""
+"DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18774,7 +19090,8 @@ msgstr "Tüm sonuçları gösterin"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
+msgstr ""
+"Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18840,7 +19157,8 @@ msgstr "Kenar çubuğunu göster"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Duck.ai'dan en iyi şekilde yararlanmak için adım adım ipuçlarını gösterin."
+msgstr ""
+"Duck.ai'dan en iyi şekilde yararlanmak için adım adım ipuçlarını gösterin."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18934,12 +19252,14 @@ msgstr "En çok ziyaret edilen bağlantıları yeni sekme sayfasında gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr ""
+"Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr ""
+"Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18968,7 +19288,8 @@ msgstr "Siz yazarken arama kutusunun altında öneriler gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
+msgstr ""
+"Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19055,7 +19376,8 @@ msgstr "Site İsimleri"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
+msgstr ""
+"Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19204,6 +19526,12 @@ msgid "Something went wrong"
 msgstr "Bir hata oluştu"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19285,7 +19613,8 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
+msgstr ""
+"Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19319,7 +19648,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
+msgstr ""
+"Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19373,7 +19703,8 @@ msgstr "Kaynak metin temizlendi"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
+msgstr ""
+"Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19633,7 +19964,8 @@ msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicileri engelleyin."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
+msgstr ""
+"Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20048,10 +20380,17 @@ msgid "Switch model"
 msgstr "Model değiştir"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr "Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
+msgstr ""
+"Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -20304,6 +20643,13 @@ msgid "Synced Devices"
 msgstr "Senkronize Edilmiş Cihazlar"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Suriye"
 
@@ -20334,6 +20680,12 @@ msgstr "Duyurulacak"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "TV"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20677,7 +21029,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
+msgstr ""
+"Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20846,7 +21199,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
+msgstr ""
+"Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20916,6 +21270,22 @@ msgstr ""
 "Bu sohbet, %2$s %3$s Modeli kullanılarak DuckDuckGo AI Chat (%1$s) ile "
 "oluşturulmuştur. Yapay zekâ sohbetleri yanlış veya rahatsız edici bilgiler "
 "gösterebilir (daha fazla bilgi için bkz. %4$s)."
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21005,6 +21375,12 @@ msgid "This information isn’t useful"
 msgstr "Bu bilgi yararlı değil"
 
 # smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
@@ -21020,7 +21396,8 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr "Bu sadece bir örnek sohbet. Silmek için yan menüdeki Fire Button'ı kullanın!"
+msgstr ""
+"Bu sadece bir örnek sohbet. Silmek için yan menüdeki Fire Button'ı kullanın!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21116,6 +21493,18 @@ msgstr ""
 "sayfamız da var."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21142,7 +21531,8 @@ msgstr "Bu video henüz burada izlenemiyor. %1$s üzerinden izleyebilirsiniz."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
+msgstr ""
+"Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21162,7 +21552,8 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr "Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
+msgstr ""
+"Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21180,7 +21571,8 @@ msgstr "Tüm ayarlarınız silinecek. Devam edilsin mi?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
+msgstr ""
+"Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21254,7 +21646,8 @@ msgstr "İpuçları"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
+msgstr ""
+"İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21286,7 +21679,8 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr "Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
+msgstr ""
+"Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -21542,7 +21936,8 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr "DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
+msgstr ""
+"DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -21709,7 +22104,8 @@ msgstr "Bu tür mesajları görmeyi durdurmak için %1$s'u deneyin."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
+msgstr ""
+"Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21755,6 +22151,12 @@ msgstr "Ücretsiz Deneyin"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Ücretsiz Deneyin"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21870,6 +22272,12 @@ msgstr "Ücretsiz Deneyin"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Ücretsiz Deneyin"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22117,6 +22525,12 @@ msgid "Turkmenistan"
 msgstr "Türkmenistan"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22127,6 +22541,12 @@ msgstr "Sync & Backup'ı Kapat"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Sync & Backup'ı Kapat"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22197,7 +22617,8 @@ msgstr "Daha doğru sonuçlar için %1$sKesin Konum%2$s'u açın"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
+msgstr ""
+"YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22215,7 +22636,8 @@ msgstr "Daha doğru sonuçlar için \"Kesin Konum\"u açın."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
+msgstr ""
+"Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22421,8 +22843,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: "
-"https://duckduckgo.com"
+"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22456,7 +22878,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
+msgstr ""
+"Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22614,6 +23037,12 @@ msgid "Unmute"
 msgstr "Sesini açın"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -22647,6 +23076,12 @@ msgstr "Güncelle"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Tarayıcıyı Güncelle"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22930,7 +23365,8 @@ msgstr "DuckDuckGo Private Search'ü kullanın"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
+msgstr ""
+"iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23510,7 +23946,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
+msgstr ""
+"En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23612,7 +24049,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
+msgstr ""
+"Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -23627,6 +24065,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 "Etkileşim olmaması nedeniyle sohbeti sonlandırdık. Tekrar denemek ister "
 "misiniz?"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23675,6 +24121,14 @@ msgstr ""
 "kullanırız. Dilediğiniz zaman fikrinizi değiştirebilirsiniz."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23691,7 +24145,8 @@ msgstr "Biz dahil hiç kimse arama geçmişinize ulaşamaz."
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr "Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
+msgstr ""
+"Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -23711,6 +24166,14 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
 "Siz internette gezinirken verilerinizi toplamaya çalışan takip edicileri "
 "engelleriz."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24031,6 +24494,12 @@ msgstr ""
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
 msgstr "Yıllık gelirlerin bazı artıları ve eksileri nelerdir?"
+
+# smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24410,7 +24879,8 @@ msgstr "<strong>%1$s</strong>Nerede İzlenir?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
+msgstr ""
+"Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24598,6 +25068,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Sıfır sağlayıcı görünürlüğü olmayanlar"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24942,7 +25420,8 @@ msgstr "Bunu istediğin zaman %1$sArama Ayarları%2$s'ndan değiştirebilirsin"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
+msgstr ""
+"Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24981,7 +25460,8 @@ msgstr "Aylık limiti kullanarak sohbet etmeye devam edebilirsiniz."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
+msgstr ""
+"Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25095,6 +25575,13 @@ msgstr "%1$s deneme hakkınız kaldı."
 msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr "1 deneme hakkınız kaldı."
+
+# smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25261,7 +25748,8 @@ msgstr "Tek bir oturum için maksimum sesli sohbet süresine ulaştınız."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
+msgstr ""
+"Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25319,6 +25807,23 @@ msgid "YouTube Standard"
 msgstr "YouTube Standart"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "DuckDuckGo arama geçmişiniz gizlidir"
@@ -25340,6 +25845,14 @@ msgstr "Gerçek konumunuz gizli kalır"
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Gerçek konumunuz gizli kalır."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25491,7 +26004,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
+msgstr ""
+"Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25538,7 +26052,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
+msgstr ""
+"Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25675,7 +26190,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
+msgstr ""
+"Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25717,7 +26233,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
+msgstr ""
+"Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25800,7 +26317,8 @@ msgstr "(bir %1$s ürünü)"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
+msgstr ""
+"DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: uk_UA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -23,8 +22,7 @@ msgstr "Пошукові ярлики !Bang"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
+msgstr "\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -50,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s (Цей пристрій)"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -503,15 +501,14 @@ msgstr "%1$sДізнайтеся, як ми зберігаємо приватн�
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$sДізнатися більше%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
+msgstr "%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -798,7 +795,7 @@ msgstr "2 місце в групі %1$s"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "Альтернативна думка"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -955,8 +952,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
+msgstr "Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1072,9 +1068,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "Наразі можливість ставити подальші запитання штучному інтелекту не "
-"підтримується. Однак ми також пропонуємо і часто посилаємось на %1$sDuck."
-"ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai — це наша "
-"служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic тощо."
+"підтримується. Однак ми також пропонуємо і часто посилаємось на "
+"%1$sDuck.ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai "
+"— це наша служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic "
+"тощо."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1488,7 +1485,7 @@ msgstr "Додати на головний екран"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "Додати до моїх чатів"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1857,7 +1854,7 @@ msgstr "Усі типи"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "Усі ваші пристрої відключено від синхронізації."
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1894,8 +1891,7 @@ msgstr "Дозволити анонімний перегляд файлів у �
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
+msgstr "Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2228,8 +2224,7 @@ msgstr "Ти ще тут?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
+msgstr "Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2385,7 +2380,7 @@ msgstr "Запитуйте будь-що. Все конфіденційно"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "Запитуйте будь-що. Все конфіденційно"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2446,11 +2441,10 @@ msgstr ""
 "Assist може анонімно генерувати відповіді ШІ на деякі пошукові запити, "
 "узагальнюючи релевантний веб-контент. Можна вибрати частоту відображення "
 "Assist: «Ніколи» (повністю приховує інтерфейс Assist із результатів пошуку), "
-"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки "
-"«Assist» ), «Іноді» (відображаються лише відповіді ШІ в разі високої "
-"релевантності) або «Часто» (відображається частіше у різних пошукових "
-"запитах). Наразі відповіді штучного інтелекту доступні лише в США "
-"(англійською)."
+"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки «Assist» "
+"), «Іноді» (відображаються лише відповіді ШІ в разі високої релевантності) "
+"або «Часто» (відображається частіше у різних пошукових запитах). Наразі "
+"відповіді штучного інтелекту доступні лише в США (англійською)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -4147,8 +4141,7 @@ msgstr "Перевірте сабреддіт DuckDuckGo, щоб дізнати�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
+msgstr "Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4574,8 +4567,7 @@ msgstr "Оберіть %1$sНалаштування%2$s з меню вибору
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
+msgstr "Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4691,8 +4683,7 @@ msgstr "Натисніть на вкладку %1$sЗагальні%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr ""
-"Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
+msgstr "Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -4709,8 +4700,7 @@ msgstr "Натисніть %1$sзначок дозволів%2$s в адресн
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
+msgstr "Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5331,7 +5321,7 @@ msgstr "Копіювати"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "Копіювати"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5380,13 +5370,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "Скопіювати посилання"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "Скопіювати код з іншого пристрою"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5395,6 +5385,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
+"Скопіюйте код з іншого пристрою. Перейдіть у %1$s«Налаштування Duck.ai» › "
+"«Чати» › Sync & Backup › «Синхронізувати з іншим пристроєм»%2$s і спробуй "
+"знову."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6083,7 +6076,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "Видалити посилання для поширення"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -6104,6 +6097,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
+"Видалення посилання скасує його дію. Люди, які вже відкрили його та додали "
+"розмову до своїх чатів, збережуть власну копію."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6365,7 +6360,7 @@ msgstr "Відхилити"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "Закрити"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -7010,8 +7005,7 @@ msgstr "Duck.ai оновлено!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
+msgstr "Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7055,10 +7049,10 @@ msgstr ""
 "У відповідь на деякі пошукові запити DuckAssist іноді анонімно шукає та "
 "узагальнює інформацію. Можна вибрати частоту відображення DuckAssist: "
 "«Ніколи» (повністю приховує інтерфейс DuckAssist із результатів пошуку), «На "
-"вимогу» (відображається лише при натисканні кнопки «Допомога»), "
-"«Іноді» (показується лише в разі високої релевантності) або "
-"«Часто» (відображається частіше у різних пошукових запитах). Наразі "
-"DuckAssist доступний лише у США (англійською)."
+"вимогу» (відображається лише при натисканні кнопки «Допомога»), «Іноді» "
+"(показується лише в разі високої релевантності) або «Часто» (відображається "
+"частіше у різних пошукових запитах). Наразі DuckAssist доступний лише у США "
+"(англійською)."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7118,8 +7112,8 @@ msgstr ""
 "основі штучного інтелекту. Відповіді DuckAssist завжди містять пряме "
 "посилання на одне або два джерела відповіді, тому ви можете швидко знайти "
 "більш детальну інформацію. Важливо пам'ятати, що відповіді автоматично "
-"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих веб-"
-"сторінках%2$s."
+"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих "
+"веб-сторінках%2$s."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7227,7 +7221,7 @@ msgstr "Браузер DuckDuckGo %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "Довідка DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7354,8 +7348,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s Duck."
-"ai."
+"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7363,8 +7357,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
+msgstr "DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7565,8 +7558,7 @@ msgstr "Редагувати запит"
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
-msgstr ""
-"Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr "Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is editing an image.
@@ -7579,8 +7571,7 @@ msgstr "Редагування зображення..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
+msgstr "Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7842,8 +7833,7 @@ msgstr "Користуєтеся Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
+msgstr "Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7891,15 +7881,13 @@ msgstr "Переконайтеся, що доступ до розташуван�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
+msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
+msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8075,7 +8063,7 @@ msgstr "Duck-сконалі програмні продукти для тих, �
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "Термін дії закінчився"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8089,7 +8077,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "Термін дії закінчується %1$s"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8114,8 +8102,7 @@ msgstr "Поясніть прийняту відповідь простими с
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
+msgstr "Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8457,8 +8444,7 @@ msgstr "Відфільтровує створені ШІ зображення з
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
+msgstr "Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8495,8 +8481,7 @@ msgstr "Фінансовий радник"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
+msgstr "Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8508,8 +8493,7 @@ msgstr "Знайдіть <b>%1$s</b> у папці завантажень"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
+msgstr "Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8976,22 +8960,19 @@ msgstr "Загальне призначення"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення з вбудованою високою модерацією"
+msgstr "Штучний інтелект загального призначення з вбудованою високою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення з вбудованою низькою модерацією"
+msgstr "Штучний інтелект загального призначення з вбудованою низькою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення із вбудованою середньою модерацією"
+msgstr "Штучний інтелект загального призначення із вбудованою середньою модерацією"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9052,8 +9033,7 @@ msgstr "Згенероване зображення"
 #. Title text shown for an assistant response that contains a generated image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Generated image. Cost %s (internal only)"
-msgstr ""
-"Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr "Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Aria label for the carousel (list of generated images) in the image generation mode.
@@ -9474,6 +9454,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
+"Перейдіть у %1$s«Налаштування Duck.ai»%2$s › %3$s«Чати» › Sync & Backup › "
+"«Синхронізувати з іншим пристроєм»%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9591,7 +9573,7 @@ msgstr "Зрозуміло"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "Зрозуміло"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10426,8 +10408,7 @@ msgctxt "Full sentence for preparing for a conversation"
 msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
-msgstr ""
-"Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
+msgstr "Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -11296,8 +11277,7 @@ msgstr "Приєднуйтесь до нашої команди!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr ""
-"Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
+msgstr "Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -11575,7 +11555,7 @@ msgstr "%1$sДокладніше%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "Дізнатися більше"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11751,8 +11731,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Дозволяє перемикатися між надсиланням пошукових запитів та промптів до Duck."
-"ai"
+"Дозволяє перемикатися між надсиланням пошукових запитів та промптів до "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11947,8 +11927,7 @@ msgstr "Завантаження..."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more image and video results when scrolling"
-msgstr ""
-"Завантаження інших результатів для зображень та відео при прокручуванні"
+msgstr "Завантаження інших результатів для зображень та відео при прокручуванні"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -12220,7 +12199,7 @@ msgstr "Керувати"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "Керувати"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12477,7 +12456,7 @@ msgstr "Меню"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "Повідомлення, надіслані після цього моменту, бачите лише ви."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12855,7 +12834,7 @@ msgstr "Більше про Duck.ai"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "Більше дій"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -13055,7 +13034,7 @@ msgstr "Приглушений червоний"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "Мої пристрої"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -14132,6 +14111,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
+"На іншому пристрої перейдіть у %1$s«Налаштування Duck.ai»%2$s › %3$s«Чати» › "
+"Sync & Backup › «Синхронізація з іншим пристроєм»%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14140,6 +14121,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
+"На іншому пристрої перейдіть у %1$s«Налаштування Duck.ai»%2$s › %3$s«Чати» › "
+"Sync & Backup › «Синхронізувати з іншим пристроєм»%4$s і проскануйте цей код:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14148,6 +14131,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"На іншому пристрої перейдіть у %1$s«Налаштування Duck.ai»%2$s › %3$s«Чати» › "
+"Sync & Backup › «Синхронізувати з іншим пристроєм»%4$s. Або відскануйте "
+"QR-код для відновлення у вашому PDF-файлі."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14273,8 +14259,7 @@ msgstr "Відкрити вебсайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
+msgstr "Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14443,8 +14428,7 @@ msgstr "Відкрити панель «Як працює Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
+msgstr "Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14833,8 +14817,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу IP-"
-"адресу, відбиток браузера чи інші дані з файлом."
+"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу "
+"IP-адресу, відбиток браузера чи інші дані з файлом."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14904,7 +14888,7 @@ msgstr "Минулий рік"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "Вставити"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14922,7 +14906,7 @@ msgstr "Вставте код синхронізації"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "Вставте код нижче"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14981,7 +14965,7 @@ msgstr "Перська"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14990,6 +14974,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
+"Personal Information Removal знаходить ваші персональні дані на сайтах "
+"брокерів даних, які їх продають. А потім ми працюємо над її видаленням для "
+"тебе."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15244,8 +15231,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
+msgstr "Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15253,8 +15239,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
+msgstr "Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15268,8 +15253,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
+msgstr "Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -16260,7 +16244,7 @@ msgstr "Читаємо сайт..."
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "Готові до сонячного затемнення?"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16302,8 +16286,7 @@ msgstr "Обґрунтування може надавати кращі відп
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Поглиблена логіка, але досягає лімітів використання у 2–5 разів швидше. %1$s"
+msgstr "Поглиблена логіка, але досягає лімітів використання у 2–5 разів швидше. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16458,7 +16441,7 @@ msgstr "Код відновлення"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "Код відновлення"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16679,8 +16662,7 @@ msgstr "Запам'ятати вибір"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
+msgstr "Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16716,7 +16698,7 @@ msgstr "Видалити %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "Видалити пристрій"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16764,13 +16746,13 @@ msgstr "Видаліть непотрібні знаки пунктуації"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "Видаліть свої дані з інтернету"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "Видаліть свої дані в мережі"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17468,7 +17450,7 @@ msgstr "Привітайтеся з Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "Знайомтеся—Duck.ai: безплатний приватний чат із ШІ від DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17623,8 +17605,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
+msgstr "Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17970,8 +17951,7 @@ msgstr "Друга думка"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
+msgstr "Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18189,21 +18169,18 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
+msgstr "Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
+msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
+msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18414,8 +18391,7 @@ msgstr "Вибраний текст із %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
+msgstr "Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18487,7 +18463,7 @@ msgstr "Сербська (латинка)"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "Дані сервера видалено"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18649,7 +18625,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "Поділитися"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18666,8 +18642,7 @@ msgstr "Поділитися"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
+msgstr "Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18805,13 +18780,13 @@ msgstr "Поділіться своїми думками у вікні пошу�
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "Посилання на спільні чати"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "Посилання на спільні чати"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -19220,14 +19195,12 @@ msgstr "Показує найпопулярніші посилання у нов
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
+msgstr "Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
+msgstr "Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19271,8 +19244,7 @@ msgstr "Показує привітальне повідомлення вгор�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
+msgstr "Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19496,7 +19468,7 @@ msgstr "Сталася помилка"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "Сталася помилка під час завантаження цього спільного чату."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19508,8 +19480,7 @@ msgstr "Щось пішло не так при збереженні на сер�
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
+msgstr "Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19613,8 +19584,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
+msgstr "На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20354,7 +20324,7 @@ msgstr "Перемкнути модель"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "Перемкнути модель"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20620,7 +20590,7 @@ msgstr "Синхронізовані пристрої"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "Синхронізовано %1$s"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20658,7 +20628,7 @@ msgstr "ТБ"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "Таблиця"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -21151,8 +21121,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
+msgstr "Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21244,7 +21213,7 @@ msgstr ""
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "Цей пристрій"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -21255,6 +21224,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
+"Цей пристрій більше не матиме доступу до ваших синхронізованих даних на "
+"інших пристроях. Останні %1$s чатів залишитимуться доступними в локальному "
+"сховищі."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21325,16 +21297,14 @@ msgstr "Це зображення не вдалося створити."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
+msgstr "Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
+msgstr "Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21345,7 +21315,7 @@ msgstr "Ця інформація некорисна"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "Це копія спільного чату."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21413,8 +21383,7 @@ msgstr "Для роботи цієї сторінки необхідний Javas
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
+msgstr "Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21464,13 +21433,13 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "Не вдалося відкрити цей спільний чат. Можливо, посилання неповне."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "Це посилання на спільний чат більше недоступне."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21501,8 +21470,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
+msgstr "Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21542,8 +21510,7 @@ msgstr "Це зітре усі налаштування. Продовжити?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
+msgstr "Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -22123,7 +22090,7 @@ msgstr "Спробувати безкоштовно"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "Спробувати безкоштовно!"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -22220,8 +22187,7 @@ msgstr "Спробуйте увімкнути анонімне розташув�
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
+msgstr "Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22245,7 +22211,7 @@ msgstr "Спробуйте безкоштовно"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "Спробуйте безкоштовно!"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -22314,8 +22280,7 @@ msgstr "Спробуйте наш браузер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
+msgstr "Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22350,8 +22315,7 @@ msgstr "Спробуйте налаштувати ваше розташуван�
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
+msgstr "Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22500,7 +22464,7 @@ msgstr "Туркменістан"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "Вимкнути"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22518,7 +22482,7 @@ msgstr "Вимкнути Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "Вимкнути Sync & Backup та видалити дані сервера?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22584,8 +22548,7 @@ msgstr "Вимкнути:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
+msgstr "Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -22816,8 +22779,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
+msgstr "В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22827,8 +22789,7 @@ msgstr "В %1$sНалаштуваннях пошуку%2$s оберіть %3$sDu
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
+msgstr "В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -22848,8 +22809,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
+msgstr "Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22988,8 +22948,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
+msgstr "Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23007,7 +22966,7 @@ msgstr "Увімкнути звук"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "Чат без назви"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -23048,7 +23007,7 @@ msgstr "Оновити браузер"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "Оновіть Duck.ai, щоб переглянути цей спільний чат."
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -23220,8 +23179,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
+msgstr "Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23530,8 +23488,7 @@ msgstr "Переглянути ціни на проживання"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
+msgstr "Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23638,8 +23595,8 @@ msgid ""
 msgstr ""
 "Відвідайте сайт Duck.ai в іншому браузері або в додатку DuckDuckGo та "
 "відкрийте налаштування Duck.ai. Виберіть «Увімкнути» у розділі «Sync & "
-"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте QR-"
-"код у PDF-файлі для відновлення."
+"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте "
+"QR-код у PDF-файлі для відновлення."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23917,8 +23874,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
+msgstr "Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23983,8 +23939,7 @@ msgstr "Ми ніколи не стежимо за вами."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
+msgstr "Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24042,6 +23997,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
+"Ми знаходимо та видаляємо ваші персональні дані із сайтів брокерів даних. А "
+"також отримайте VPN та інші переваги."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24096,6 +24053,8 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
+"Ми регулярно перевіряємо сайти брокерів даних на наявність ваших "
+"персональних даних і показуємо прогрес вилучення у зручній панелі керування."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24131,8 +24090,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
+msgstr "Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24141,6 +24099,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
+"Ми шукатимемо на сайтах брокерів даних вашу електронну пошту, ім'я, адресу й "
+"інші відомості та працюватимемо над їх повним видаленням."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24460,7 +24420,7 @@ msgstr "Які плюси і мінуси ануїтетів?"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Які переваги у Duck.ai?"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -24563,8 +24523,7 @@ msgstr "Які страви тут варто скуштувати?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Які години роботи, місцезнаходження та контактна інформація цього місця?"
+msgstr "Які години роботи, місцезнаходження та контактна інформація цього місця?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24715,8 +24674,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Що таке збережена в хмарі закладка і чим вона відрізняється від URL-"
-"параметрів?"
+"Що таке збережена в хмарі закладка і чим вона відрізняється від "
+"URL-параметрів?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24791,8 +24750,7 @@ msgstr "Про що б ви хотіли залишити відгук?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
+msgstr "Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25038,6 +24996,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
+"Працює безпосередньо з вашого пристрою, щоб видалити вашу електронну пошту, "
+"ім'я, адресу та інші дані із сайтів брокерів даних."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25543,7 +25503,7 @@ msgstr "Залишилася 1 спроба."
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "У вас немає посилань на спільні чати."
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -25605,8 +25565,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
+msgstr "Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25774,14 +25733,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
+msgstr "Ваші %1$s останні чати будуть доступні у локальному сховищі на цих браузерах:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "Ваші чати Duck.ai синхронізуються за допомогою наскрізного шифрування."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25813,6 +25772,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
+"Вашу резервну копію буде видалено із сервера DuckDuckGo. Всі пристрої будуть "
+"відключені від синхронізації."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25901,8 +25862,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
+msgstr "Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25962,8 +25922,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
+msgstr "Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: uk_UA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -22,7 +23,8 @@ msgstr "Пошукові ярлики !Bang"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr "\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
+msgstr ""
+"\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -41,6 +43,14 @@ msgstr "% повністю вакцинованих"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "% вакцинованих"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -489,11 +499,19 @@ msgid "%sLearn how we keep your location private%s."
 msgstr "%1$sДізнайтеся, як ми зберігаємо приватність вашого розташування%2$s."
 
 # smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
+msgstr ""
+"%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -777,6 +795,12 @@ msgid "2nd in Group %s"
 msgstr "2 місце в групі %1$s"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -931,7 +955,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
+msgstr ""
+"Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1047,10 +1072,9 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "Наразі можливість ставити подальші запитання штучному інтелекту не "
-"підтримується. Однак ми також пропонуємо і часто посилаємось на "
-"%1$sDuck.ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai "
-"— це наша служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic "
-"тощо."
+"підтримується. Однак ми також пропонуємо і часто посилаємось на %1$sDuck."
+"ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai — це наша "
+"служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic тощо."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1461,6 +1485,12 @@ msgid "Add to Home Screen"
 msgstr "Додати на головний екран"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Додатки"
@@ -1823,6 +1853,13 @@ msgid "All types"
 msgstr "Усі типи"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1857,7 +1894,8 @@ msgstr "Дозволити анонімний перегляд файлів у �
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
+msgstr ""
+"Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2190,7 +2228,8 @@ msgstr "Ти ще тут?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
+msgstr ""
+"Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2343,6 +2382,12 @@ msgid "Ask anything privately"
 msgstr "Запитуйте будь-що. Все конфіденційно"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2401,10 +2446,11 @@ msgstr ""
 "Assist може анонімно генерувати відповіді ШІ на деякі пошукові запити, "
 "узагальнюючи релевантний веб-контент. Можна вибрати частоту відображення "
 "Assist: «Ніколи» (повністю приховує інтерфейс Assist із результатів пошуку), "
-"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки «Assist» "
-"), «Іноді» (відображаються лише відповіді ШІ в разі високої релевантності) "
-"або «Часто» (відображається частіше у різних пошукових запитах). Наразі "
-"відповіді штучного інтелекту доступні лише в США (англійською)."
+"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки "
+"«Assist» ), «Іноді» (відображаються лише відповіді ШІ в разі високої "
+"релевантності) або «Часто» (відображається частіше у різних пошукових "
+"запитах). Наразі відповіді штучного інтелекту доступні лише в США "
+"(англійською)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -4101,7 +4147,8 @@ msgstr "Перевірте сабреддіт DuckDuckGo, щоб дізнати�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
+msgstr ""
+"Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4527,7 +4574,8 @@ msgstr "Оберіть %1$sНалаштування%2$s з меню вибору
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
+msgstr ""
+"Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4643,7 +4691,8 @@ msgstr "Натисніть на вкладку %1$sЗагальні%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr "Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
+msgstr ""
+"Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -4660,7 +4709,8 @@ msgstr "Натисніть %1$sзначок дозволів%2$s в адресн
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
+msgstr ""
+"Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5278,6 +5328,12 @@ msgid "Copy"
 msgstr "Копіювати"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5317,6 +5373,28 @@ msgstr "Копіювати або зберегти цей код"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "Копіювати код відновлення"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6000,6 +6078,14 @@ msgid "Delete recent chats?"
 msgstr "Видалити останні чати?"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -6010,6 +6096,14 @@ msgstr "Видалити цей чат?"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "Видалені чати"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6265,6 +6359,13 @@ msgstr "Відхилити"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "Відхилити"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6909,7 +7010,8 @@ msgstr "Duck.ai оновлено!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
+msgstr ""
+"Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6953,10 +7055,10 @@ msgstr ""
 "У відповідь на деякі пошукові запити DuckAssist іноді анонімно шукає та "
 "узагальнює інформацію. Можна вибрати частоту відображення DuckAssist: "
 "«Ніколи» (повністю приховує інтерфейс DuckAssist із результатів пошуку), «На "
-"вимогу» (відображається лише при натисканні кнопки «Допомога»), «Іноді» "
-"(показується лише в разі високої релевантності) або «Часто» (відображається "
-"частіше у різних пошукових запитах). Наразі DuckAssist доступний лише у США "
-"(англійською)."
+"вимогу» (відображається лише при натисканні кнопки «Допомога»), "
+"«Іноді» (показується лише в разі високої релевантності) або "
+"«Часто» (відображається частіше у різних пошукових запитах). Наразі "
+"DuckAssist доступний лише у США (англійською)."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7016,8 +7118,8 @@ msgstr ""
 "основі штучного інтелекту. Відповіді DuckAssist завжди містять пряме "
 "посилання на одне або два джерела відповіді, тому ви можете швидко знайти "
 "більш детальну інформацію. Важливо пам'ятати, що відповіді автоматично "
-"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих "
-"веб-сторінках%2$s."
+"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих веб-"
+"сторінках%2$s."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7119,6 +7221,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "Браузер DuckDuckGo %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7245,8 +7354,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s "
-"Duck.ai."
+"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7254,7 +7363,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
+msgstr ""
+"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7455,7 +7565,8 @@ msgstr "Редагувати запит"
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
-msgstr "Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr ""
+"Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is editing an image.
@@ -7468,7 +7579,8 @@ msgstr "Редагування зображення..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
+msgstr ""
+"Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7730,7 +7842,8 @@ msgstr "Користуєтеся Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
+msgstr ""
+"Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7778,13 +7891,15 @@ msgstr "Переконайтеся, що доступ до розташуван�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
+msgstr ""
+"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
+msgstr ""
+"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7956,10 +8071,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "Duck-сконалі програмні продукти для тих, хто любить приватність."
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "Закінчилася"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7984,7 +8114,8 @@ msgstr "Поясніть прийняту відповідь простими с
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
+msgstr ""
+"Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8326,7 +8457,8 @@ msgstr "Відфільтровує створені ШІ зображення з
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
+msgstr ""
+"Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8363,7 +8495,8 @@ msgstr "Фінансовий радник"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
+msgstr ""
+"Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8375,7 +8508,8 @@ msgstr "Знайдіть <b>%1$s</b> у папці завантажень"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
+msgstr ""
+"Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8842,19 +8976,22 @@ msgstr "Загальне призначення"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr "Штучний інтелект загального призначення з вбудованою високою модерацією"
+msgstr ""
+"Штучний інтелект загального призначення з вбудованою високою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Штучний інтелект загального призначення з вбудованою низькою модерацією"
+msgstr ""
+"Штучний інтелект загального призначення з вбудованою низькою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr "Штучний інтелект загального призначення із вбудованою середньою модерацією"
+msgstr ""
+"Штучний інтелект загального призначення із вбудованою середньою модерацією"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -8915,7 +9052,8 @@ msgstr "Згенероване зображення"
 #. Title text shown for an assistant response that contains a generated image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Generated image. Cost %s (internal only)"
-msgstr "Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr ""
+"Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Aria label for the carousel (list of generated images) in the image generation mode.
@@ -9330,6 +9468,14 @@ msgstr ""
 "для відновлення."
 
 # smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -9440,6 +9586,12 @@ msgstr "Зрозуміло"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "Зрозуміло"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -10274,7 +10426,8 @@ msgctxt "Full sentence for preparing for a conversation"
 msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
-msgstr "Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
+msgstr ""
+"Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -11143,7 +11296,8 @@ msgstr "Приєднуйтесь до нашої команди!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr "Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
+msgstr ""
+"Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -11418,6 +11572,12 @@ msgid "Learn %sMore%s"
 msgstr "%1$sДокладніше%2$s"
 
 # smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -11591,8 +11751,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Дозволяє перемикатися між надсиланням пошукових запитів та промптів до "
-"Duck.ai"
+"Дозволяє перемикатися між надсиланням пошукових запитів та промптів до Duck."
+"ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11787,7 +11947,8 @@ msgstr "Завантаження..."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more image and video results when scrolling"
-msgstr "Завантаження інших результатів для зображень та відео при прокручуванні"
+msgstr ""
+"Завантаження інших результатів для зображень та відео при прокручуванні"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -12055,6 +12216,13 @@ msgid "Manage"
 msgstr "Керувати"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -12304,6 +12472,12 @@ msgstr "Меню"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Меню"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12678,6 +12852,12 @@ msgid "More about Duck.ai"
 msgstr "Більше про Duck.ai"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Більше на"
@@ -12870,6 +13050,12 @@ msgstr "Приглушено"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Приглушений червоний"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13940,6 +14126,30 @@ msgstr ""
 "піктограму %4$s > Настройки%5$s"
 
 # smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -14063,7 +14273,8 @@ msgstr "Відкрити вебсайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
+msgstr ""
+"Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14232,7 +14443,8 @@ msgstr "Відкрити панель «Як працює Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
+msgstr ""
+"Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14621,8 +14833,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу "
-"IP-адресу, відбиток браузера чи інші дані з файлом."
+"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу IP-"
+"адресу, відбиток браузера чи інші дані з файлом."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14689,6 +14901,12 @@ msgid "Past year"
 msgstr "Минулий рік"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14699,6 +14917,12 @@ msgstr "Вставити"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "Вставте код синхронізації"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14752,6 +14976,20 @@ msgstr "Зачинено назавжди"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Перська"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15006,7 +15244,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
+msgstr ""
+"Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15014,7 +15253,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
+msgstr ""
+"Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15028,7 +15268,8 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
+msgstr ""
+"Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -16016,6 +16257,12 @@ msgid "Reading website…"
 msgstr "Читаємо сайт..."
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -16055,7 +16302,8 @@ msgstr "Обґрунтування може надавати кращі відп
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Поглиблена логіка, але досягає лімітів використання у 2–5 разів швидше. %1$s"
+msgstr ""
+"Поглиблена логіка, але досягає лімітів використання у 2–5 разів швидше. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16205,6 +16453,12 @@ msgstr "Відновлення"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "Код відновлення"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16425,7 +16679,8 @@ msgstr "Запам'ятати вибір"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
+msgstr ""
+"Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16456,6 +16711,12 @@ msgstr "Видалити %1$s"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "Видалити %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16498,6 +16759,18 @@ msgstr "Видалити вибраний текст"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "Видаліть непотрібні знаки пунктуації"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17192,6 +17465,12 @@ msgid "Say hello to Duck.ai"
 msgstr "Привітайтеся з Duck.ai"
 
 # smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai!"
@@ -17344,7 +17623,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
+msgstr ""
+"Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17690,7 +17970,8 @@ msgstr "Друга думка"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
+msgstr ""
+"Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17908,18 +18189,21 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
+msgstr ""
+"Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
+msgstr ""
+"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
+msgstr ""
+"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18130,7 +18414,8 @@ msgstr "Вибраний текст із %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
+msgstr ""
+"Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18196,6 +18481,13 @@ msgstr "Сербська (кирилиця)"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Сербська (латинка)"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18352,6 +18644,14 @@ msgid "Share"
 msgstr "Поділитися"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -18366,7 +18666,8 @@ msgstr "Поділитися"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
+msgstr ""
+"Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18499,6 +18800,18 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
 msgstr "Поділіться своїми думками у вікні пошуку."
+
+# smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18907,12 +19220,14 @@ msgstr "Показує найпопулярніші посилання у нов
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
+msgstr ""
+"Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
+msgstr ""
+"Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18956,7 +19271,8 @@ msgstr "Показує привітальне повідомлення вгор�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
+msgstr ""
+"Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19177,6 +19493,12 @@ msgid "Something went wrong"
 msgstr "Сталася помилка"
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
@@ -19186,7 +19508,8 @@ msgstr "Щось пішло не так при збереженні на сер�
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
+msgstr ""
+"Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19290,7 +19613,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
+msgstr ""
+"На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20027,6 +20351,12 @@ msgid "Switch model"
 msgstr "Перемкнути модель"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -20286,6 +20616,13 @@ msgid "Synced Devices"
 msgstr "Синхронізовані пристрої"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "Сирія"
 
@@ -20316,6 +20653,12 @@ msgstr "Уточнюється"
 # smartling.placeholder_format=C
 msgid "TV"
 msgstr "ТБ"
+
+# smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20808,7 +21151,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
+msgstr ""
+"Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20897,6 +21241,22 @@ msgstr ""
 "читайте тут: %4$s)."
 
 # smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -20965,19 +21325,27 @@ msgstr "Це зображення не вдалося створити."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
+msgstr ""
+"Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
+msgstr ""
+"Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Ця інформація некорисна"
+
+# smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -21045,7 +21413,8 @@ msgstr "Для роботи цієї сторінки необхідний Javas
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
+msgstr ""
+"Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21092,6 +21461,18 @@ msgstr ""
 "стартова сторінка %1$s, де ніколи не відображаються відповіді ШІ."
 
 # smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
 msgctxt "translations_module"
 msgid "This translation is helpful"
@@ -21120,7 +21501,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
+msgstr ""
+"Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21160,7 +21542,8 @@ msgstr "Це зітре усі налаштування. Продовжити?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
+msgstr ""
+"Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21737,6 +22120,12 @@ msgid "Try Free"
 msgstr "Спробувати безкоштовно"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21831,7 +22220,8 @@ msgstr "Спробуйте увімкнути анонімне розташув�
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
+msgstr ""
+"Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21850,6 +22240,12 @@ msgstr "Спробуйте безкоштовно"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "Спробуйте безкоштовно"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21918,7 +22314,8 @@ msgstr "Спробуйте наш браузер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
+msgstr ""
+"Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -21953,7 +22350,8 @@ msgstr "Спробуйте налаштувати ваше розташуван�
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
+msgstr ""
+"Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22099,6 +22497,12 @@ msgid "Turkmenistan"
 msgstr "Туркменістан"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -22109,6 +22513,12 @@ msgstr "Вимкнути Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "Вимкнути Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22174,7 +22584,8 @@ msgstr "Вимкнути:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
+msgstr ""
+"Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -22405,7 +22816,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
+msgstr ""
+"В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22415,7 +22827,8 @@ msgstr "В %1$sНалаштуваннях пошуку%2$s оберіть %3$sDu
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
+msgstr ""
+"В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -22435,7 +22848,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
+msgstr ""
+"Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22574,7 +22988,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
+msgstr ""
+"Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -22587,6 +23002,12 @@ msgstr "Розблокуйте преміум-захисти"
 msgctxt "voice chat"
 msgid "Unmute"
 msgstr "Увімкнути звук"
+
+# smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22622,6 +23043,12 @@ msgstr "Оновити"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "Оновити браузер"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22793,7 +23220,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
+msgstr ""
+"Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23102,7 +23530,8 @@ msgstr "Переглянути ціни на проживання"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
+msgstr ""
+"Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23209,8 +23638,8 @@ msgid ""
 msgstr ""
 "Відвідайте сайт Duck.ai в іншому браузері або в додатку DuckDuckGo та "
 "відкрийте налаштування Duck.ai. Виберіть «Увімкнути» у розділі «Sync & "
-"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте "
-"QR-код у PDF-файлі для відновлення."
+"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте QR-"
+"код у PDF-файлі для відновлення."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23488,7 +23917,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
+msgstr ""
+"Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23553,7 +23983,8 @@ msgstr "Ми ніколи не стежимо за вами."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
+msgstr ""
+"Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23605,6 +24036,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "Ми завершили чат через неактивність. Хочеш спробувати ще раз?"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -23651,6 +24090,14 @@ msgstr ""
 "результатів, ближче до вас. Ви завжди можете це змінити."
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -23684,7 +24131,16 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
+msgstr ""
+"Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24001,6 +24457,12 @@ msgid "What are some pros and cons of annuities?"
 msgstr "Які плюси і мінуси ануїтетів?"
 
 # smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
 msgctxt "User prompt seeded by Learn More CTA"
 msgid ""
@@ -24101,7 +24563,8 @@ msgstr "Які страви тут варто скуштувати?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Які години роботи, місцезнаходження та контактна інформація цього місця?"
+msgstr ""
+"Які години роботи, місцезнаходження та контактна інформація цього місця?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24252,8 +24715,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Що таке збережена в хмарі закладка і чим вона відрізняється від "
-"URL-параметрів?"
+"Що таке збережена в хмарі закладка і чим вона відрізняється від URL-"
+"параметрів?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24328,7 +24791,8 @@ msgstr "Про що б ви хотіли залишити відгук?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
+msgstr ""
+"Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24566,6 +25030,14 @@ msgstr ""
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "Без нульової видимості для постачальника"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25067,6 +25539,13 @@ msgid "You have 1 attempt left."
 msgstr "Залишилася 1 спроба."
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -25126,7 +25605,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
+msgstr ""
+"Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25287,6 +25767,23 @@ msgid "YouTube Standard"
 msgstr "Стандарт YouTube"
 
 # smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr "Журнал пошуку на DuckDuckGo є конфіденційним"
@@ -25308,6 +25805,14 @@ msgstr "Ваше фактичне місцезнаходження залиша�
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
 msgstr "Ваше фактичне місцезнаходження залишається конфіденційним."
+
+# smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25396,7 +25901,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
+msgstr ""
+"Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25456,7 +25962,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
+msgstr ""
+"Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/ur_PK/LC_MESSAGES/duckduckgo.po
+++ b/locales/ur_PK/LC_MESSAGES/duckduckgo.po
@@ -42,6 +42,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -392,6 +399,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -626,6 +639,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1179,6 +1197,11 @@ msgstr " %s میں شامل کریں "
 msgid "Add to Home Screen"
 msgstr ""
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "اضافی پلگ ان"
@@ -1471,6 +1494,12 @@ msgstr ""
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
+msgstr ""
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
 msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1881,6 +1910,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4197,6 +4231,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4229,6 +4268,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4789,6 +4847,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4797,6 +4862,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5003,6 +5075,12 @@ msgstr ""
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5650,6 +5728,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6312,9 +6396,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7407,6 +7504,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7491,6 +7595,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9083,6 +9192,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "معلومات حاصل کریں %s کو زیادہ %s کو"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9600,6 +9714,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9805,6 +9925,11 @@ msgstr "مینو"
 #. Refers to the menu of a restaurant.
 msgctxt "maps_places"
 msgid "Menu"
+msgstr ""
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -10107,6 +10232,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "میں زیادہ"
@@ -10266,6 +10396,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "خاموش سرخ"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11143,6 +11278,27 @@ msgid ""
 "Settings%s"
 msgstr ""
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11747,6 +11903,11 @@ msgstr ""
 msgid "Past year"
 msgstr ""
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11755,6 +11916,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11799,6 +11965,18 @@ msgstr ""
 #. The name of the Persian language
 msgctxt "language_name"
 msgid "Persian"
+msgstr ""
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -12813,6 +12991,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -12962,6 +13145,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13169,6 +13357,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13202,6 +13395,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13750,6 +13953,11 @@ msgstr "بادل پر گمنام آپ کی ترتیبات کو بچانے کے"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14516,6 +14724,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr ""
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14640,6 +14854,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14759,6 +14980,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15306,6 +15537,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -15995,6 +16231,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16192,6 +16433,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16217,6 +16464,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "ٹی وی"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16669,6 +16921,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16737,6 +17003,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16820,6 +17091,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17334,6 +17615,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17426,6 +17712,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17625,6 +17916,11 @@ msgstr ""
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17633,6 +17929,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18010,6 +18311,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18037,6 +18343,11 @@ msgstr ""
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18803,6 +19114,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18837,6 +19155,13 @@ msgid ""
 "you. You can always change your mind later."
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18861,6 +19186,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19105,6 +19437,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19567,6 +19904,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -19969,6 +20313,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20135,6 +20485,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr ""
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20152,6 +20517,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/vi_VN/LC_MESSAGES/duckduckgo.po
+++ b/locales/vi_VN/LC_MESSAGES/duckduckgo.po
@@ -43,6 +43,13 @@ msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr ""
 
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
+
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
 msgctxt "Sports module"
 msgid "%s Intermission"
@@ -394,6 +401,12 @@ msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%sTìm hiểm xem cách chúng tôi giữ bảo mật cho vị trí của bạn%s."
 
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
+
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
@@ -628,6 +641,11 @@ msgstr ""
 #. Text indicating the runner-up of a World Cup group when that team is not yet known
 msgctxt "Sports module"
 msgid "2nd in Group %s"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
 msgstr ""
 
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -1183,6 +1201,11 @@ msgstr "Thêm vào %s"
 msgid "Add to Home Screen"
 msgstr "Thêm vào màn hình chính"
 
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "Các tiện ích"
@@ -1474,6 +1497,12 @@ msgstr "Tất cả kích cỡ"
 msgctxt "image-type"
 msgid "All types"
 msgstr "Tất cả các loại"
+
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
@@ -1887,6 +1916,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages when the chat is empty.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask anything privately"
 msgstr ""
 
@@ -4229,6 +4263,11 @@ msgctxt "Button label that copies the recovery code text to clipboard"
 msgid "Copy"
 msgstr ""
 
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -4261,6 +4300,25 @@ msgstr ""
 #. Aria label for the icon button that copies the recovery code to the clipboard.
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
+msgstr ""
+
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
 msgstr ""
 
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -4821,6 +4879,13 @@ msgctxt "Modal header for deleting all recent chats confirmation"
 msgid "Delete recent chats?"
 msgstr ""
 
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -4829,6 +4894,13 @@ msgstr ""
 #. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
+msgstr ""
+
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
 msgstr ""
 
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5035,6 +5107,12 @@ msgstr "Huỷ bỏ"
 
 #. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
 msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
 msgstr ""
 
@@ -5682,6 +5760,12 @@ msgctxt ""
 "Placeholder name for a DuckDuckGo native browser/app in the synced devices "
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
 msgstr ""
 
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6360,9 +6444,22 @@ msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
 
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
+msgstr ""
+
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
 msgstr ""
 
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7454,6 +7551,13 @@ msgid ""
 "on your Recovery PDF."
 msgstr ""
 
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
+
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -7538,6 +7642,11 @@ msgstr ""
 
 #. A button that closes the welcome modal.
 msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
 msgstr ""
 
@@ -9142,6 +9251,11 @@ msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "TÌm hiểu %sthêm%s"
 
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
+
 #. Text for a button that opens a modal or page with additional information about a feature.
 msgctxt "Button text to learn more about a feature"
 msgid "Learn More"
@@ -9659,6 +9773,12 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -9865,6 +9985,11 @@ msgstr "Menu"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "Menu"
+
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
@@ -10166,6 +10291,11 @@ msgctxt "Onboarding welcome screen title for deferred experiment"
 msgid "More about Duck.ai"
 msgstr ""
 
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "Tìm thêm tại"
@@ -10323,6 +10453,11 @@ msgstr ""
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "Đỏ lừ"
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
 msgctxt "Label for user name input"
@@ -11202,6 +11337,27 @@ msgstr ""
 "Trên Mac, %sNhấp vào Maxthon > Tuỳ chỉnh%s, Trên Windows, %sNhấp vào biểu "
 "tượng %s > Thiết lập%s"
 
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
+
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
@@ -11819,6 +11975,11 @@ msgstr "Tuần trước"
 msgid "Past year"
 msgstr "Năm ngoái"
 
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -11827,6 +11988,11 @@ msgstr ""
 #. Label for the paste button on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
+msgstr ""
+
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
 msgstr ""
 
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -11872,6 +12038,18 @@ msgstr ""
 msgctxt "language_name"
 msgid "Persian"
 msgstr "Tiếng Ba Tư"
+
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
 msgctxt "Assistant role option label for Personal trainer"
@@ -12885,6 +13063,11 @@ msgctxt "Assistant response progress report"
 msgid "Reading website…"
 msgstr ""
 
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -13034,6 +13217,11 @@ msgstr ""
 
 #. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
 msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
 msgstr ""
 
@@ -13241,6 +13429,11 @@ msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr ""
 
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -13274,6 +13467,16 @@ msgstr ""
 #. A prompt asking users to try searching without any punctuation to get more results.
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
 msgstr ""
 
 msgctxt "settings"
@@ -13822,6 +14025,11 @@ msgstr "Lưu cài đặt ẩn danh trên mây"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
 msgstr ""
 
 #. Title displayed on the welcome screen of the onboarding.
@@ -14601,6 +14809,12 @@ msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "Tiếng Serbia (Latin)"
 
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
+
 #. Status label shown when the voice chat session has ended.
 msgctxt "voice chat"
 msgid "Session ended"
@@ -14725,6 +14939,13 @@ msgctxt "Button for sharing a chat or response"
 msgid "Share"
 msgstr ""
 
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -14845,6 +15066,16 @@ msgstr ""
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
 msgstr ""
 
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -15392,6 +15623,11 @@ msgstr ""
 #. Error modal title.
 msgctxt "duckai_migration"
 msgid "Something went wrong"
+msgstr ""
+
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
 msgstr ""
 
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -16085,6 +16321,11 @@ msgctxt "AI Chat - Tooltip for switch model chat action"
 msgid "Switch model"
 msgstr ""
 
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -16283,6 +16524,12 @@ msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "Synced Devices"
 msgstr ""
 
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
 msgid "Syria"
 msgstr ""
 
@@ -16308,6 +16555,11 @@ msgstr ""
 
 msgid "TV"
 msgstr "TV"
+
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
 
 #. The name of the Tahitian language
 msgctxt "language_name"
@@ -16768,6 +17020,20 @@ msgid ""
 "more info)."
 msgstr ""
 
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
+
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
@@ -16836,6 +17102,11 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
 msgstr ""
 
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -16919,6 +17190,16 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
 msgstr ""
 
 #. User feedback indicating that a translation is helpful
@@ -17435,6 +17716,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr ""
 
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -17527,6 +17813,11 @@ msgstr ""
 #. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
 msgstr ""
 
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -17728,6 +18019,11 @@ msgstr "Tiếng Thổ Nhĩ Kỳ"
 msgid "Turkmenistan"
 msgstr ""
 
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -17736,6 +18032,11 @@ msgstr ""
 #. Disconnects the current device from sync without deleting server data.
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
 msgstr ""
 
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -18117,6 +18418,11 @@ msgctxt "voice chat"
 msgid "Unmute"
 msgstr ""
 
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -18144,6 +18450,11 @@ msgstr "Cập nhật"
 #. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
+msgstr ""
+
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
 msgstr ""
 
 #. Button that updates the user's current location on a map.
@@ -18924,6 +19235,13 @@ msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -18960,6 +19278,13 @@ msgstr ""
 "Chúng tôi chỉ dùng vị trí ẩn danh của bạn để đưa ra kết quả tốt hơn, gần bạn "
 "hơn. Bạn lúc nào cũng có thể thay đổi cài đặt."
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
+
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
@@ -18984,6 +19309,13 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
 msgstr ""
 
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -19228,6 +19560,11 @@ msgstr ""
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
 msgctxt "Full sentence for uncovering pros and cons"
 msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
 msgstr ""
 
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -19692,6 +20029,13 @@ msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr ""
 
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
+
 #. Label for the global number of confirmed Covid 19 cases
 msgctxt "Covid 19 module"
 msgid "World"
@@ -20097,6 +20441,12 @@ msgctxt "Anomaly modal"
 msgid "You have 1 attempt left."
 msgstr ""
 
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
@@ -20265,6 +20615,21 @@ msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "Tiêu chuẩn YouTube"
 
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
+
 msgctxt "homepage ATB modal"
 msgid "Your DuckDuckGo search history is private"
 msgstr ""
@@ -20282,6 +20647,13 @@ msgstr ""
 #. Description of the location prompt
 msgctxt "DuckChat location prompt"
 msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
 msgstr ""
 
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s（该设备）"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -189,9 +189,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
-"者切换到 Plus 或免费模型。"
+msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -200,9 +198,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
-"者切换到 Plus 或免费模型。"
+msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -217,9 +213,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，"
-"或切换到免费模式。"
+msgstr "%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，或切换到免费模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -323,9 +317,7 @@ msgid ""
 "%s runs in a Trusted Execution Environment. This means not even the model "
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
-msgstr ""
-"%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的"
-"响应，也不会在其服务器上保存此聊天记录。"
+msgstr "%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的响应，也不会在其服务器上保存此聊天记录。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -439,8 +431,7 @@ msgstr "%1$s点击%2$s添加%3$s勾选%4$s允许%5$s，然后点击%6$s确定%7$
 #. Instructions on what buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
+msgstr "%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -449,9 +440,7 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr ""
-"%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确"
-"定%9$s"
+msgstr "%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -484,7 +473,7 @@ msgstr "%1$s了解我们如何保障你的定位信息安全%2$s。"
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$s了解详情%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -776,7 +765,7 @@ msgstr "%1$s 组排名第二"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "第二意见"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -920,8 +909,7 @@ msgstr "客场"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
+msgstr "网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -979,9 +967,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 "
-"DuckDuckGo Search 中的 AI Chat 功能。关闭此设置后，仍可以通过访问 "
-"%1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
+"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 DuckDuckGo Search 中的 AI Chat "
+"功能。关闭此设置后，仍可以通过访问 %1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1042,9 +1029,8 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s 并"
-"通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 "
-"OpenAI 和 Anthropic 等公司的聊天模型。"
+"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s "
+"并通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 OpenAI 和 Anthropic 等公司的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1450,7 +1436,7 @@ msgstr "添加到主页"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "添加到“我的聊天”"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1738,9 +1724,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
-"DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用"
-"你的对话来训练聊天模型"
+msgstr "DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用你的对话来训练聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1811,7 +1795,7 @@ msgstr "不限类型"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "你的所有设备都已断开同步连接。"
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1856,8 +1840,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给"
-"数据留存期有限的搜索引擎。%2$s 的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
+"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给数据留存期有限的搜索引擎。%2$s "
+"的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2022,8 +2006,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
+msgstr "根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2233,9 +2216,7 @@ msgstr "截至"
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保"
-"护隐私。"
+msgstr "根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保护隐私。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2319,7 +2300,7 @@ msgstr "私密地提问任何问题"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "私密地提问任何问题"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2377,11 +2358,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可"
-"以选择显示 Assist 的频率：从不（从搜索结果中完全移除 Assist 用户界面)、按需"
-"（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人"
-"工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案"
-"目前仅供美国（英语）地区使用。"
+"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可以选择显示 Assist 的频率：从不（从搜索结果中完全移除 "
+"Assist "
+"用户界面)、按需（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2393,10 +2372,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答"
-"案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，"
-"根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并"
-"通过%1$s爬取网络内容%2$s自动生成。"
+"Assist "
+"是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2421,9 +2398,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr ""
-"无论是在咖啡馆、机场还是酒店，DuckDuckGo VPN 都能加密你的网络连接，并在 Wi-"
-"Fi 环境下隐藏你的 IP 地址。"
+msgstr "无论是在咖啡馆、机场还是酒店，DuckDuckGo VPN 都能加密你的网络连接，并在 Wi-Fi 环境下隐藏你的 IP 地址。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2568,9 +2543,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。"
-"Assist 目前仅供英语地区使用。"
+msgstr "为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。Assist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2578,9 +2551,7 @@ msgid ""
 "Automatically shows DuckAssist for relevant searches. DuckAssist can "
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
-msgstr ""
-"为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些"
-"搜索。DuckAssist 目前仅供英语地区使用。"
+msgstr "为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。DuckAssist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2785,9 +2756,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
-"在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身"
-"份信息，对你的对话进行匿名化处理。"
+msgstr "在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身份信息，对你的对话进行匿名化处理。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2916,8 +2885,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr ""
-"订阅我们的服务即可屏蔽有害网站、隐藏你的 IP 地址，并解锁更多高级保护功能。"
+msgstr "订阅我们的服务即可屏蔽有害网站、隐藏你的 IP 地址，并解锁更多高级保护功能。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3176,26 +3144,20 @@ msgstr "浏览文件"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，"
-"还能屏蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏"
-"蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即"
-"可匿名搜索、屏蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即可匿名搜索、屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3302,18 +3264,15 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 "
-"Cloud Save 功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令"
-"也只有浏览器知道。"
+"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 Cloud Save "
+"功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令也只有浏览器知道。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用"
-"之前，请参阅我们的%1$s。"
+msgstr "启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3321,9 +3280,7 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始"
-"使用之前，请参阅我们的%1$s。"
+msgstr "启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3807,10 +3764,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿"
-"名对话，该功能支持 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
-"DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过"
-"访问 %1$shttps://duck.ai%2$s 来使用聊天功能。 "
+"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿名对话，该功能支持 OpenAI、Anthropic "
+"等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
+"%1$shttps://duck.ai%2$s 来使用聊天功能。 "
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3940,9 +3896,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历"
-"史记录会删除已置顶的聊天记录。"
+msgstr "聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历史记录会删除已置顶的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3954,9 +3908,8 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
-"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删"
-"除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
+"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
+"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3978,9 +3931,7 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr ""
-"与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审"
-"核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
+msgstr "与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4339,9 +4290,7 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr ""
-"清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者"
-"在超过 7 天未使用 AI Chat 后自动将其删除。"
+msgstr "清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者在超过 7 天未使用 AI Chat 后自动将其删除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4350,9 +4299,7 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr ""
-"清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近"
-"期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
+msgstr "清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4369,8 +4316,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密"
-"人工智能聊天服务支持 OpenAI、Anthropic 等聊天模型。"
+"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密人工智能聊天服务支持 OpenAI、Anthropic "
+"等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4411,9 +4358,7 @@ msgstr "在弹出的菜单中点击 %1$s更改搜索设置%2$s"
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选"
-"项%4$s"
+msgstr "Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选项%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4443,9 +4388,7 @@ msgstr "在左侧的列表中点击 %1$s隐私和服务%2$s。"
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图"
-"标%4$s）"
+msgstr "在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图标%4$s）"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4535,9 +4478,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻"
-"触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
+msgstr "点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4547,9 +4488,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设"
-"置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
+msgstr "点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4617,9 +4556,7 @@ msgstr "点击搜索栏中的下拉菜单"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 "
-"%3$sDuckDuckGo%4$s。"
+msgstr "点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -5204,7 +5141,7 @@ msgstr "复制"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "复制"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5253,13 +5190,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "复制已共享链接"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "从其他设备复制代码"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5267,7 +5204,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
-msgstr ""
+msgstr "从其他设备复制代码。前往“%1$sDuck.ai 设置 › 聊天 › Sync & Backup › 与其他设备同步%2$s”并重试。"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5948,7 +5885,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "删除已共享链接"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -5968,7 +5905,7 @@ msgctxt "Description at the top of the Duck.ai shared links modal"
 msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
-msgstr ""
+msgstr "删除链接会导致该链接失效。已打开对话并将其添加到自己聊天中的人，将保留各自的副本。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6081,8 +6018,7 @@ msgstr "暂时无法使用听写功能"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
+msgstr "听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6227,7 +6163,7 @@ msgstr "隐藏"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "隐藏"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6400,9 +6336,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
-"不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 "
-"AI 生成的图像。 %3$s了解详情%4$s"
+msgstr "不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 AI 生成的图像。 %3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6411,8 +6345,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤"
-"掉 AI 生成的图像。%3$s了解详情%4$s"
+"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤掉 AI "
+"生成的图像。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6694,9 +6628,7 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr ""
-"Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非"
-"你选择在设置中自动附加页面。"
+msgstr "Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非你选择在设置中自动附加页面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6705,9 +6637,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程"
-"序再试一次。"
+msgstr "Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程序再试一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6730,9 +6660,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何"
-"希望重新掌控自己个人信息的人。"
+msgstr "Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何希望重新掌控自己个人信息的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6746,9 +6674,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页："
-"https://duck.ai"
+msgstr "Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页：https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6762,9 +6688,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 "
-"%2$s"
+msgstr "暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6784,9 +6708,7 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr ""
-"Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链"
-"接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
+msgstr "Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6797,10 +6719,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、"
-"Anthropic 等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 中的 Duck.ai 按钮"
-"和链接。不过，即使关闭该设置，仍然可以直接通过访问 %1$shttps://duck.ai%2$s 来"
-"使用 Duck.ai。"
+"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
+"DuckDuckGo Search 中的 Duck.ai 按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
+"%1$shttps://duck.ai%2$s 来使用 Duck.ai。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6861,9 +6782,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需"
-"注册的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 "
-"AI、无需账户的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需注册的 AI "
+"聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 AI、无需账户的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6891,10 +6811,10 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示"
-"频率：从不（从搜索结果中完全移除 DuckAssist 用户界面)、按需（仅在点击“协助”按"
-"钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显"
-"示）。DuckAssist 目前仅供美国（英语）地区使用。"
+"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示频率：从不（从搜索结果中完全移除 "
+"DuckAssist "
+"用户界面)、按需（仅在点击“协助”按钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显示）。DuckAssist "
+"目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6903,9 +6823,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI Chat%2$s，这"
-"是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天"
-"模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI "
+"Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6914,8 +6833,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这"
-"是一种人工智能驱动的私密聊天服务，支持 OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持 "
+"OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6927,10 +6846,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该"
-"功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生"
-"成这些信息的摘要。 请注意，其回复目前基于维基百科和相关内容，其准确性未经核"
-"实。"
+"DuckAssist "
+""
+"是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生成这些信息的摘要。 "
+"请注意，其回复目前基于维基百科和相关内容，其准确性未经核实。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6944,11 +6863,10 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist 是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，"
-"该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的"
-"相关信息生成简短的答案。DuckAssist 的回复始终直接链接到一个或两个资料来源，并"
-"注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资"
-"料来源，并通过%1$s爬取网络内容%2$s自动生成。"
+"DuckAssist "
+""
+"是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。DuckAssist "
+"的回复始终直接链接到一个或两个资料来源，并注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6971,9 +6889,7 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
-"和 %3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6981,9 +6897,7 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
-"和 %3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6999,9 +6913,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 "
-"%1$s 发送到 %2$s"
+msgstr "暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7048,7 +6960,7 @@ msgstr "DuckDuckGo 浏览器 %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo 帮助页面"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7164,18 +7076,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息"
-"来对这些报告进行匿名化。"
+msgstr "DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息来对这些报告进行匿名化。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 "
-"%2$s。"
+msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 %2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7183,8 +7091,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
+msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7192,9 +7099,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟"
-"踪程序，这些公司经常试图在其他网站上跟踪你。"
+msgstr "DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟踪程序，这些公司经常试图在其他网站上跟踪你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7206,9 +7111,8 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo 的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时"
-"会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名"
-"性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
+"DuckDuckGo "
+"的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7227,8 +7131,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
+msgstr "DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7320,8 +7223,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，"
-"并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 个字符。"
+"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 "
+"个字符。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7570,9 +7473,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置"
-"信息。"
+msgstr "启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置信息。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7758,8 +7659,7 @@ msgstr "输入文本"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
+msgstr "输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7866,7 +7766,7 @@ msgstr "为真正关心隐私的人精心打造的产品。"
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "已过期"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7880,7 +7780,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "于 %1$s 到期"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8150,9 +8050,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问"
-"题。"
+msgstr "类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问题。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8617,9 +8515,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; "
-"“<strong>Check for Updates...</strong>”（查看更新……），然后选"
-"择“<strong>Install Update</strong>”（安装更新）。"
+"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; “<strong>Check for "
+"Updates...</strong>”（查看更新……），然后选择“<strong>Install Update</strong>”（安装更新）。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8905,8 +8802,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"获取 DuckDuckGo VPN、高级 Duck.ai、Personal Information Removal 以及 "
-"Identity Theft Restoration 服务。"
+"获取 DuckDuckGo VPN、高级 Duck.ai、Personal Information Removal 以及 Identity Theft "
+"Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -8992,8 +8889,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"获取快速的无日志 VPN、可选高级人工智能聊天、Personal Information Removal 以"
-"及 Identity Theft Restoration 服务。"
+"获取快速的无日志 VPN、可选高级人工智能聊天、Personal Information Removal 以及 Identity Theft "
+"Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9001,9 +8898,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr ""
-"获取快速的无日志 VPN、可选高级人工智能聊天以及 Identity Theft Restoration 服"
-"务。"
+msgstr "获取快速的无日志 VPN、可选高级人工智能聊天以及 Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9011,9 +8906,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和"
-"其他高级隐私保护功能。"
+msgstr "订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9023,9 +8916,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和"
-"其他高级隐私保护功能。"
+msgstr "通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9068,9 +8959,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr ""
-"获取我们快速的无日志 VPN、可选高级人工智能模型（具备更高的聊天限额）以及更多"
-"高级保护功能。"
+msgstr "获取我们快速的无日志 VPN、可选高级人工智能模型（具备更高的聊天限额）以及更多高级保护功能。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9079,16 +8968,15 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"获取我们安全的无日志 VPN、高级 Duck.ai、Personal Information Removal 以及 "
-"Identity Theft Restoration 服务。"
+"获取我们安全的无日志 VPN、高级 Duck.ai、Personal Information Removal 以及 Identity Theft "
+"Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"获取我们安全的无日志 VPN，高级 Duck.ai 以及 Identity Theft Restoration 服务。"
+msgstr "获取我们安全的无日志 VPN，高级 Duck.ai 以及 Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9188,8 +9076,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊"
-"天 › Sync & Backup › 与其他设备同步 › 复制文本二维码%4$s"
+"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊天 › Sync & Backup › "
+"与其他设备同步 › 复制文本二维码%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9198,8 +9086,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
-"天 › Sync & Backup › 与其他设备同步%4$s"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
+"与其他设备同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9209,8 +9097,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊"
-"天 › Sync & Backup › 与其他设备同步%4$s并扫描此二维码："
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊天 › Sync & Backup › "
+"与其他设备同步%4$s并扫描此二维码："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9220,8 +9108,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
-"天 › Sync & Backup › 与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
+"与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9229,7 +9117,7 @@ msgctxt "Detail under the first numbered step on the Enter Code tab"
 msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
-msgstr ""
+msgstr "前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9251,9 +9139,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 "
-"%3$sDuckDuckGo%4$s。"
+msgstr "转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9343,7 +9229,7 @@ msgstr "明白了"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "明白了"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9967,9 +9853,7 @@ msgstr "历史"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr ""
-"按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s"
-"设为默认搜索引擎%6$s"
+msgstr "按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s设为默认搜索引擎%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9982,9 +9866,7 @@ msgstr "白苗语"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保"
-"护。"
+msgstr "稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保护。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10329,9 +10211,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与"
-"隐私”%2$s。"
+msgstr "如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与隐私”%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10341,8 +10221,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站"
-"设置” > “位置”%2$s，并确认已允许 DuckDuckGo 使用定位信息。"
+"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站设置” > “位置”%2$s，并确认已允许 "
+"DuckDuckGo 使用定位信息。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10356,8 +10236,7 @@ msgstr "如果你继续看到此错误，请联系 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
+msgstr "如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10365,9 +10244,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 "
-"%2$s 支持页面。"
+msgstr "如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 %2$s 支持页面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10375,9 +10252,7 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码"
-"以文本文件的形式保存到设备中。"
+msgstr "如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码以文本文件的形式保存到设备中。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -10392,9 +10267,7 @@ msgstr "如果你仍愿支持我们，可%1$s协助推广 DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版"
-"本。"
+msgstr "如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版本。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10541,9 +10414,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄"
-"露搜索内容。%1$s了解详情%2$s。"
+msgstr "如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄露搜索内容。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10553,8 +10424,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
+msgstr "在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10568,9 +10438,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具"
-"体都存了什么。"
+msgstr "本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具体都存了什么。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10975,8 +10843,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向"
-"商户页面，与广告不同，DuckDuckGo 不会通过这些搜索结果获得收益。"
+"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向商户页面，与广告不同，DuckDuckGo "
+"不会通过这些搜索结果获得收益。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11293,7 +11161,7 @@ msgstr "详细了解%1$s%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "了解详情"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11929,7 +11797,7 @@ msgstr "管理"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "管理"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12186,7 +12054,7 @@ msgstr "菜单"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "在此之后的消息仅对你可见。"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12558,7 +12426,7 @@ msgstr "关于 Duck.ai 的更多信息"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "更多操作"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12758,7 +12626,7 @@ msgstr "暗红色"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "我的设备"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -13000,9 +12868,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互"
-"联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和"
-"回复的临时存储功能。"
+"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
+"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13823,9 +13690,7 @@ msgstr "按需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设"
-"置%5$s"
+msgstr "Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设置%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -13833,7 +13698,7 @@ msgctxt "Instruction under the Scan QR tab sub-heading"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
-msgstr ""
+msgstr "在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -13841,7 +13706,7 @@ msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
-msgstr ""
+msgstr "在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”并扫描此代码："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -13850,6 +13715,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”。或者扫描恢复 "
+"PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14238,9 +14105,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简"
-"单。"
+msgstr "即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简单。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14253,9 +14118,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr ""
-"我们快速的无日志 VPN 附带更智能、限额更高的人工智能聊天功能，以及更多高级保护"
-"功能。一站式订阅服务。"
+msgstr "我们快速的无日志 VPN 附带更智能、限额更高的人工智能聊天功能，以及更多高级保护功能。一站式订阅服务。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14269,9 +14132,7 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。"
-"现已支持 %1$siOS 和 Android%2$s。"
+msgstr "我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。现已支持 %1$siOS 和 Android%2$s。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14523,9 +14384,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口"
-"令。"
+msgstr "我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口令。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14595,7 +14454,7 @@ msgstr "一年内"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "粘贴"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14613,7 +14472,7 @@ msgstr "粘贴同步二维码"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "将其粘贴到下方"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14672,7 +14531,7 @@ msgstr "波斯语"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14680,7 +14539,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
-msgstr ""
+msgstr "Personal Information Removal 会在出售个人信息的数据中介网站上查找你的信息。然后，我们会努力为你将其删除。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14750,9 +14609,7 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获"
-"得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
+msgstr "以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14761,8 +14618,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答"
-"案。 如需调整此功能的工作方式或将其关闭，请访问 %1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答案。 如需调整此功能的工作方式或将其关闭，请访问 "
+"%1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14772,8 +14629,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答"
-"案。若要将其关闭并隐藏“协助”按钮，请访问 %1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答案。若要将其关闭并隐藏“协助”按钮，请访问 "
+"%1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14813,8 +14670,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
+msgstr "选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14970,9 +14826,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害"
-"或非法。"
+msgstr "请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害或非法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14980,9 +14834,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法"
-"或有害。"
+msgstr "请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15922,7 +15774,7 @@ msgstr "正在读取网站……"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "准备好迎接日食了吗？"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16019,8 +15871,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16028,8 +15879,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16038,9 +15888,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
-"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
+msgstr "最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16114,7 +15962,7 @@ msgstr "恢复代码"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "恢复代码"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16321,9 +16169,7 @@ msgstr "重新加载 Duck.ai"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重"
-"新加载）按钮。"
+msgstr "请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重新加载）按钮。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16369,7 +16215,7 @@ msgstr "移除 %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "移除设备"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16417,31 +16263,27 @@ msgstr "删除不必要的标点符号"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "从互联网上删除你的信息"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "删除你的在线信息"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的"
-"答案。"
+msgstr "移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示"
-"缓存的答案。"
+msgstr "移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16498,18 +16340,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提"
-"供给 %1$s，以便共同提高服务质量。"
+msgstr "你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提供给 %1$s，以便共同提高服务质量。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信"
-"息。"
+msgstr "发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16517,9 +16355,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是"
-"匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
+msgstr "发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16610,9 +16446,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助"
-"的答案受我们的%1$s服务条款%2$s约束。"
+msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助的答案受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16620,9 +16454,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受"
-"我们的%1$s服务条款%2$s约束。"
+msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16632,8 +16464,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内"
-"容生成，可能包含不准确的信息。Search Assist 受我们的%1$s服务条款%2$s约束。"
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内容生成，可能包含不准确的信息。Search Assist "
+"受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17057,9 +16889,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记"
-"录。"
+msgstr "在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记录。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17108,7 +16938,7 @@ msgstr "向 Duck.ai 打个招呼"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "体验 Duck.ai——DuckDuckGo 提供的免费、私密 AI 聊天工具。"
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17225,9 +17055,7 @@ msgstr "向下滚动并点击 %1$s查看高级设置%2$s。"
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s"
-"添加搜索引擎%6$s）"
+msgstr "向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s添加搜索引擎%6$s）"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17235,9 +17063,7 @@ msgstr ""
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr ""
-"向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 "
-"%5$s添加搜索引擎%6$s）。"
+msgstr "向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 %5$s添加搜索引擎%6$s）。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17315,10 +17141,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，"
-"然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点"
-"击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显"
-"示）。Search Assist 目前仅供部分英语地区使用。"
+"Search Assist "
+""
+"匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显示）。Search "
+"Assist 目前仅供部分英语地区使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17334,8 +17160,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s"
-"扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
+"Search Assist "
+"是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17455,8 +17281,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
+msgstr "使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17474,9 +17299,7 @@ msgstr "匿名搜索并屏蔽跟踪程序"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 "
-"%1$sduckduckgo.com%2$s 发起搜索。"
+msgstr "通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 %1$sduckduckgo.com%2$s 发起搜索。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17495,9 +17318,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud "
-"Save 将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，"
-"且你的口令仅限在你的浏览器中使用。"
+"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud Save "
+"将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，且你的口令仅限在你的浏览器中使用。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17599,9 +17421,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
-"访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17609,9 +17429,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
-"访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17619,9 +17437,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同"
-"步的设备访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同步的设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17629,9 +17445,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相"
-"关内容。"
+msgstr "利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相关内容。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17645,9 +17459,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看"
-"到你的数据，甚至我们也不行。"
+msgstr "采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看到你的数据，甚至我们也不行。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -17861,16 +17673,14 @@ msgstr "在弹出的菜单中点击 %1$s管理加载项%2$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
+msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
+msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18055,9 +17865,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后"
-"的所有对话。"
+msgstr "向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后的所有对话。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18084,7 +17892,7 @@ msgstr "塞尔维亚语（拉丁字母）"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "服务器数据已删除"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18242,7 +18050,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "共享"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18285,9 +18093,7 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智"
-"能模型透露你的精确位置。"
+msgstr "与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智能模型透露你的精确位置。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18382,8 +18188,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
+msgstr "将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18395,13 +18200,13 @@ msgstr "在搜索框中分享你的看法。"
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "已共享的聊天链接"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "已共享的聊天链接"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18409,9 +18214,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr ""
-"使用我们快速的无日志 VPN 来保护你的在线活动。易于设置，并且可以随时轻松开启或"
-"关闭。"
+msgstr "使用我们快速的无日志 VPN 来保护你的在线活动。易于设置，并且可以随时轻松开启或关闭。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18768,18 +18571,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不"
-"会影响搜索隐私。"
+msgstr "提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不会影响搜索隐私。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不"
-"会影响搜索保护。"
+msgstr "提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不会影响搜索保护。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19076,7 +18875,7 @@ msgstr "出了点问题"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "加载此共享聊天时出错。"
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19912,7 +19711,7 @@ msgstr "切换模型"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "切换模型"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20094,8 +19893,7 @@ msgid ""
 msgstr ""
 "同步恢复代码\n"
 "\n"
-"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无"
-"法访问某个设备时恢复已同步的数据。\n"
+"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无法访问某个设备时恢复已同步的数据。\n"
 "\n"
 "请妥善保管此信息。\n"
 "任何可访问此代码的人都可以访问你的同步数据。\n"
@@ -20107,8 +19905,7 @@ msgstr ""
 "2. 选择“开启 Sync & Backup”，然后选择“恢复同步数据”\n"
 " 3. 复制上方的恢复代码，并将其粘贴到“在此处粘贴代码”处\n"
 "\n"
-"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据"
-"将从服务器中删除且无法恢复。"
+"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据将从服务器中删除且无法恢复。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20169,7 +19966,7 @@ msgstr "已同步设备"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "已于 %1$s 同步"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20207,7 +20004,7 @@ msgstr "电视"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "表格"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20240,9 +20037,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
-"随时随地使用 Duck.ai。下载内置此功能的免费应用——无论你身在何处，都能快速调"
-"用。"
+msgstr "随时随地使用 Duck.ai。下载内置此功能的免费应用——无论你身在何处，都能快速调用。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20250,9 +20045,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
-"随时随地使用 Duck.ai。将其内置于我们的免费浏览器中——无论你何时浏览网页，都能"
-"快速调用。"
+msgstr "随时随地使用 Duck.ai。将其内置于我们的免费浏览器中——无论你何时浏览网页，都能快速调用。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20495,9 +20288,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银"
-"行账号。"
+msgstr "这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银行账号。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20613,8 +20404,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
+msgstr "在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20646,9 +20436,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设"
-"为默认搜索引擎，从而保护你的隐私。"
+msgstr "所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设为默认搜索引擎，从而保护你的隐私。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20731,9 +20519,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr ""
-"此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不"
-"准确或令人反感的信息（详情请参阅%4$s）。"
+msgstr "此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20742,9 +20528,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或"
-"令人反感的信息（详情请参阅%2$s）。"
+msgstr "此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20752,9 +20536,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感"
-"的信息。（详情请参见 %2$s）。"
+msgstr "这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感的信息。（详情请参见 %2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20764,14 +20546,14 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可"
-"能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s "
+"模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "此设备"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -20781,7 +20563,7 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr ""
+msgstr "此设备将无法再访问你在其他设备上已同步的数据。最近的 %1$s 条聊天记录仍将保留在本地存储中。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20870,7 +20652,7 @@ msgstr "这些信息没有用"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "这是已共享聊天记录的副本。"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -20878,9 +20660,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
-"这只是一个示例聊天记录。打开其菜单（三个点），然后选择“置顶”，将其置于聊天记"
-"录顶部！"
+msgstr "这只是一个示例聊天记录。打开其菜单（三个点），然后选择“置顶”，将其置于聊天记录顶部！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20908,9 +20688,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据"
-"保留模式。"
+msgstr "该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20918,9 +20696,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据"
-"保留模式。"
+msgstr "该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20956,9 +20732,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，"
-"之后可以通过任何浏览器访问这些记录。"
+msgstr "这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，之后可以通过任何浏览器访问这些记录。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20966,9 +20740,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
-"么你可能会再次看到 AI 辅助的答案。"
+msgstr "此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI 辅助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20978,21 +20750,20 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
-"么你可能会再次看到 AI 辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显"
-"示 AI 辅助答案。"
+"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI "
+"辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显示 AI 辅助答案。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "无法打开此分享的聊天。 链接可能不完整。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "此共享聊天链接已不再可用。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21031,8 +20802,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你"
-"仍然可以在连接到 Sync & Backup 的其他浏览器中浏览你的聊天记录。"
+"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你仍然可以在连接到 Sync & Backup "
+"的其他浏览器中浏览你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21177,8 +20948,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
+msgstr "打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21187,9 +20957,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格"
-"式保存到最初用于设置同步的设备上。"
+msgstr "需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格式保存到最初用于设置同步的设备上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21197,9 +20965,7 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再"
-"试一次。"
+msgstr "如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21401,8 +21167,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
+msgstr "此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21622,7 +21387,7 @@ msgstr "免费试用"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "免费试用！"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21741,7 +21506,7 @@ msgstr "免费试用"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "免费试用！"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21934,9 +21699,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设"
-"置。%3$s了解详情%4$s"
+msgstr "想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21944,9 +21707,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的"
-"设置。%3$s了解详情%4$s"
+msgstr "想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21988,7 +21749,7 @@ msgstr "土库曼斯坦"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "关闭"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -22006,7 +21767,7 @@ msgstr "关闭 Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "关闭 Sync & Backup 并删除服务器数据？"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22146,9 +21907,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间"
-"出现短暂的延迟。"
+msgstr "在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间出现短暂的延迟。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22277,16 +22036,14 @@ msgstr "了解优点和缺点"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
+msgstr "在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
+msgstr "在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22401,9 +22158,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍"
-"的使用限额。"
+msgstr "升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍的使用限额。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22481,7 +22236,7 @@ msgstr "取消静音"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "未命名聊天"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22522,7 +22277,7 @@ msgstr "更新浏览器"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "请更新 Duck.ai 以查看此共享聊天记录。"
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22785,9 +22540,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公"
-"司的侵害。确保信息保密。免费。无需账户。"
+msgstr "私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公司的侵害。确保信息保密。免费。无需账户。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23005,8 +22758,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
+msgstr "DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23048,8 +22800,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
+"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & Backup%4$s > "
+"%5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23059,8 +22811,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup 栏下选择“开"
-"启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup "
+"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23070,9 +22822,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设"
-"置%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同"
-"步%8$s”。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设置%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同步%8$s”。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23082,9 +22833,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。"
-"在 Sync & Backup 栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF "
-"中的二维码。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。在 Sync & Backup "
+"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23279,9 +23029,7 @@ msgstr "在 Duck Player 中观看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 "
-"YouTube 推荐。"
+msgstr "在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 YouTube 推荐。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23301,8 +23049,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。"
-"DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube 没有任何关系。"
+"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube "
+"没有任何关系。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23325,9 +23073,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
-"我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 "
-"DuckDuckGo，这样我们才能调查并处理这个问题。"
+msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 DuckDuckGo，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23338,9 +23084,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回"
-"复，这样我们才能调查并处理这个问题。"
+msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回复，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23393,9 +23137,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟"
-"踪："
+msgstr "我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23403,9 +23145,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们"
-"跟踪："
+msgstr "我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23469,7 +23209,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr ""
+msgstr "我们会从数据中介网站查找并删除你的个人信息。此外，还可以获取 VPN 及更多功能。"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23509,8 +23249,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
+msgstr "匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -23518,7 +23257,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr ""
+msgstr "我们会定期在数据中介网站上扫描你的个人信息，并通过易于使用的仪表板与你共享我们的进度。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23544,9 +23283,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更"
-"正可能需要一段时间。"
+msgstr "你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更正可能需要一段时间。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23559,7 +23296,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr ""
+msgstr "我们会在数据中介网站上扫描你的电子邮件、姓名、地址等信息，并努力删除找到的有关你的任何信息。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23567,8 +23304,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
+msgstr "我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23576,8 +23312,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
+msgstr "我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23720,9 +23455,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用"
-"于训练人工智能模型。"
+msgstr "欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23730,9 +23463,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处"
-"理，不会用于训练人工智能模型。"
+msgstr "欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23742,8 +23473,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天"
-"内容均为私密，DuckDuckGo 绝不会存储或用于训练 AI 模型。"
+"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天内容均为私密，DuckDuckGo "
+"绝不会存储或用于训练 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23862,7 +23593,7 @@ msgstr "年金有哪些优点和缺点？"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Duck.ai 有哪些好处？"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -23875,9 +23606,8 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官"
-"方 DuckDuckGo 来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。"
-"保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
+"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官方 DuckDuckGo "
+"来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24412,9 +24142,7 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr ""
-"使用 Duck.ai，你的聊天内容均已匿名处理，且绝不会用于训练 AI。 可以随时"
-"在“%1$s”菜单中开启或关闭。"
+msgstr "使用 Duck.ai，你的聊天内容均已匿名处理，且绝不会用于训练 AI。 可以随时在“%1$s”菜单中开启或关闭。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24428,7 +24156,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
-msgstr ""
+msgstr "直接通过你的设备即可从数据中介网站删除您的电子邮件、姓名、地址等信息。"
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24703,8 +24431,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
+msgstr "可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24748,8 +24475,7 @@ msgstr "您最多可以附加 %1$s 个文本选中内容。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
+msgstr "可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24916,7 +24642,7 @@ msgstr "你还可以再试 1 次。"
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "你没有已共享的聊天链接。"
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -24924,9 +24650,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限"
-"额。"
+msgstr "你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限额。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24934,9 +24658,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 "
-"DuckDuckGo 订阅保护功能。"
+msgstr "现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 DuckDuckGo 订阅保护功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24957,9 +24679,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
-"存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24968,9 +24688,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
-"存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24997,9 +24715,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装"
-"的 App 上网还能进一步保护隐私，它可以："
+msgstr "现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装的 App 上网还能进一步保护隐私，它可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25087,8 +24803,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 "
-"%1$s 条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
+"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 %1$s "
+"条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25098,8 +24814,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s 条包含"
-"附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
+"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s "
+"条包含附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25112,9 +24828,7 @@ msgstr "你已用尽存储空间"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 "
-"Google 与 YouTube 跟踪。"
+msgstr "Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 Google 与 YouTube 跟踪。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25135,14 +24849,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
+msgstr "你最近的 %1$s 条聊天记录将保存在以下浏览器的本地存储中："
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "正在通过端到端加密同步你的 Duck.ai 聊天记录。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25173,7 +24887,7 @@ msgctxt "First body paragraph in the Delete Server Data confirmation modal"
 msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
-msgstr ""
+msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25182,9 +24896,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
-"览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
+msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25193,9 +24905,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
-"览器中，你最近的 100 条聊天记录将保存在本地存储中："
+msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 100 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25234,8 +24944,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
+msgstr "你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25260,16 +24969,14 @@ msgstr "你的聊天内容均为私密，绝不会用于训练人工智能模型
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25297,9 +25004,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请"
-"按照以下步骤保留聊天记录。"
+msgstr "聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请按照以下步骤保留聊天记录。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25338,9 +25043,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample "
-"message%3$s]"
+msgstr "我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample message%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25383,9 +25086,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 "
-"512 位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密"
-"钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
+"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 512 "
+"位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25399,9 +25101,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商"
-"无法将对话内容与你本人关联起来。"
+msgstr "你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商无法将对话内容与你本人关联起来。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25445,9 +25145,7 @@ msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
-msgstr ""
-"已保存你的设置，但清理浏览器 Cookie 会将其重置。启用 %1$sDuckDuckGo No "
-"AI%2$s 扩展插件，以便永久保存你的设置。"
+msgstr "已保存你的设置，但清理浏览器 Cookie 会将其重置。启用 %1$sDuckDuckGo No AI%2$s 扩展插件，以便永久保存你的设置。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25456,8 +25154,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No "
-"AI%2$s 扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
+"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No AI%2$s "
+"扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25476,9 +25174,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更"
-"多保护。已安装该浏览器并可以："
+msgstr "你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更多保护。已安装该浏览器并可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "疫苗完全接种率"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "疫苗接种率"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -181,7 +189,9 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
+msgstr ""
+"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
+"者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -190,7 +200,9 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
+msgstr ""
+"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
+"者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -205,7 +217,9 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr "%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，或切换到免费模式。"
+msgstr ""
+"%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，"
+"或切换到免费模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -309,7 +323,9 @@ msgid ""
 "%s runs in a Trusted Execution Environment. This means not even the model "
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
-msgstr "%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的响应，也不会在其服务器上保存此聊天记录。"
+msgstr ""
+"%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的"
+"响应，也不会在其服务器上保存此聊天记录。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -423,7 +439,8 @@ msgstr "%1$s点击%2$s添加%3$s勾选%4$s允许%5$s，然后点击%6$s确定%7$
 #. Instructions on what buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
+msgstr ""
+"%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -432,7 +449,9 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr "%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
+msgstr ""
+"%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确"
+"定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -459,6 +478,13 @@ msgstr "%1$s详细了解%2$s。"
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%1$s了解我们如何保障你的定位信息安全%2$s。"
+
+# smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -747,6 +773,12 @@ msgid "2nd in Group %s"
 msgstr "%1$s 组排名第二"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -888,7 +920,8 @@ msgstr "客场"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
+msgstr ""
+"网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -946,8 +979,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 DuckDuckGo Search 中的 AI Chat "
-"功能。关闭此设置后，仍可以通过访问 %1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
+"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 "
+"DuckDuckGo Search 中的 AI Chat 功能。关闭此设置后，仍可以通过访问 "
+"%1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1008,8 +1042,9 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s "
-"并通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 OpenAI 和 Anthropic 等公司的聊天模型。"
+"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s 并"
+"通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 "
+"OpenAI 和 Anthropic 等公司的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1412,6 +1447,12 @@ msgid "Add to Home Screen"
 msgstr "添加到主页"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "插件"
@@ -1697,7 +1738,9 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr "DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用你的对话来训练聊天模型"
+msgstr ""
+"DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用"
+"你的对话来训练聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1764,6 +1807,13 @@ msgid "All types"
 msgstr "不限类型"
 
 # smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow"
@@ -1806,8 +1856,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给数据留存期有限的搜索引擎。%2$s "
-"的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
+"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给"
+"数据留存期有限的搜索引擎。%2$s 的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1972,7 +2022,8 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr "根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
+msgstr ""
+"根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2182,7 +2233,9 @@ msgstr "截至"
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr "根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保护隐私。"
+msgstr ""
+"根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保"
+"护隐私。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2263,6 +2316,12 @@ msgid "Ask anything privately"
 msgstr "私密地提问任何问题"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2318,9 +2377,11 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可以选择显示 Assist 的频率：从不（从搜索结果中完全移除 "
-"Assist "
-"用户界面)、按需（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案目前仅供美国（英语）地区使用。"
+"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可"
+"以选择显示 Assist 的频率：从不（从搜索结果中完全移除 Assist 用户界面)、按需"
+"（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人"
+"工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案"
+"目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2332,8 +2393,10 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist "
-"是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
+"Assist 是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答"
+"案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，"
+"根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并"
+"通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2358,7 +2421,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr "无论是在咖啡馆、机场还是酒店，DuckDuckGo VPN 都能加密你的网络连接，并在 Wi-Fi 环境下隐藏你的 IP 地址。"
+msgstr ""
+"无论是在咖啡馆、机场还是酒店，DuckDuckGo VPN 都能加密你的网络连接，并在 Wi-"
+"Fi 环境下隐藏你的 IP 地址。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2503,7 +2568,9 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr "为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。Assist 目前仅供英语地区使用。"
+msgstr ""
+"为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。"
+"Assist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2511,7 +2578,9 @@ msgid ""
 "Automatically shows DuckAssist for relevant searches. DuckAssist can "
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
-msgstr "为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。DuckAssist 目前仅供英语地区使用。"
+msgstr ""
+"为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些"
+"搜索。DuckAssist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2716,7 +2785,9 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr "在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身份信息，对你的对话进行匿名化处理。"
+msgstr ""
+"在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身"
+"份信息，对你的对话进行匿名化处理。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2845,7 +2916,8 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr "订阅我们的服务即可屏蔽有害网站、隐藏你的 IP 地址，并解锁更多高级保护功能。"
+msgstr ""
+"订阅我们的服务即可屏蔽有害网站、隐藏你的 IP 地址，并解锁更多高级保护功能。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3104,20 +3176,26 @@ msgstr "浏览文件"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
+msgstr ""
+"正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，"
+"还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
+msgstr ""
+"正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏"
+"蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr "正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即可匿名搜索、屏蔽跟踪程序、开启网站加密。"
+msgstr ""
+"正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即"
+"可匿名搜索、屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3224,15 +3302,18 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 Cloud Save "
-"功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令也只有浏览器知道。"
+"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 "
+"Cloud Save 功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令"
+"也只有浏览器知道。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
+msgstr ""
+"启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用"
+"之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3240,7 +3321,9 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
+msgstr ""
+"启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始"
+"使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3724,9 +3807,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿名对话，该功能支持 OpenAI、Anthropic "
-"等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
-"%1$shttps://duck.ai%2$s 来使用聊天功能。 "
+"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿"
+"名对话，该功能支持 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
+"DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过"
+"访问 %1$shttps://duck.ai%2$s 来使用聊天功能。 "
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3856,7 +3940,9 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历史记录会删除已置顶的聊天记录。"
+msgstr ""
+"聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历"
+"史记录会删除已置顶的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3868,8 +3954,9 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
-"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
+"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
+"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删"
+"除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3891,7 +3978,9 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr "与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
+msgstr ""
+"与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审"
+"核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4250,7 +4339,9 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr "清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者在超过 7 天未使用 AI Chat 后自动将其删除。"
+msgstr ""
+"清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者"
+"在超过 7 天未使用 AI Chat 后自动将其删除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4259,7 +4350,9 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr "清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
+msgstr ""
+"清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近"
+"期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4276,8 +4369,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密人工智能聊天服务支持 OpenAI、Anthropic "
-"等聊天模型。"
+"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密"
+"人工智能聊天服务支持 OpenAI、Anthropic 等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4318,7 +4411,9 @@ msgstr "在弹出的菜单中点击 %1$s更改搜索设置%2$s"
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr "Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选项%4$s"
+msgstr ""
+"Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选"
+"项%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4348,7 +4443,9 @@ msgstr "在左侧的列表中点击 %1$s隐私和服务%2$s。"
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr "在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图标%4$s）"
+msgstr ""
+"在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图"
+"标%4$s）"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4438,7 +4535,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr "点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
+msgstr ""
+"点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻"
+"触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4448,7 +4547,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr "点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
+msgstr ""
+"点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设"
+"置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4516,7 +4617,9 @@ msgstr "点击搜索栏中的下拉菜单"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr "点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 %3$sDuckDuckGo%4$s。"
+msgstr ""
+"点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 "
+"%3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -5098,6 +5201,12 @@ msgid "Copy"
 msgstr "复制"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5137,6 +5246,28 @@ msgstr "复制或保存此代码"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "复制恢复代码"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5812,6 +5943,14 @@ msgid "Delete recent chats?"
 msgstr "删除最近的聊天记录？"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -5822,6 +5961,14 @@ msgstr "删除此聊天记录？"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "已删除聊天记录"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5934,7 +6081,8 @@ msgstr "暂时无法使用听写功能"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
+msgstr ""
+"听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6073,6 +6221,13 @@ msgstr "隐藏"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "隐藏"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6245,7 +6400,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr "不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 AI 生成的图像。 %3$s了解详情%4$s"
+msgstr ""
+"不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 "
+"AI 生成的图像。 %3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6254,8 +6411,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤掉 AI "
-"生成的图像。%3$s了解详情%4$s"
+"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤"
+"掉 AI 生成的图像。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6537,7 +6694,9 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr "Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非你选择在设置中自动附加页面。"
+msgstr ""
+"Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非"
+"你选择在设置中自动附加页面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6546,7 +6705,9 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr "Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程序再试一次。"
+msgstr ""
+"Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程"
+"序再试一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6569,7 +6730,9 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr "Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何希望重新掌控自己个人信息的人。"
+msgstr ""
+"Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何"
+"希望重新掌控自己个人信息的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6583,7 +6746,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页：https://duck.ai"
+msgstr ""
+"Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页："
+"https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6597,7 +6762,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
+msgstr ""
+"暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6617,7 +6784,9 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr "Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
+msgstr ""
+"Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链"
+"接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6628,9 +6797,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
-"DuckDuckGo Search 中的 Duck.ai 按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
-"%1$shttps://duck.ai%2$s 来使用 Duck.ai。"
+"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、"
+"Anthropic 等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 中的 Duck.ai 按钮"
+"和链接。不过，即使关闭该设置，仍然可以直接通过访问 %1$shttps://duck.ai%2$s 来"
+"使用 Duck.ai。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6691,8 +6861,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需注册的 AI "
-"聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 AI、无需账户的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需"
+"注册的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 "
+"AI、无需账户的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6720,10 +6891,10 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示频率：从不（从搜索结果中完全移除 "
-"DuckAssist "
-"用户界面)、按需（仅在点击“协助”按钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显示）。DuckAssist "
-"目前仅供美国（英语）地区使用。"
+"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示"
+"频率：从不（从搜索结果中完全移除 DuckAssist 用户界面)、按需（仅在点击“协助”按"
+"钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显"
+"示）。DuckAssist 目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6732,8 +6903,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI "
-"Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI Chat%2$s，这"
+"是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天"
+"模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6742,8 +6914,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持 "
-"OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这"
+"是一种人工智能驱动的私密聊天服务，支持 OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6755,10 +6927,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist "
-""
-"是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生成这些信息的摘要。 "
-"请注意，其回复目前基于维基百科和相关内容，其准确性未经核实。"
+"DuckAssist 是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该"
+"功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生"
+"成这些信息的摘要。 请注意，其回复目前基于维基百科和相关内容，其准确性未经核"
+"实。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6772,10 +6944,11 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist "
-""
-"是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。DuckAssist "
-"的回复始终直接链接到一个或两个资料来源，并注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
+"DuckAssist 是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，"
+"该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的"
+"相关信息生成简短的答案。DuckAssist 的回复始终直接链接到一个或两个资料来源，并"
+"注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资"
+"料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6798,7 +6971,9 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
+"和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6806,7 +6981,9 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
+"和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6822,7 +6999,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
+msgstr ""
+"暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 "
+"%1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6863,6 +7042,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo 浏览器 %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6978,14 +7164,18 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr "DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息来对这些报告进行匿名化。"
+msgstr ""
+"DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息"
+"来对这些报告进行匿名化。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 %2$s。"
+msgstr ""
+"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 "
+"%2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6993,7 +7183,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
+msgstr ""
+"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7001,7 +7192,9 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr "DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟踪程序，这些公司经常试图在其他网站上跟踪你。"
+msgstr ""
+"DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟"
+"踪程序，这些公司经常试图在其他网站上跟踪你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7013,8 +7206,9 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo "
-"的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
+"DuckDuckGo 的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时"
+"会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名"
+"性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7033,7 +7227,8 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr "DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
+msgstr ""
+"DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7125,8 +7320,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 "
-"个字符。"
+"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，"
+"并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 个字符。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7375,7 +7570,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置信息。"
+msgstr ""
+"启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置"
+"信息。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7561,7 +7758,8 @@ msgstr "输入文本"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
+msgstr ""
+"输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7664,10 +7862,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "为真正关心隐私的人精心打造的产品。"
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "已过期"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7937,7 +8150,9 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问题。"
+msgstr ""
+"类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问"
+"题。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8402,8 +8617,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; “<strong>Check for "
-"Updates...</strong>”（查看更新……），然后选择“<strong>Install Update</strong>”（安装更新）。"
+"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; "
+"“<strong>Check for Updates...</strong>”（查看更新……），然后选"
+"择“<strong>Install Update</strong>”（安装更新）。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8689,8 +8905,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"获取 DuckDuckGo VPN、高级 Duck.ai、Personal Information Removal 以及 Identity Theft "
-"Restoration 服务。"
+"获取 DuckDuckGo VPN、高级 Duck.ai、Personal Information Removal 以及 "
+"Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -8776,8 +8992,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"获取快速的无日志 VPN、可选高级人工智能聊天、Personal Information Removal 以及 Identity Theft "
-"Restoration 服务。"
+"获取快速的无日志 VPN、可选高级人工智能聊天、Personal Information Removal 以"
+"及 Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -8785,7 +9001,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr "获取快速的无日志 VPN、可选高级人工智能聊天以及 Identity Theft Restoration 服务。"
+msgstr ""
+"获取快速的无日志 VPN、可选高级人工智能聊天以及 Identity Theft Restoration 服"
+"务。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -8793,7 +9011,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和其他高级隐私保护功能。"
+msgstr ""
+"订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和"
+"其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8803,7 +9023,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和其他高级隐私保护功能。"
+msgstr ""
+"通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和"
+"其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8846,7 +9068,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr "获取我们快速的无日志 VPN、可选高级人工智能模型（具备更高的聊天限额）以及更多高级保护功能。"
+msgstr ""
+"获取我们快速的无日志 VPN、可选高级人工智能模型（具备更高的聊天限额）以及更多"
+"高级保护功能。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -8855,15 +9079,16 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"获取我们安全的无日志 VPN、高级 Duck.ai、Personal Information Removal 以及 Identity Theft "
-"Restoration 服务。"
+"获取我们安全的无日志 VPN、高级 Duck.ai、Personal Information Removal 以及 "
+"Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "获取我们安全的无日志 VPN，高级 Duck.ai 以及 Identity Theft Restoration 服务。"
+msgstr ""
+"获取我们安全的无日志 VPN，高级 Duck.ai 以及 Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -8963,8 +9188,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊天 › Sync & Backup › "
-"与其他设备同步 › 复制文本二维码%4$s"
+"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊"
+"天 › Sync & Backup › 与其他设备同步 › 复制文本二维码%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8973,8 +9198,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
-"与其他设备同步%4$s"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
+"天 › Sync & Backup › 与其他设备同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8984,8 +9209,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊天 › Sync & Backup › "
-"与其他设备同步%4$s并扫描此二维码："
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊"
+"天 › Sync & Backup › 与其他设备同步%4$s并扫描此二维码："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8995,8 +9220,16 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
-"与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
+"天 › Sync & Backup › 与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9018,7 +9251,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr "转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 %3$sDuckDuckGo%4$s。"
+msgstr ""
+"转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 "
+"%3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9103,6 +9338,12 @@ msgstr "明白了"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "明白了"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9726,7 +9967,9 @@ msgstr "历史"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr "按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s设为默认搜索引擎%6$s"
+msgstr ""
+"按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s"
+"设为默认搜索引擎%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9739,7 +9982,9 @@ msgstr "白苗语"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr "稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保护。"
+msgstr ""
+"稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保"
+"护。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10084,7 +10329,9 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr "如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与隐私”%2$s。"
+msgstr ""
+"如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与"
+"隐私”%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10094,8 +10341,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站设置” > “位置”%2$s，并确认已允许 "
-"DuckDuckGo 使用定位信息。"
+"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站"
+"设置” > “位置”%2$s，并确认已允许 DuckDuckGo 使用定位信息。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10109,7 +10356,8 @@ msgstr "如果你继续看到此错误，请联系 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
+msgstr ""
+"如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10117,7 +10365,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr "如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 %2$s 支持页面。"
+msgstr ""
+"如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 "
+"%2$s 支持页面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10125,7 +10375,9 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码以文本文件的形式保存到设备中。"
+msgstr ""
+"如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码"
+"以文本文件的形式保存到设备中。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -10140,7 +10392,9 @@ msgstr "如果你仍愿支持我们，可%1$s协助推广 DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版本。"
+msgstr ""
+"如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版"
+"本。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10287,7 +10541,9 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr "如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄露搜索内容。%1$s了解详情%2$s。"
+msgstr ""
+"如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄"
+"露搜索内容。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10297,7 +10553,8 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
+msgstr ""
+"在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10311,7 +10568,9 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr "本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具体都存了什么。"
+msgstr ""
+"本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具"
+"体都存了什么。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10716,8 +10975,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向商户页面，与广告不同，DuckDuckGo "
-"不会通过这些搜索结果获得收益。"
+"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向"
+"商户页面，与广告不同，DuckDuckGo 不会通过这些搜索结果获得收益。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11029,6 +11288,12 @@ msgstr "详细了解%1$s%2$s"
 msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "详细了解%1$s%2$s"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11660,6 +11925,13 @@ msgid "Manage"
 msgstr "管理"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -11909,6 +12181,12 @@ msgstr "菜单"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "菜单"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12277,6 +12555,12 @@ msgid "More about Duck.ai"
 msgstr "关于 Duck.ai 的更多信息"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "详见"
@@ -12469,6 +12753,12 @@ msgstr "静音"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "暗红色"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -12710,8 +13000,9 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
-"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
+"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互"
+"联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和"
+"回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13532,7 +13823,33 @@ msgstr "按需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设置%5$s"
+msgstr ""
+"Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设"
+"置%5$s"
+
+# smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13921,7 +14238,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简单。"
+msgstr ""
+"即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简"
+"单。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13934,7 +14253,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr "我们快速的无日志 VPN 附带更智能、限额更高的人工智能聊天功能，以及更多高级保护功能。一站式订阅服务。"
+msgstr ""
+"我们快速的无日志 VPN 附带更智能、限额更高的人工智能聊天功能，以及更多高级保护"
+"功能。一站式订阅服务。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -13948,7 +14269,9 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr "我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。现已支持 %1$siOS 和 Android%2$s。"
+msgstr ""
+"我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。"
+"现已支持 %1$siOS 和 Android%2$s。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14200,7 +14523,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口令。"
+msgstr ""
+"我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口"
+"令。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14267,6 +14592,12 @@ msgid "Past year"
 msgstr "一年内"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14277,6 +14608,12 @@ msgstr "粘贴"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "粘贴同步二维码"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14330,6 +14667,20 @@ msgstr "已永久关闭"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "波斯语"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14399,7 +14750,9 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr "以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
+msgstr ""
+"以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获"
+"得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14408,8 +14761,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答案。 如需调整此功能的工作方式或将其关闭，请访问 "
-"%1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答"
+"案。 如需调整此功能的工作方式或将其关闭，请访问 %1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14419,8 +14772,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答案。若要将其关闭并隐藏“协助”按钮，请访问 "
-"%1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答"
+"案。若要将其关闭并隐藏“协助”按钮，请访问 %1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14460,7 +14813,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr "选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
+msgstr ""
+"选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14616,7 +14970,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr "请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害或非法。"
+msgstr ""
+"请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害"
+"或非法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14624,7 +14980,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法或有害。"
+msgstr ""
+"请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法"
+"或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15561,6 +15919,12 @@ msgid "Reading website…"
 msgstr "正在读取网站……"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -15655,7 +16019,8 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr ""
+"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15663,7 +16028,8 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr ""
+"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15672,7 +16038,9 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr "最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
+msgstr ""
+"最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
+"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15741,6 +16109,12 @@ msgstr "恢复"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "恢复代码"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -15947,7 +16321,9 @@ msgstr "重新加载 Duck.ai"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr "请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重新加载）按钮。"
+msgstr ""
+"请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重"
+"新加载）按钮。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15988,6 +16364,12 @@ msgstr "移除 %1$s"
 msgctxt "Accessible label for remove button on attached file"
 msgid "Remove %s"
 msgstr "移除 %1$s"
+
+# smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16032,18 +16414,34 @@ msgid "Remove unnecessary punctuation"
 msgstr "删除不必要的标点符号"
 
 # smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr "移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
+msgstr ""
+"移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的"
+"答案。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr "移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
+msgstr ""
+"移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示"
+"缓存的答案。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16100,14 +16498,18 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr "你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提供给 %1$s，以便共同提高服务质量。"
+msgstr ""
+"你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提"
+"供给 %1$s，以便共同提高服务质量。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信息。"
+msgstr ""
+"发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信"
+"息。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16115,7 +16517,9 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr "发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
+msgstr ""
+"发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是"
+"匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16206,7 +16610,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助的答案受我们的%1$s服务条款%2$s约束。"
+msgstr ""
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助"
+"的答案受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16214,7 +16620,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受我们的%1$s服务条款%2$s约束。"
+msgstr ""
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受"
+"我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16224,8 +16632,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内容生成，可能包含不准确的信息。Search Assist "
-"受我们的%1$s服务条款%2$s约束。"
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内"
+"容生成，可能包含不准确的信息。Search Assist 受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16649,7 +17057,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记录。"
+msgstr ""
+"在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记"
+"录。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16693,6 +17103,12 @@ msgstr "将设置匿名同步到云端"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "向 Duck.ai 打个招呼"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -16809,7 +17225,9 @@ msgstr "向下滚动并点击 %1$s查看高级设置%2$s。"
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr "向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s添加搜索引擎%6$s）"
+msgstr ""
+"向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s"
+"添加搜索引擎%6$s）"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16817,7 +17235,9 @@ msgstr "向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr "向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 %5$s添加搜索引擎%6$s）。"
+msgstr ""
+"向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 "
+"%5$s添加搜索引擎%6$s）。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16895,10 +17315,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist "
-""
-"匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显示）。Search "
-"Assist 目前仅供部分英语地区使用。"
+"Search Assist 匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，"
+"然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点"
+"击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显"
+"示）。Search Assist 目前仅供部分英语地区使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16914,8 +17334,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist "
-"是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
+"Search Assist 是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s"
+"扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17035,7 +17455,8 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr "使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
+msgstr ""
+"使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17053,7 +17474,9 @@ msgstr "匿名搜索并屏蔽跟踪程序"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr "通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 %1$sduckduckgo.com%2$s 发起搜索。"
+msgstr ""
+"通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 "
+"%1$sduckduckgo.com%2$s 发起搜索。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17072,8 +17495,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud Save "
-"将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，且你的口令仅限在你的浏览器中使用。"
+"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud "
+"Save 将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，"
+"且你的口令仅限在你的浏览器中使用。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17175,7 +17599,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
+msgstr ""
+"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
+"访问。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17183,7 +17609,9 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
+msgstr ""
+"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
+"访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17191,7 +17619,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同步的设备访问。"
+msgstr ""
+"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同"
+"步的设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17199,7 +17629,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相关内容。"
+msgstr ""
+"利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相"
+"关内容。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17213,7 +17645,9 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看到你的数据，甚至我们也不行。"
+msgstr ""
+"采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看"
+"到你的数据，甚至我们也不行。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -17427,14 +17861,16 @@ msgstr "在弹出的菜单中点击 %1$s管理加载项%2$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
+msgstr ""
+"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
+msgstr ""
+"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17619,7 +18055,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后的所有对话。"
+msgstr ""
+"向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后"
+"的所有对话。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17640,6 +18078,13 @@ msgstr "塞尔维亚语（西里尔字母）"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "塞尔维亚语（拉丁字母）"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -17792,6 +18237,14 @@ msgid "Share"
 msgstr "分享"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -17832,7 +18285,9 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr "与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智能模型透露你的精确位置。"
+msgstr ""
+"与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智"
+"能模型透露你的精确位置。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -17927,7 +18382,8 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr "将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
+msgstr ""
+"将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17936,12 +18392,26 @@ msgid "Share your thoughts on the search box."
 msgstr "在搜索框中分享你的看法。"
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr "使用我们快速的无日志 VPN 来保护你的在线活动。易于设置，并且可以随时轻松开启或关闭。"
+msgstr ""
+"使用我们快速的无日志 VPN 来保护你的在线活动。易于设置，并且可以随时轻松开启或"
+"关闭。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18298,14 +18768,18 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr "提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不会影响搜索隐私。"
+msgstr ""
+"提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不"
+"会影响搜索隐私。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不会影响搜索保护。"
+msgstr ""
+"提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不"
+"会影响搜索保护。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18597,6 +19071,12 @@ msgstr "其他内容"
 msgctxt "duckai_migration"
 msgid "Something went wrong"
 msgstr "出了点问题"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19429,6 +19909,12 @@ msgid "Switch model"
 msgstr "切换模型"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -19608,7 +20094,8 @@ msgid ""
 msgstr ""
 "同步恢复代码\n"
 "\n"
-"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无法访问某个设备时恢复已同步的数据。\n"
+"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无"
+"法访问某个设备时恢复已同步的数据。\n"
 "\n"
 "请妥善保管此信息。\n"
 "任何可访问此代码的人都可以访问你的同步数据。\n"
@@ -19620,7 +20107,8 @@ msgstr ""
 "2. 选择“开启 Sync & Backup”，然后选择“恢复同步数据”\n"
 " 3. 复制上方的恢复代码，并将其粘贴到“在此处粘贴代码”处\n"
 "\n"
-"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据将从服务器中删除且无法恢复。"
+"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据"
+"将从服务器中删除且无法恢复。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19677,6 +20165,13 @@ msgid "Synced Devices"
 msgstr "已同步设备"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "叙利亚"
 
@@ -19709,6 +20204,12 @@ msgid "TV"
 msgstr "电视"
 
 # smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Tahitian language
 msgctxt "language_name"
 msgid "Tahitian"
@@ -19739,7 +20240,9 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr "随时随地使用 Duck.ai。下载内置此功能的免费应用——无论你身在何处，都能快速调用。"
+msgstr ""
+"随时随地使用 Duck.ai。下载内置此功能的免费应用——无论你身在何处，都能快速调"
+"用。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -19747,7 +20250,9 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr "随时随地使用 Duck.ai。将其内置于我们的免费浏览器中——无论你何时浏览网页，都能快速调用。"
+msgstr ""
+"随时随地使用 Duck.ai。将其内置于我们的免费浏览器中——无论你何时浏览网页，都能"
+"快速调用。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19990,7 +20495,9 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr "这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银行账号。"
+msgstr ""
+"这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银"
+"行账号。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20106,7 +20613,8 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
+msgstr ""
+"在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20138,7 +20646,9 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr "所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设为默认搜索引擎，从而保护你的隐私。"
+msgstr ""
+"所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设"
+"为默认搜索引擎，从而保护你的隐私。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20221,7 +20731,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr "此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+msgstr ""
+"此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不"
+"准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20230,7 +20742,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr "此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%2$s）。"
+msgstr ""
+"此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或"
+"令人反感的信息（详情请参阅%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20238,7 +20752,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr "这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感的信息。（详情请参见 %2$s）。"
+msgstr ""
+"这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感"
+"的信息。（详情请参见 %2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20248,8 +20764,24 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s "
-"模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可"
+"能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20335,12 +20867,20 @@ msgid "This information isn’t useful"
 msgstr "这些信息没有用"
 
 # smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr "这只是一个示例聊天记录。打开其菜单（三个点），然后选择“置顶”，将其置于聊天记录顶部！"
+msgstr ""
+"这只是一个示例聊天记录。打开其菜单（三个点），然后选择“置顶”，将其置于聊天记"
+"录顶部！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20368,7 +20908,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据保留模式。"
+msgstr ""
+"该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据"
+"保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20376,7 +20918,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据保留模式。"
+msgstr ""
+"该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据"
+"保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20412,7 +20956,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，之后可以通过任何浏览器访问这些记录。"
+msgstr ""
+"这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，"
+"之后可以通过任何浏览器访问这些记录。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20420,7 +20966,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI 辅助的答案。"
+msgstr ""
+"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
+"么你可能会再次看到 AI 辅助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20430,8 +20978,21 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI "
-"辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显示 AI 辅助答案。"
+"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
+"么你可能会再次看到 AI 辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显"
+"示 AI 辅助答案。"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20470,8 +21031,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你仍然可以在连接到 Sync & Backup "
-"的其他浏览器中浏览你的聊天记录。"
+"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你"
+"仍然可以在连接到 Sync & Backup 的其他浏览器中浏览你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20616,7 +21177,8 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
+msgstr ""
+"打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20625,7 +21187,9 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr "需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格式保存到最初用于设置同步的设备上。"
+msgstr ""
+"需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格"
+"式保存到最初用于设置同步的设备上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20633,7 +21197,9 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再试一次。"
+msgstr ""
+"如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再"
+"试一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20835,7 +21401,8 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr "此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
+msgstr ""
+"此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21052,6 +21619,12 @@ msgid "Try Free"
 msgstr "免费试用"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21163,6 +21736,12 @@ msgstr "免费试用"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "免费试用"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21355,7 +21934,9 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr "想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
+msgstr ""
+"想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设"
+"置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21363,7 +21944,9 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr "想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
+msgstr ""
+"想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的"
+"设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21402,6 +21985,12 @@ msgid "Turkmenistan"
 msgstr "土库曼斯坦"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -21412,6 +22001,12 @@ msgstr "关闭 Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "关闭 Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -21551,7 +22146,9 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间出现短暂的延迟。"
+msgstr ""
+"在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间"
+"出现短暂的延迟。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21680,14 +22277,16 @@ msgstr "了解优点和缺点"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr "在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
+msgstr ""
+"在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr "在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
+msgstr ""
+"在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21802,7 +22401,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍的使用限额。"
+msgstr ""
+"升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍"
+"的使用限额。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21877,6 +22478,12 @@ msgid "Unmute"
 msgstr "取消静音"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -21910,6 +22517,12 @@ msgstr "更新定位"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "更新浏览器"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22172,7 +22785,9 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr "私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公司的侵害。确保信息保密。免费。无需账户。"
+msgstr ""
+"私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公"
+"司的侵害。确保信息保密。免费。无需账户。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22390,7 +23005,8 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
+msgstr ""
+"DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22432,8 +23048,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & Backup%4$s > "
-"%5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
+"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22443,8 +23059,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup "
-"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup 栏下选择“开"
+"启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22454,8 +23070,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设置%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同步%8$s”。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设"
+"置%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同"
+"步%8$s”。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22465,8 +23082,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。在 Sync & Backup "
-"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。"
+"在 Sync & Backup 栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF "
+"中的二维码。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22661,7 +23279,9 @@ msgstr "在 Duck Player 中观看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr "在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 YouTube 推荐。"
+msgstr ""
+"在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 "
+"YouTube 推荐。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22681,8 +23301,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube "
-"没有任何关系。"
+"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。"
+"DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube 没有任何关系。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22705,7 +23325,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 DuckDuckGo，这样我们才能调查并处理这个问题。"
+msgstr ""
+"我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 "
+"DuckDuckGo，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22716,7 +23338,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回复，这样我们才能调查并处理这个问题。"
+msgstr ""
+"我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回"
+"复，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -22769,7 +23393,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
+msgstr ""
+"我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟"
+"踪："
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22777,7 +23403,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
+msgstr ""
+"我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们"
+"跟踪："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22836,6 +23464,14 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "由于长时间闲置，我们已结束聊天。想再试一次？"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
@@ -22873,7 +23509,16 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
+msgstr ""
+"匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22899,7 +23544,9 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr "你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更正可能需要一段时间。"
+msgstr ""
+"你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更"
+"正可能需要一段时间。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22907,12 +23554,21 @@ msgid "We'll block trackers trying to collect your data as you browse."
 msgstr "我们将屏蔽试图在你浏览时收集个人数据的跟踪程序。"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
 msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr "我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
+msgstr ""
+"我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22920,7 +23576,8 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr "我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
+msgstr ""
+"我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23063,7 +23720,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr "欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用"
+"于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23071,7 +23730,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr "欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处"
+"理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23081,8 +23742,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天内容均为私密，DuckDuckGo "
-"绝不会存储或用于训练 AI 模型。"
+"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天"
+"内容均为私密，DuckDuckGo 绝不会存储或用于训练 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23198,6 +23859,12 @@ msgid "What are some pros and cons of annuities?"
 msgstr "年金有哪些优点和缺点？"
 
 # smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
 msgctxt "User prompt seeded by Learn More CTA"
 msgid ""
@@ -23208,8 +23875,9 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官方 DuckDuckGo "
-"来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
+"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官"
+"方 DuckDuckGo 来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。"
+"保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23744,13 +24412,23 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr "使用 Duck.ai，你的聊天内容均已匿名处理，且绝不会用于训练 AI。 可以随时在“%1$s”菜单中开启或关闭。"
+msgstr ""
+"使用 Duck.ai，你的聊天内容均已匿名处理，且绝不会用于训练 AI。 可以随时"
+"在“%1$s”菜单中开启或关闭。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "不提供“对提供商不可见”保护"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24025,7 +24703,8 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr "可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
+msgstr ""
+"可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24069,7 +24748,8 @@ msgstr "您最多可以附加 %1$s 个文本选中内容。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
+msgstr ""
+"可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24232,12 +24912,21 @@ msgid "You have 1 attempt left."
 msgstr "你还可以再试 1 次。"
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限额。"
+msgstr ""
+"你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限"
+"额。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24245,7 +24934,9 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr "现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 DuckDuckGo 订阅保护功能。"
+msgstr ""
+"现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 "
+"DuckDuckGo 订阅保护功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24266,7 +24957,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr ""
+"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
+"存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24275,7 +24968,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr ""
+"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
+"存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24302,7 +24997,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr "现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装的 App 上网还能进一步保护隐私，它可以："
+msgstr ""
+"现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装"
+"的 App 上网还能进一步保护隐私，它可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24390,8 +25087,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 %1$s "
-"条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
+"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 "
+"%1$s 条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24401,8 +25098,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s "
-"条包含附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
+"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s 条包含"
+"附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24415,7 +25112,9 @@ msgstr "你已用尽存储空间"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr "Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 Google 与 YouTube 跟踪。"
+msgstr ""
+"Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 "
+"Google 与 YouTube 跟踪。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24427,6 +25126,23 @@ msgstr "YouTube 隐私警告"
 msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "YouTube 标准"
+
+# smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24452,13 +25168,23 @@ msgid "Your actual location remains private."
 msgstr "你的实际位置会保密。"
 
 # smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
 msgctxt "Body copy for the Delete Server Data confirmation modal"
 msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
+msgstr ""
+"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
+"览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24467,7 +25193,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 100 条聊天记录将保存在本地存储中："
+msgstr ""
+"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
+"览器中，你最近的 100 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24506,7 +25234,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
+msgstr ""
+"你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24531,14 +25260,16 @@ msgstr "你的聊天内容均为私密，绝不会用于训练人工智能模型
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24566,7 +25297,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr "聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请按照以下步骤保留聊天记录。"
+msgstr ""
+"聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请"
+"按照以下步骤保留聊天记录。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24605,7 +25338,9 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample message%3$s]"
+msgstr ""
+"我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample "
+"message%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24648,8 +25383,9 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 512 "
-"位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
+"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 "
+"512 位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密"
+"钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24663,7 +25399,9 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr "你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商无法将对话内容与你本人关联起来。"
+msgstr ""
+"你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商"
+"无法将对话内容与你本人关联起来。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24707,7 +25445,9 @@ msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
-msgstr "已保存你的设置，但清理浏览器 Cookie 会将其重置。启用 %1$sDuckDuckGo No AI%2$s 扩展插件，以便永久保存你的设置。"
+msgstr ""
+"已保存你的设置，但清理浏览器 Cookie 会将其重置。启用 %1$sDuckDuckGo No "
+"AI%2$s 扩展插件，以便永久保存你的设置。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -24716,8 +25456,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No AI%2$s "
-"扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
+"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No "
+"AI%2$s 扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -24736,7 +25476,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr "你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更多保护。已安装该浏览器并可以："
+msgstr ""
+"你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更"
+"多保护。已安装该浏览器并可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +48,7 @@ msgctxt ""
 "Title of the device detail sheet when it shows the device the person is "
 "using right now; %s is the device name"
 msgid "%s (This device)"
-msgstr ""
+msgstr "%1$s（此裝置）"
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -189,9 +189,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換"
-"至 Plus 或免費模式。"
+msgstr "%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -200,9 +198,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切"
-"換至 Plus 或免費模式。"
+msgstr "%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -217,9 +213,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或"
-"切換至免費模式。"
+msgstr "%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或切換至免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -324,8 +318,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s 運行於受信任執行環境（Trusted Execution Environment）。這表示即使是模型"
-"提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
+"%1$s 運行於受信任執行環境（Trusted Execution "
+"Environment）。這表示即使是模型提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -410,8 +404,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
+msgstr "%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -421,8 +414,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
+msgstr "%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -450,8 +442,7 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr ""
-"%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
+msgstr "%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -484,7 +475,7 @@ msgstr "%1$s瞭解我們如何保護你的位置隱私%2$s。"
 msgctxt ""
 "Learn more link at the end of the recovery section description inside Manage"
 msgid "%sLearn more%s"
-msgstr ""
+msgstr "%1$s瞭解更多%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -776,7 +767,7 @@ msgstr "%1$s組中第二"
 #. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
 msgctxt "Label, tooltip and aria-label for an action button"
 msgid "2nd opinion"
-msgstr ""
+msgstr "第二觀點"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
@@ -920,8 +911,7 @@ msgstr "客場戰績"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
+msgstr "網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -979,9 +969,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo "
-"Search 上的 AI Chat 功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/"
-"aichat%2$s 使用 AI Chat 功能。"
+"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo Search 上的 AI Chat "
+"功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/aichat%2$s 使用 AI Chat 功能。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1042,9 +1031,8 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck."
-"ai%2$s 以回答後續問題，這是我們的私密 AI 驅動的聊天服務，支援來自 OpenAI、"
-"Anthropic 等的聊天模型。"
+"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck.ai%2$s 以回答後續問題，這是我們的私密 AI "
+"驅動的聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1450,7 +1438,7 @@ msgstr "新增至主畫面"
 #. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
 msgctxt "Button in the footer of a shared-chat copy panel"
 msgid "Add to My Chats"
-msgstr ""
+msgstr "新增至我的聊天"
 
 # smartling.placeholder_format=C
 #. In the top menu under Goodies
@@ -1738,9 +1726,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
-"所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型"
-"供應商用於訓練聊天模型"
+msgstr "所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型供應商用於訓練聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1786,9 +1772,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會"
-"被移除。"
+msgstr "在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會被移除。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1813,7 +1797,7 @@ msgstr "所有類型"
 msgctxt ""
 "Body of the success screen shown after the server data has been deleted"
 msgid "All your devices are disconnected from Sync."
-msgstr ""
+msgstr "你的所有裝置都已與 Sync 中斷連線。"
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1858,8 +1842,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期"
-"限有限的搜尋引擎。%2$s 的提示和回應仍具有%3$s零提供者可見度%4$s。"
+"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期限有限的搜尋引擎。%2$s "
+"的提示和回應仍具有%3$s零提供者可見度%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2024,8 +2008,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
+msgstr "根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2198,9 +2181,7 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr ""
-"你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天"
-"記錄一併刪除。"
+msgstr "你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天記錄一併刪除。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2237,9 +2218,7 @@ msgstr "更新時間："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業"
-"皆於你的裝置上進行。"
+msgstr "根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業皆於你的裝置上進行。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2323,7 +2302,7 @@ msgstr "您可以私下詢問任何事情"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask anything privately"
-msgstr ""
+msgstr "您可以私下詢問任何事情"
 
 # smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
@@ -2381,10 +2360,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想"
-"要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 Assist 使用介面)、隨選 (僅在"
-"點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更"
-"頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
+"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 "
+"Assist 使用介面)、隨選 (僅在點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 "
+"(在更廣泛的搜尋中更頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2396,10 +2374,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI 協助的搜尋查詢答案。"
-"為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言"
-"技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並"
-"根據%1$s搜耙網路%2$s自動產生的。"
+"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI "
+"協助的搜尋查詢答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2424,9 +2400,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr ""
-"無論是在咖啡廳、機場還是飯店，DuckDuckGo VPN 都能加密你的網路連線，並在 Wi-"
-"Fi 上隱藏你的 IP 位址。"
+msgstr "無論是在咖啡廳、機場還是飯店，DuckDuckGo VPN 都能加密你的網路連線，並在 Wi-Fi 上隱藏你的 IP 位址。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2571,9 +2545,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜"
-"尋結果。目前，Assist 僅供英語地區使用。"
+msgstr "自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，Assist 僅供英語地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2582,8 +2554,8 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應"
-"某些搜尋結果。目前，DuckAssist 僅供說英文的地區使用。"
+"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，DuckAssist "
+"僅供說英文的地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2788,9 +2760,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
-"在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身"
-"份資訊，將你的對話匿名化。"
+msgstr "在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身份資訊，將你的對話匿名化。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2919,8 +2889,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr ""
-"封鎖有害網站、隱藏你的 IP 地址，訂閱我們的服務還能獲得更多高階保護功能。"
+msgstr "封鎖有害網站、隱藏你的 IP 地址，訂閱我們的服務還能獲得更多高階保護功能。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3179,26 +3148,20 @@ msgstr "瀏覽檔案"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組"
-"合為一項%1$s%2$s延伸模組%3$s。"
+msgstr "享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執"
-"行程式組合為一項%1$s%2$s延伸模組%3$s。"
+msgstr "你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽"
-"器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
+msgstr "你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3305,18 +3268,15 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使"
-"用匿名的 Could Save 以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別"
-"的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
+"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使用匿名的 Could Save "
+"以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始"
-"之前，請先查看我們的%1$s。"
+msgstr "啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3324,9 +3284,7 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開"
-"始之前，請先查看我們的%1$s。"
+msgstr "啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3810,10 +3768,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 "
-"OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo Search 上的聊天按鈕和連"
-"結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 直接使用聊天功"
-"能。"
+"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 "
+"DuckDuckGo Search 上的聊天按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s "
+"直接使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3943,9 +3900,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用"
-"聊天記錄將刪除置頂的聊天。"
+msgstr "聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用聊天記錄將刪除置頂的聊天。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3957,9 +3912,8 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 "
-"DuckDuckGo 伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置"
-"頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
+"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
+"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3981,9 +3935,7 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr ""
-"與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴"
-"供應商匿名審核，以用於 %2$s。"
+msgstr "與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴供應商匿名審核，以用於 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4342,9 +4294,7 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr ""
-"清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近"
-"的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
+msgstr "清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4354,8 +4304,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期"
-"保存，或在不使用 Duck.ai 的情況下 7 天後自動刪除，視您的瀏覽器而定。"
+"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期保存，或在不使用 Duck.ai 的情況下 7 "
+"天後自動刪除，視您的瀏覽器而定。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4372,8 +4322,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私"
-"人 AI 聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
+"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私人 AI 聊天服務，支援來自 "
+"OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4534,9 +4484,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏"
-"覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
+msgstr "按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4546,9 +4494,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的"
-"瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
+msgstr "按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4823,8 +4769,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
+msgstr "Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5202,7 +5147,7 @@ msgstr "複製"
 #. Shorter label for the copy button under the QR, used when it sits next to a Share button.
 msgctxt "Short button label that copies the sync code text to clipboard"
 msgid "Copy"
-msgstr ""
+msgstr "複製"
 
 # smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
@@ -5251,13 +5196,13 @@ msgctxt ""
 "Tooltip and accessible name for the copy button on a row of the Duck.ai "
 "shared links modal"
 msgid "Copy shared link"
-msgstr ""
+msgstr "複製分享連結"
 
 # smartling.placeholder_format=C
 #. Tells the user to copy the pairing code on their other device.
 msgctxt "First numbered step heading on the Enter Code tab"
 msgid "Copy the code from another device"
-msgstr ""
+msgstr "從另一裝置複製代碼"
 
 # smartling.placeholder_format=C
 #. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
@@ -5265,7 +5210,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
-msgstr ""
+msgstr "從其他裝置複製代碼。前往 %1$s Duck.ai 設定 › 聊天 › Sync & Backup › 與其他裝置同步%2$s，然後再試一次。"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5946,7 +5891,7 @@ msgctxt ""
 "Tooltip and accessible name for the delete button on a row of the Duck.ai "
 "shared links modal"
 msgid "Delete shared link"
-msgstr ""
+msgstr "刪除分享連結"
 
 # smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
@@ -5966,7 +5911,7 @@ msgctxt "Description at the top of the Duck.ai shared links modal"
 msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
-msgstr ""
+msgstr "刪除連結會導致連結失效。已經開啟連結並將對話加入聊天的人會保留自己的副本。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6079,9 +6024,7 @@ msgstr "聽寫功能暫時無法使用"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 "
-"Duck.ai 中聊天。"
+msgstr "語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6226,7 +6169,7 @@ msgstr "隱藏"
 msgctxt ""
 "Accessibility label for the shared-chat introduction promo close button"
 msgid "Dismiss"
-msgstr ""
+msgstr "隱藏"
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6399,9 +6342,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
-"不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖"
-"片。 %3$s瞭解更多%4$s"
+msgstr "不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖片。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6409,9 +6350,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr ""
-"不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖"
-"片的搜尋。%3$s瞭解更多%4$s"
+msgstr "不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖片的搜尋。%3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6693,9 +6632,7 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr ""
-"Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包"
-"含，除非你在設定中選擇自動附加頁面。"
+msgstr "Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包含，除非你在設定中選擇自動附加頁面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6704,9 +6641,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任"
-"何擴充套件，然後再試一次。"
+msgstr "Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任何擴充套件，然後再試一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6729,9 +6664,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重"
-"新掌控個人資訊的人。"
+msgstr "Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重新掌控個人資訊的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6745,9 +6678,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁："
-"https://duck.ai"
+msgstr "Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁：https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6761,8 +6692,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
+msgstr "Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6783,8 +6713,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，"
-"但你仍然可以造訪 %1$sduck.ai%2$s 直接使用。"
+"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，但你仍然可以造訪 %1$sduck.ai%2$s "
+"直接使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6795,9 +6725,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。"
-"關閉此設定將隱藏 DuckDuckGo Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定"
-"後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 Duck.ai使用聊天功能。"
+"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo "
+"Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 "
+"Duck.ai使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6858,9 +6788,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需"
-"註冊的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點"
-"的 AI、無需帳號的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需註冊的 AI "
+"聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點的 AI、無需帳號的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6888,10 +6817,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 "
-"DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 DuckAssist UI)、隨選 (僅在"
-"點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁"
-"地顯示)。目前 DuckAssist 僅供美國 (英文) 地區使用。"
+"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 "
+"DuckAssist UI)、隨選 (僅在點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁地顯示)。目前 "
+"DuckAssist 僅供美國 (英文) 地區使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6900,8 +6828,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這"
-"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 等聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
+"OpenAI 和 Anthropic 等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6910,8 +6838,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這"
-"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
+"OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6923,10 +6851,8 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了"
-"完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 AI 驅動的自"
-"然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，"
-"尚未確認準確性。"
+"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 "
+"AI 驅動的自然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，尚未確認準確性。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6940,11 +6866,10 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完"
-"成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，"
-"根據找到的相關資訊產生簡短的答案。DuckAssist 的回應始終直接連結至一個或兩個來"
-"源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是"
-"從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
+"DuckAssist "
+""
+"是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。DuckAssist "
+"的回應始終直接連結至一個或兩個來源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6967,9 +6892,7 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
-"%3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6977,9 +6900,7 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
-"%3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6995,9 +6916,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件"
-"傳送至%2$s"
+msgstr "DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7044,7 +6963,7 @@ msgstr "DuckDuckGo 瀏覽器 %1$s"
 msgctxt ""
 "Attribution shown in place of the model name in a Duck.ai assistant message"
 msgid "DuckDuckGo Help Pages"
-msgstr ""
+msgstr "DuckDuckGo 說明頁面"
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -7160,17 +7079,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資"
-"訊來匿名化這些報告。"
+msgstr "DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資訊來匿名化這些報告。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
+msgstr "DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7186,9 +7102,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤"
-"器，它們經常試圖在你造訪其他網站時追蹤你。"
+msgstr "DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤器，它們經常試圖在你造訪其他網站時追蹤你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7199,11 +7113,7 @@ msgid ""
 "use it to improve results for that search, and then we promptly throw it "
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
-msgstr ""
-"DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置"
-"上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我"
-"們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保"
-"護你的隱私%2$s。"
+msgstr "DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保護你的隱私%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7222,9 +7132,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更"
-"接近你的搜尋結果。%1$s瞭解更多%2$s。"
+msgstr "DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更接近你的搜尋結果。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7315,10 +7223,7 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr ""
-"當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我"
-"們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18"
-"至20個字元。"
+msgstr "當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18至20個字元。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7567,9 +7472,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保"
-"密。"
+msgstr "啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保密。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7730,9 +7633,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關"
-"密語下。"
+msgstr "輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關密語下。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7757,8 +7658,7 @@ msgstr "輸入文字"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
+msgstr "輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7865,7 +7765,7 @@ msgstr "專為重視隱私的人精心打造的產品。"
 msgctxt ""
 "Status shown in place of the expiry date once a shared link has lapsed"
 msgid "Expired"
-msgstr ""
+msgstr "已過期"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7879,7 +7779,7 @@ msgctxt ""
 "Expiry line under a link title in the Duck.ai shared links modal; %s is a "
 "localized date"
 msgid "Expires %s"
-msgstr ""
+msgstr "%1$s 到期"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -8149,9 +8049,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的"
-"問題。"
+msgstr "像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的問題。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8388,8 +8286,7 @@ msgstr "多霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
+msgstr "按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8617,8 +8514,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> &gt;"
-"<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
+"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> "
+"&gt;<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8990,9 +8887,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
-msgstr ""
-"取得快速、無紀錄的 VPN、選配的進階 AI 對話、個人資訊移除，以及 Identity "
-"Theft Restoration 服務。"
+msgstr "取得快速、無紀錄的 VPN、選配的進階 AI 對話、個人資訊移除，以及 Identity Theft Restoration 服務。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9000,8 +8895,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr ""
-"取得快速、無紀錄的 VPN、選配的進階 AI 對話，以及 Identity Theft Restoration。"
+msgstr "取得快速、無紀錄的 VPN、選配的進階 AI 對話，以及 Identity Theft Restoration。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9009,9 +8903,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
-"隱私權保護。"
+msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9021,9 +8913,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
-"隱私權保護。"
+msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9066,9 +8956,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr ""
-"取得我們快速、不記錄活動的 VPN、可選擇存取具有更高聊天限制的進階 AI 模型，以"
-"及更多高級防護。"
+msgstr "取得我們快速、不記錄活動的 VPN、可選擇存取具有更高聊天限制的進階 AI 模型，以及更多高級防護。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9077,16 +8965,15 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"取得我們安全的無紀錄 VPN、先進的 Duck.ai，Personal Information Removal，以及 "
-"Identity Theft Restoration。"
+"取得我們安全的無紀錄 VPN、先進的 Duck.ai，Personal Information Removal，以及 Identity Theft "
+"Restoration。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"取得我們安全、無日誌的 VPN、先進的 Duck.ai 以及 Identity Theft Restoration。"
+msgstr "取得我們安全、無日誌的 VPN、先進的 Duck.ai 以及 Identity Theft Restoration。"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9186,8 +9073,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 "
-"%3$s聊天記錄 › Sync & Backup › 與另一裝置同步 › 複製文字代碼%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 %3$s聊天記錄 › Sync & Backup "
+"› 與另一裝置同步 › 複製文字代碼%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9196,8 +9083,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s"
-"聊天記錄 › Sync & Backup › 與另一裝置同步%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s聊天記錄 › Sync & Backup "
+"› 與另一裝置同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9207,8 +9094,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊"
-"天 › Sync & Backup › 與其他裝置同步%4$s，然後掃描此代碼："
+"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊天 › Sync & Backup › "
+"與其他裝置同步%4$s，然後掃描此代碼："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9218,8 +9105,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s"
-"聊天 › Sync & Backup › 與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s聊天 › Sync & Backup › "
+"與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9227,7 +9114,7 @@ msgctxt "Detail under the first numbered step on the Enter Code tab"
 msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
-msgstr ""
+msgstr "前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9241,8 +9128,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr ""
-"前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
+msgstr "前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9250,8 +9136,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
+msgstr "前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9341,7 +9226,7 @@ msgstr "瞭解了"
 #. The user taps this to close the screen after their server data has been deleted.
 msgctxt "Button that dismisses the server-data-deleted success screen"
 msgid "Got It"
-msgstr ""
+msgstr "確認"
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9965,9 +9850,7 @@ msgstr "最近活動"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr ""
-"在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定"
-"為預設%6$s"
+msgstr "在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定為預設%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10325,9 +10208,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與"
-"隱私」%2$s。"
+msgstr "如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與隱私」%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10337,8 +10218,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > "
-"網站設定 > 位置%2$s，確認DuckDuckGo是被允許的存取位置。"
+"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > 網站設定 > "
+"位置%2$s，確認DuckDuckGo是被允許的存取位置。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10352,8 +10233,7 @@ msgstr "如果你繼續看到此錯誤，請聯絡 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
+msgstr "如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10361,9 +10241,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 "
-"%2$s 支援頁面。"
+msgstr "若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 %2$s 支援頁面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10371,9 +10249,7 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢"
-"復碼儲存成文字檔，儲存至您的裝置。"
+msgstr "如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢復碼儲存成文字檔，儲存至您的裝置。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -10535,9 +10411,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避"
-"免搜尋記錄外洩。%1$s瞭解更多%2$s。"
+msgstr "若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避免搜尋記錄外洩。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10547,9 +10421,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同"
-"步」。"
+msgstr "在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同步」。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10968,9 +10840,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad Network播送。點擊後"
-"會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收"
-"到任何報酬。"
+"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad "
+"Network播送。點擊後會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收到任何報酬。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10978,9 +10849,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安"
-"全。"
+msgstr "比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安全。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11289,7 +11158,7 @@ msgstr "瞭解%1$s更多%2$s"
 #. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
 msgctxt "Button in the eclipse logo modal (mobile)"
 msgid "Learn More"
-msgstr ""
+msgstr "瞭解更多"
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11925,7 +11794,7 @@ msgstr "管理"
 msgctxt ""
 "Button on the Shared Links settings row that opens the shared links modal"
 msgid "Manage"
-msgstr ""
+msgstr "管理"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
@@ -12182,7 +12051,7 @@ msgstr "選單"
 #. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
 msgctxt "Divider under the shared-copy panel"
 msgid "Messages beyond this point are only visible to you."
-msgstr ""
+msgstr "在此之後的訊息僅你可見。"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12554,7 +12423,7 @@ msgstr "更多關於 Duck.ai 的資訊"
 #. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
 msgctxt "Accessible label for a menu button on a chat response"
 msgid "More actions"
-msgstr ""
+msgstr "更多操作"
 
 # smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
@@ -12754,7 +12623,7 @@ msgstr "暗紅"
 #. Label preceding the list of devices currently registered to the account.
 msgctxt "Section header for the device list inside Manage Sync & Backup"
 msgid "My Devices"
-msgstr ""
+msgstr "我的裝置"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -12996,9 +12865,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你失去"
-"網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應"
-"的暫時儲存功能。"
+"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
+"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13819,9 +13687,7 @@ msgstr "隨需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設"
-"定%5$s"
+msgstr "在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設定%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -13829,7 +13695,7 @@ msgctxt "Instruction under the Scan QR tab sub-heading"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
-msgstr ""
+msgstr "在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -13837,7 +13703,7 @@ msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
-msgstr ""
+msgstr "在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s，然後掃描此代碼："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -13846,6 +13712,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
+"在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s。或掃描你復原 "
+"PDF 上的 QR 碼。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13872,8 +13740,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
+msgstr "附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14235,8 +14102,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
+msgstr "即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14249,9 +14115,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr ""
-"我們快速、不記錄日誌的 VPN 提供更聰明且限制更高的 AI 聊天功能，以及更多頂級保"
-"護。一站式訂閱。"
+msgstr "我們快速、不記錄日誌的 VPN 提供更聰明且限制更高的 AI 聊天功能，以及更多頂級保護。一站式訂閱。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14265,9 +14129,7 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功"
-"能。提供%1$siOS及Android%2$s版本。"
+msgstr "我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功能。提供%1$siOS及Android%2$s版本。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14519,9 +14381,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找"
-"回通關密語。"
+msgstr "我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找回通關密語。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14591,7 +14451,7 @@ msgstr "過去一年"
 #. Label for the paste button docked in the code field on the Enter Code tab.
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste"
-msgstr ""
+msgstr "貼上"
 
 # smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
@@ -14609,7 +14469,7 @@ msgstr "貼上同步代碼"
 #. Tells the user to paste the copied code into the field below.
 msgctxt "Second numbered step heading on the Enter Code tab"
 msgid "Paste it below"
-msgstr ""
+msgstr "貼在下方"
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14668,7 +14528,7 @@ msgstr "波斯語"
 #. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Personal Information Removal"
-msgstr ""
+msgstr "Personal Information Removal"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
@@ -14676,7 +14536,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
-msgstr ""
+msgstr "Personal Information Removal 會在販售你資訊的資料仲介網站上找出你的資訊。接下來，我們會努力為你將該資訊移除。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14747,8 +14607,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常"
-"能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 %1$s搜尋設定%2$s。"
+"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 "
+"%1$s搜尋設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14757,9 +14617,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
-"顯示並且通常能得出更好的答案。 欲調整此功能的運作方式或將其關閉，請造訪 "
-"%1$sDuckAssist 設定%2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能顯示並且通常能得出更好的答案。 "
+"欲調整此功能的運作方式或將其關閉，請造訪 %1$sDuckAssist 設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14769,9 +14628,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
-"自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s "
-"DuckAssist 設定 %2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist "
+"更可能自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s DuckAssist 設定 %2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14803,8 +14661,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
+msgstr "選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14820,8 +14677,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
+msgstr "選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14969,9 +14825,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非"
-"法。"
+msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14979,9 +14833,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有"
-"害。"
+msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15921,7 +15773,7 @@ msgstr "正在讀取網站…"
 #. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
 msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
 msgid "Ready for the solar eclipse?"
-msgstr ""
+msgstr "準備好迎接日食了嗎？"
 
 # smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
@@ -16018,9 +15870,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
-"中。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16028,9 +15878,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
-"中。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16039,9 +15887,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲"
-"存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16115,7 +15961,7 @@ msgstr "恢復碼"
 #. Label preceding the recovery code description and Download Recovery Code link.
 msgctxt "Section header for the recovery code area inside Manage"
 msgid "Recovery Code"
-msgstr ""
+msgstr "恢復碼"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -16322,8 +16168,7 @@ msgstr "重新載入 Duck.ai。"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
+msgstr "按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16369,7 +16214,7 @@ msgstr "移除 %1$s"
 #. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
 msgctxt "Button that starts removing one of the other devices from syncing"
 msgid "Remove Device"
-msgstr ""
+msgstr "移除裝置"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
@@ -16417,13 +16262,13 @@ msgstr "移除不必要的標點符號"
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info from the internet"
-msgstr ""
+msgstr "從網際網路上移除你的個人資訊"
 
 # smartling.placeholder_format=C
 #. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Remove your info online"
-msgstr ""
+msgstr "線上移除你的個人資訊"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16494,18 +16339,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享"
-"給%1$s來協助改善其服務。"
+msgstr "報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享給%1$s來協助改善其服務。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別"
-"身分的資訊。"
+msgstr "傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16513,9 +16354,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿"
-"名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
+msgstr "傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16606,9 +16445,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回"
-"答受我們的 %1$s 服務條款%2$s約束。"
+msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回答受我們的 %1$s 服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16616,9 +16453,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist "
-"受我們的%1$s服務條款%2$s約束。"
+msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist 受我們的%1$s服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16628,8 +16463,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁"
-"內容生成，可能會有不準確之處。Search Assist 受我們的 %1$s服務條款%2$s 約束。"
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁內容生成，可能會有不準確之處。Search Assist 受我們的 "
+"%1$s服務條款%2$s 約束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17053,9 +16888,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更"
-"多內容。"
+msgstr "你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更多內容。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17104,7 +16937,7 @@ msgstr "向 Duck.ai 打聲招呼！"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
+msgstr "向 Duck.ai 打聲招呼——由 DuckDuckGo 提供的免費、私密 AI 聊天功能。"
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17307,18 +17140,16 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相"
-"關內容，然後使用 AI 生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在"
-"點按 Assist 時)、有時 (在高度相關時)，或經常 (在廣泛的搜尋中)。目前，Search "
-"Assist 功能僅供部分英語地區使用。"
+"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相關內容，然後使用 AI "
+"生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在點按 Assist 時)、有時 (在高度相關時)，或經常 "
+"(在廣泛的搜尋中)。目前，Search Assist 功能僅供部分英語地區使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr ""
-"Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
+msgstr "Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17327,8 +17158,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網"
-"路%2$s以尋找相關內容，然後使用 AI 根據找到的資訊生成簡短的答案。"
+"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網路%2$s以尋找相關內容，然後使用 AI "
+"根據找到的資訊生成簡短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17448,9 +17279,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋"
-"「ducks」。"
+msgstr "使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋「ducks」。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17468,9 +17297,7 @@ msgstr "私密搜尋與封鎖追蹤器"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋"
-"功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
+msgstr "使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17489,9 +17316,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 "
-"Cloud Save 將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資"
-"料，且你的通關密語永遠不會離開你的瀏覽器。"
+"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 Cloud Save "
+"將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資料，且你的通關密語永遠不會離開你的瀏覽器。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17609,9 +17435,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步"
-"的裝置存取。"
+msgstr "以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17619,9 +17443,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存"
-"取。"
+msgstr "以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17635,9 +17457,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到"
-"你的資料，連我們也不行。"
+msgstr "採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到你的資料，連我們也不行。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18043,9 +17863,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有"
-"對話。"
+msgstr "向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有對話。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18072,7 +17890,7 @@ msgstr "塞爾維亞語（拉丁文）"
 msgctxt ""
 "Title of the success screen shown after the server data has been deleted"
 msgid "Server data deleted"
-msgstr ""
+msgstr "伺服器資料已刪除"
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -18167,8 +17985,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
+msgstr "開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18231,7 +18048,7 @@ msgctxt ""
 "Button label that opens the system share sheet to send the sync code link to "
 "another app"
 msgid "Share"
-msgstr ""
+msgstr "分享"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
@@ -18274,9 +18091,7 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透"
-"露你的精確位置。"
+msgstr "與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透露你的精確位置。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18383,13 +18198,13 @@ msgstr "分享你對搜尋方塊的想法。"
 #. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
 msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
 msgid "Shared Chat Links"
-msgstr ""
+msgstr "已分享的聊天連結"
 
 # smartling.placeholder_format=C
 #. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
 msgctxt "Header of the Duck.ai shared links modal"
 msgid "Shared chat links"
-msgstr ""
+msgstr "已分享的聊天連結"
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
@@ -18397,9 +18212,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr ""
-"使用我們無記錄、快速的 VPN 來保護你的線上活動。 設定簡單，且可隨時輕鬆開啟或"
-"關閉。"
+msgstr "使用我們無記錄、快速的 VPN 來保護你的線上活動。 設定簡單，且可隨時輕鬆開啟或關閉。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18756,18 +18569,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影"
-"響私密搜尋。"
+msgstr "提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影響私密搜尋。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影"
-"響搜尋保護。"
+msgstr "提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影響搜尋保護。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19064,7 +18873,7 @@ msgstr "發生錯誤"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
+msgstr "載入此分享的聊天時發生錯誤。"
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19900,7 +19709,7 @@ msgstr "切換模型"
 #. Text for the button that allows the user to switch to a different model.
 msgctxt "Button to switch to a different model"
 msgid "Switch model"
-msgstr ""
+msgstr "切換模型"
 
 # smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
@@ -20082,19 +19891,16 @@ msgid ""
 msgstr ""
 "同步恢復碼\n"
 "\n"
-"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在"
-"你無法存取某個裝置時恢復你的同步資料。\n"
+"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在你無法存取某個裝置時恢復你的同步資料。\n"
 "\n"
 "確保此資訊安全無虞。\n"
 "任何有權限存取此代碼的人都能存取你同步的資料。%1$s\n"
 "\n"
 "這段代碼是如何運作的？\n"
-"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & "
-"Backup」，然後選擇「恢復已同步的資料」\n"
+"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & Backup」，然後選擇「恢復已同步的資料」\n"
 "3. 複製上方的恢復代碼，並貼到顯示「將你的代碼貼在這裡」的地方\n"
 "\n"
-"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將"
-"從伺服器上刪除，且無法恢復。"
+"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將從伺服器上刪除，且無法恢復。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20155,7 +19961,7 @@ msgstr "同步裝置"
 msgctxt ""
 "Shows the date a device last synced; %s is a date such as Apr 17, 2025"
 msgid "Synced on %s"
-msgstr ""
+msgstr "於 %1$s 同步"
 
 # smartling.placeholder_format=C
 msgid "Syria"
@@ -20193,7 +19999,7 @@ msgstr "電視"
 #. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
 msgctxt "AI Chat accessible label for a scrollable table in a response"
 msgid "Table"
-msgstr ""
+msgstr "表格"
 
 # smartling.placeholder_format=C
 #. The name of the Tahitian language
@@ -20226,9 +20032,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
-"隨身帶著 Duck.ai。 無論身在何處，都能透過我們免費 App 的內建功能更快速地存"
-"取。"
+msgstr "隨身帶著 Duck.ai。 無論身在何處，都能透過我們免費 App 的內建功能更快速地存取。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20236,9 +20040,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
-"隨時隨地帶著 Duck.ai。 使用我們免費瀏覽器的內建功能，無論你在何處瀏覽都能更快"
-"速存取。"
+msgstr "隨時隨地帶著 Duck.ai。 使用我們免費瀏覽器的內建功能，無論你在何處瀏覽都能更快速存取。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20481,9 +20283,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第"
-"三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
+msgstr "這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20599,8 +20399,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
+msgstr "在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20632,9 +20431,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設"
-"搜尋引擎，藉此為你造訪的網站新增隱私保護。"
+msgstr "這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設搜尋引擎，藉此為你造訪的網站新增隱私保護。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20718,8 +20515,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準"
-"確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %4$s "
+"取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20728,9 +20525,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令"
-"人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
+msgstr "此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20738,9 +20533,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感"
-"的資訊。（更多資訊請參見%2$s）。"
+msgstr "這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感的資訊。（更多資訊請參見%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20750,14 +20543,14 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能"
-"會顯示不準確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 "
+"(請參閱 %4$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
 msgctxt "Label marking the current device in the synced devices list"
 msgid "This device"
-msgstr ""
+msgstr "此裝置"
 
 # smartling.placeholder_format=C
 #. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
@@ -20767,7 +20560,7 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr ""
+msgstr "此裝置將無法再存取你在其他裝置上的同步資料。最近的 %1$s 個聊天記錄仍將保留在本機儲存空間中。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20856,7 +20649,7 @@ msgstr "這些資訊沒有用"
 #. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
 msgctxt "Label above messages in a shared chat view"
 msgid "This is a copy of a shared chat."
-msgstr ""
+msgstr "這是共享聊天的副本。"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
@@ -20864,9 +20657,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
-"這只是一則範例聊天。 開啟選單（三個點），然後選擇「釘選」，將它保持在聊天的最"
-"上方！"
+msgstr "這只是一則範例聊天。 開啟選單（三個點），然後選擇「釘選」，將它保持在聊天的最上方！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20894,9 +20685,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留"
-"模式。"
+msgstr "此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20904,9 +20693,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模"
-"式。"
+msgstr "此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20942,9 +20729,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從"
-"任何瀏覽器存取。"
+msgstr "這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從任何瀏覽器存取。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20952,9 +20737,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
-"可能會再次看到 AI 輔助的答案。"
+msgstr "此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI 輔助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20964,21 +20747,20 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
-"可能會再次看到 AI 輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 "
-"AI 輔助答案。"
+"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI "
+"輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 AI 輔助答案。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
+msgstr "無法開啟此分享的聊天。 連結可能不完整。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
 msgctxt "Toast when a share link is missing or expired"
 msgid "This shared chat link is no longer available."
-msgstr ""
+msgstr "此共享聊天連結已無法使用。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21017,8 +20799,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然"
-"可以在連接到 Sync & Backup 的其他瀏覽器中存取您的聊天記錄。"
+"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然可以在連接到 Sync & Backup "
+"的其他瀏覽器中存取您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21163,9 +20945,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖"
-"示。%4$s"
+msgstr "如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖示。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21174,9 +20954,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲"
-"存在您最初用於設定同步的裝置上。"
+msgstr "若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲存在您最初用於設定同步的裝置上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21184,9 +20962,7 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再"
-"試一次。"
+msgstr "欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再試一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21435,8 +21211,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
+msgstr "將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21444,8 +21219,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
+msgstr "將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21610,7 +21384,7 @@ msgstr "免費試用"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try Free!"
-msgstr ""
+msgstr "免費試用！"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
@@ -21729,7 +21503,7 @@ msgstr "免費試用"
 #. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid "Try for Free!"
-msgstr ""
+msgstr "免費試用！"
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21922,9 +21696,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設"
-"定。 %3$s瞭解更多%4$s"
+msgstr "想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21932,9 +21704,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設"
-"定。 %3$s瞭解更多%4$s"
+msgstr "想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21976,7 +21746,7 @@ msgstr "土庫曼"
 #. The user taps this to turn off Sync & Backup on the device they are using.
 msgctxt "Button that confirms turning off syncing"
 msgid "Turn Off"
-msgstr ""
+msgstr "關閉"
 
 # smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
@@ -21994,7 +21764,7 @@ msgstr "關閉 Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
+msgstr "是否要關閉 Sync & Backup 並刪除伺服器資料？"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22134,9 +21904,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延"
-"遲。"
+msgstr "在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延遲。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22387,9 +22155,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus "
-"方案的使用上限。"
+msgstr "透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus 方案的使用上限。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22467,7 +22233,7 @@ msgstr "取消靜音"
 #. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
 msgctxt "Fallback name for a shared link whose chat has no title"
 msgid "Untitled chat"
-msgstr ""
+msgstr "未命名聊天"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
@@ -22508,7 +22274,7 @@ msgstr "更新瀏覽器"
 #. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
 msgid "Update Duck.ai to view this shared chat."
-msgstr ""
+msgstr "更新 Duck.ai 以檢視此共享聊天。"
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22771,9 +22537,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵"
-"害。對資訊保密。免費。不需要帳戶。"
+msgstr "私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵害。對資訊保密。免費。不需要帳戶。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22983,8 +22747,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
+msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -22992,9 +22755,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管"
-"理。"
+msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23036,8 +22797,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & Backup%4$s > "
+"%5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23047,8 +22808,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & Backup」下選取"
-"「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
+"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & "
+"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23058,8 +22819,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設"
-"定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23069,9 +22830,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在"
-"「Sync & Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 "
-"PDF 上的二維碼。"
+"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在「Sync & "
+"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23266,9 +23026,7 @@ msgstr "在 Duck Player 中觀看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推"
-"播干擾。"
+msgstr "在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推播干擾。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23288,8 +23046,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內"
-"容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube 沒有任何關係。"
+"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube "
+"沒有任何關係。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23312,9 +23070,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
-"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo "
-"分享此對話，以便我們調查並處理該問題。"
+msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo 分享此對話，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23325,9 +23081,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的"
-"提示詞與回覆內容，以便我們調查並處理該問題。"
+msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的提示詞與回覆內容，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23367,8 +23121,7 @@ msgstr "我們不會儲存你的個人資訊。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr ""
-"我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
+msgstr "我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23389,8 +23142,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
+msgstr "本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23429,9 +23181,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr ""
-"我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告"
-"商。"
+msgstr "我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告商。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23456,7 +23206,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr ""
+msgstr "我們會從資料仲介網站中尋找並移除你的個人資訊。另外還能取得 VPN 等功能。"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23464,9 +23214,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智"
-"慧。"
+msgstr "我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智慧。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23498,9 +23246,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主"
-"意。"
+msgstr "我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主意。"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -23508,7 +23254,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr ""
+msgstr "我們會定期在資料仲介網站上掃描你的個人資訊，並在易於使用的儀表板中與你分享我們的進度。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23534,9 +23280,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立"
-"刻出現。"
+msgstr "我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立刻出現。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23549,7 +23293,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr ""
+msgstr "我們會針對你的電子郵件、姓名、地址等資訊掃描資料仲介網站，並努力將找到的你任何相關資訊移除。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23708,9 +23452,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會"
-"用來訓練人工智慧模型。"
+msgstr "歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23718,9 +23460,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名"
-"化，且不會用來訓練人工智慧模型。"
+msgstr "歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23730,8 +23470,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這"
-"裡的所有聊天內容都是私密的，且永遠不會被 DuckDuckGo 儲存或用來訓練 AI 模型。"
+"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這裡的所有聊天內容都是私密的，且永遠不會被 "
+"DuckDuckGo 儲存或用來訓練 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23850,7 +23590,7 @@ msgstr "年金的優缺點是？"
 #. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
 msgid "What are the benefits of Duck.ai?"
-msgstr ""
+msgstr "Duck.ai 有哪些好處？"
 
 # smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
@@ -23863,9 +23603,8 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 "
-"DuckDuckGo 來源。將回應分成清晰的部分，並以 Duck.ai 整合和隱私保護為重點。對"
-"於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
+"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 DuckDuckGo 來源。將回應分成清晰的部分，並以 "
+"Duck.ai 整合和隱私保護為重點。對於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24400,9 +24139,7 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr ""
-"使用 Duck.ai，你的聊天內容都會經過匿名處理，且絕不會用於訓練 AI。 你可以隨時"
-"在「%1$s」選單中將其開啟或關閉。"
+msgstr "使用 Duck.ai，你的聊天內容都會經過匿名處理，且絕不會用於訓練 AI。 你可以隨時在「%1$s」選單中將其開啟或關閉。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24416,7 +24153,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
-msgstr ""
+msgstr "直接在你的裝置上運作，從資料仲介網站中移除你的電子郵件、姓名、地址等資訊。"
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24735,8 +24472,7 @@ msgstr "你最多可以附加 %1$s 個文字選擇。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
+msgstr "你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24756,8 +24492,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
+msgstr "你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24904,7 +24639,7 @@ msgstr "你還可以嘗試1次。"
 msgctxt ""
 "Empty state shown inside the list container of the Duck.ai shared links modal"
 msgid "You have no shared chat links."
-msgstr ""
+msgstr "你沒有任何已分享的聊天連結。"
 
 # smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
@@ -24912,9 +24647,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高"
-"出 2 倍的使用上限。"
+msgstr "您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高出 2 倍的使用上限。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24922,9 +24655,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 "
-"DuckDuckGo 訂閱保護功能。"
+msgstr "你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 DuckDuckGo 訂閱保護功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24945,9 +24676,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
-"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24956,9 +24685,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
-"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24985,9 +24712,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏"
-"覽。應用程式已經安裝完畢，而且可以："
+msgstr "你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏覽。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25074,9 +24799,7 @@ msgctxt "Sync file storage limit modal description"
 msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
-msgstr ""
-"您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的"
-"聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr "您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25085,9 +24808,7 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats. Delete the %s "
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
-msgstr ""
-"您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件"
-"聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr "您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25100,9 +24821,7 @@ msgstr "你的儲存空間已用完"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/"
-"Google追蹤。"
+msgstr "YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/Google追蹤。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25123,14 +24842,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
+msgstr "在以下瀏覽器中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
+msgstr "你的 Duck.ai 聊天記錄正透過端對端加密進行同步。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25161,7 +24880,7 @@ msgctxt "First body paragraph in the Delete Server Data confirmation modal"
 msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
-msgstr ""
+msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25170,9 +24889,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
-"中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
+msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25181,9 +24898,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
-"中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
+msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25247,16 +24962,14 @@ msgstr "您的聊天內容是私密的，且絕不會用於訓練 AI 模型"
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25284,9 +24997,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些"
-"步驟保留您的聊天記錄。"
+msgstr "您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些步驟保留您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25325,8 +25036,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
+msgstr "你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25368,10 +25078,7 @@ msgid ""
 "known as %sSHA-2%s. Only the key and associated settings file leave your "
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
-msgstr ""
-"我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。"
-"只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔"
-"案。DuckDuckGo不會知道你的通關密語。"
+msgstr "我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔案。DuckDuckGo不會知道你的通關密語。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25385,9 +25092,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者"
-"無法將你的對話與你連結起來。"
+msgstr "你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者無法將你的對話與你連結起來。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25431,9 +25136,7 @@ msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
-msgstr ""
-"你的設定已儲存，但清除 Cookie 將會重設這些設定。啟用 %1$sDuckDuckGo No "
-"AI%2$s 擴充套件以使其永久生效。"
+msgstr "你的設定已儲存，但清除 Cookie 將會重設這些設定。啟用 %1$sDuckDuckGo No AI%2$s 擴充套件以使其永久生效。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25442,8 +25145,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No "
-"AI%2$s 擴充套件以使其永久生效。 %3$s瞭解更多%4$s"
+"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No AI%2$s 擴充套件以使其永久生效。 "
+"%3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25462,9 +25165,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得"
-"更全面的保護。應用程式已經安裝完畢，而且可以："
+msgstr "你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得更全面的保護。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25480,8 +25181,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
+msgstr "您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,6 +41,14 @@ msgstr "完整接種率 (%)"
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
 msgstr "疫苗接種率 (%)"
+
+# smartling.placeholder_format=C
+#. %s is replaced with the name of the device, for example Chrome 150 (This device). Reword or move the parenthetical if that reads better in your language.
+msgctxt ""
+"Title of the device detail sheet when it shows the device the person is "
+"using right now; %s is the device name"
+msgid "%s (This device)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
@@ -181,7 +189,9 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
+msgstr ""
+"%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換"
+"至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -190,7 +200,9 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
+msgstr ""
+"%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切"
+"換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -205,7 +217,9 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr "%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或切換至免費模式。"
+msgstr ""
+"%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或"
+"切換至免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -310,8 +324,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s 運行於受信任執行環境（Trusted Execution "
-"Environment）。這表示即使是模型提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
+"%1$s 運行於受信任執行環境（Trusted Execution Environment）。這表示即使是模型"
+"提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -396,7 +410,8 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr "%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
+msgstr ""
+"%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -406,7 +421,8 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
+msgstr ""
+"%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -434,7 +450,8 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr "%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
+msgstr ""
+"%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -461,6 +478,13 @@ msgstr "%1$s瞭解更多%2$s。"
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr "%1$s瞭解我們如何保護你的位置隱私%2$s。"
+
+# smartling.placeholder_format=C
+#. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
+msgctxt ""
+"Learn more link at the end of the recovery section description inside Manage"
+msgid "%sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -749,6 +773,12 @@ msgid "2nd in Group %s"
 msgstr "%1$s組中第二"
 
 # smartling.placeholder_format=C
+#. Call to action that re-asks the same question to a different AI model. Also used as visible label text in one layout, so it's intentionally abbreviated to fit a crowded row — please keep translations similarly short.
+msgctxt "Label, tooltip and aria-label for an action button"
+msgid "2nd opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "3 premium protections. 1 subscription."
@@ -890,7 +920,8 @@ msgstr "客場戰績"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
+msgstr ""
+"網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -948,8 +979,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo Search 上的 AI Chat "
-"功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/aichat%2$s 使用 AI Chat 功能。"
+"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo "
+"Search 上的 AI Chat 功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/"
+"aichat%2$s 使用 AI Chat 功能。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1010,8 +1042,9 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck.ai%2$s 以回答後續問題，這是我們的私密 AI "
-"驅動的聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
+"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck."
+"ai%2$s 以回答後續問題，這是我們的私密 AI 驅動的聊天服務，支援來自 OpenAI、"
+"Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1414,6 +1447,12 @@ msgid "Add to Home Screen"
 msgstr "新增至主畫面"
 
 # smartling.placeholder_format=C
+#. Button in the shared conversation panel footer that saves the conversation to the viewer's on-device chat history, called My Chats.
+msgctxt "Button in the footer of a shared-chat copy panel"
+msgid "Add to My Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the top menu under Goodies
 msgid "Add-ons"
 msgstr "附加元件"
@@ -1699,7 +1738,9 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr "所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型供應商用於訓練聊天模型"
+msgstr ""
+"所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型"
+"供應商用於訓練聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1745,7 +1786,9 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr "在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會被移除。"
+msgstr ""
+"在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會"
+"被移除。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1764,6 +1807,13 @@ msgstr "所有大小"
 msgctxt "image-type"
 msgid "All types"
 msgstr "所有類型"
+
+# smartling.placeholder_format=C
+#. Tells the user that every device has been signed out of syncing now that the data is gone.
+msgctxt ""
+"Body of the success screen shown after the server data has been deleted"
+msgid "All your devices are disconnected from Sync."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
@@ -1808,8 +1858,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期限有限的搜尋引擎。%2$s "
-"的提示和回應仍具有%3$s零提供者可見度%4$s。"
+"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期"
+"限有限的搜尋引擎。%2$s 的提示和回應仍具有%3$s零提供者可見度%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1974,7 +2024,8 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr "根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
+msgstr ""
+"根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2147,7 +2198,9 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr "你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天記錄一併刪除。"
+msgstr ""
+"你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天"
+"記錄一併刪除。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2184,7 +2237,9 @@ msgstr "更新時間："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr "根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業皆於你的裝置上進行。"
+msgstr ""
+"根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業"
+"皆於你的裝置上進行。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2265,6 +2320,12 @@ msgid "Ask anything privately"
 msgstr "您可以私下詢問任何事情"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask anything privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
 msgctxt "Label for the switch to ask clarifying questions"
 msgid "Ask clarifying questions"
@@ -2320,9 +2381,10 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 "
-"Assist 使用介面)、隨選 (僅在點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 "
-"(在更廣泛的搜尋中更頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
+"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想"
+"要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 Assist 使用介面)、隨選 (僅在"
+"點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更"
+"頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2334,8 +2396,10 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI "
-"協助的搜尋查詢答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的。"
+"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI 協助的搜尋查詢答案。"
+"為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言"
+"技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並"
+"根據%1$s搜耙網路%2$s自動產生的。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2360,7 +2424,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr "無論是在咖啡廳、機場還是飯店，DuckDuckGo VPN 都能加密你的網路連線，並在 Wi-Fi 上隱藏你的 IP 位址。"
+msgstr ""
+"無論是在咖啡廳、機場還是飯店，DuckDuckGo VPN 都能加密你的網路連線，並在 Wi-"
+"Fi 上隱藏你的 IP 位址。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2505,7 +2571,9 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr "自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，Assist 僅供英語地區使用。"
+msgstr ""
+"自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜"
+"尋結果。目前，Assist 僅供英語地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2514,8 +2582,8 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，DuckAssist "
-"僅供說英文的地區使用。"
+"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應"
+"某些搜尋結果。目前，DuckAssist 僅供說英文的地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2720,7 +2788,9 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr "在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身份資訊，將你的對話匿名化。"
+msgstr ""
+"在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身"
+"份資訊，將你的對話匿名化。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2849,7 +2919,8 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr "封鎖有害網站、隱藏你的 IP 地址，訂閱我們的服務還能獲得更多高階保護功能。"
+msgstr ""
+"封鎖有害網站、隱藏你的 IP 地址，訂閱我們的服務還能獲得更多高階保護功能。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3108,20 +3179,26 @@ msgstr "瀏覽檔案"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
+msgstr ""
+"享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組"
+"合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
+msgstr ""
+"你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執"
+"行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr "你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
+msgstr ""
+"你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽"
+"器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3228,15 +3305,18 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使用匿名的 Could Save "
-"以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
+"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使"
+"用匿名的 Could Save 以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別"
+"的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
+msgstr ""
+"啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始"
+"之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3244,7 +3324,9 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
+msgstr ""
+"啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開"
+"始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3728,9 +3810,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 "
-"DuckDuckGo Search 上的聊天按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s "
-"直接使用聊天功能。"
+"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 "
+"OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo Search 上的聊天按鈕和連"
+"結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 直接使用聊天功"
+"能。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3860,7 +3943,9 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用聊天記錄將刪除置頂的聊天。"
+msgstr ""
+"聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用"
+"聊天記錄將刪除置頂的聊天。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3872,8 +3957,9 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
-"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
+"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 "
+"DuckDuckGo 伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置"
+"頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3895,7 +3981,9 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr "與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴供應商匿名審核，以用於 %2$s。"
+msgstr ""
+"與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴"
+"供應商匿名審核，以用於 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4254,7 +4342,9 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr "清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
+msgstr ""
+"清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近"
+"的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4264,8 +4354,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期保存，或在不使用 Duck.ai 的情況下 7 "
-"天後自動刪除，視您的瀏覽器而定。"
+"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期"
+"保存，或在不使用 Duck.ai 的情況下 7 天後自動刪除，視您的瀏覽器而定。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4282,8 +4372,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私人 AI 聊天服務，支援來自 "
-"OpenAI、Anthropic 等的聊天模型。"
+"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私"
+"人 AI 聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4444,7 +4534,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr "按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
+msgstr ""
+"按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏"
+"覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4454,7 +4546,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr "按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
+msgstr ""
+"按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的"
+"瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4729,7 +4823,8 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr "Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
+msgstr ""
+"Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5104,6 +5199,12 @@ msgid "Copy"
 msgstr "複製"
 
 # smartling.placeholder_format=C
+#. Shorter label for the copy button under the QR, used when it sits next to a Share button.
+msgctxt "Short button label that copies the sync code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
 msgctxt "duckassist"
 msgid "Copy"
@@ -5143,6 +5244,28 @@ msgstr "複製或儲存此代碼"
 msgctxt "Accessible label for the copy button on the recovery code screen"
 msgid "Copy recovery code"
 msgstr "複製恢復碼"
+
+# smartling.placeholder_format=C
+#. Names the icon-only action that copies that row's share URL to the clipboard.
+msgctxt ""
+"Tooltip and accessible name for the copy button on a row of the Duck.ai "
+"shared links modal"
+msgid "Copy shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user to copy the pairing code on their other device.
+msgctxt "First numbered step heading on the Enter Code tab"
+msgid "Copy the code from another device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown when the code the user entered is not a valid sync code. Tells them where to find the correct code. The text between the two %s is the on-screen menu path and is shown in a darker colour.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%s and try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5818,6 +5941,14 @@ msgid "Delete recent chats?"
 msgstr "刪除最近的聊天記錄？"
 
 # smartling.placeholder_format=C
+#. Names the icon-only action that revokes that row's share link. Deleting is immediate — there is no confirmation step.
+msgctxt ""
+"Tooltip and accessible name for the delete button on a row of the Duck.ai "
+"shared links modal"
+msgid "Delete shared link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of the modal that asks the user if they want to delete their current chat.
 msgctxt "Modal header for deleting a chat"
 msgid "Delete this chat?"
@@ -5828,6 +5959,14 @@ msgstr "刪除此聊天記錄？"
 msgctxt "Feedback prompt"
 msgid "Deleted chats"
 msgstr "已刪除的聊天記錄"
+
+# smartling.placeholder_format=C
+#. Sets expectations before the user deletes a link: revoking the link blocks future views, but anyone who already saved the conversation into their own chats keeps that copy.
+msgctxt "Description at the top of the Duck.ai shared links modal"
+msgid ""
+"Deleting a link stops it from working. People who have opened it and added "
+"the conversation to their chats will keep their own copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -5940,7 +6079,9 @@ msgstr "聽寫功能暫時無法使用"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 Duck.ai 中聊天。"
+msgstr ""
+"語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 "
+"Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6079,6 +6220,13 @@ msgstr "隱藏"
 msgctxt "Accessibility label for close button"
 msgid "Dismiss"
 msgstr "隱藏"
+
+# smartling.placeholder_format=C
+#. Accessible label for the button that dismisses the Duck.ai introduction banner shown on a shared-chat page.
+msgctxt ""
+"Accessibility label for the shared-chat introduction promo close button"
+msgid "Dismiss"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A button to dismiss the assist settings modal.
@@ -6251,7 +6399,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr "不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖片。 %3$s瞭解更多%4$s"
+msgstr ""
+"不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖"
+"片。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6259,7 +6409,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr "不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖片的搜尋。%3$s瞭解更多%4$s"
+msgstr ""
+"不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖"
+"片的搜尋。%3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6541,7 +6693,9 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr "Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包含，除非你在設定中選擇自動附加頁面。"
+msgstr ""
+"Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包"
+"含，除非你在設定中選擇自動附加頁面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6550,7 +6704,9 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr "Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任何擴充套件，然後再試一次。"
+msgstr ""
+"Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任"
+"何擴充套件，然後再試一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6573,7 +6729,9 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr "Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重新掌控個人資訊的人。"
+msgstr ""
+"Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重"
+"新掌控個人資訊的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6587,7 +6745,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁：https://duck.ai"
+msgstr ""
+"Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁："
+"https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6601,7 +6761,8 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
+msgstr ""
+"Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6622,8 +6783,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，但你仍然可以造訪 %1$sduck.ai%2$s "
-"直接使用。"
+"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，"
+"但你仍然可以造訪 %1$sduck.ai%2$s 直接使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6634,9 +6795,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo "
-"Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 "
-"Duck.ai使用聊天功能。"
+"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。"
+"關閉此設定將隱藏 DuckDuckGo Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定"
+"後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 Duck.ai使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6697,8 +6858,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需註冊的 AI "
-"聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點的 AI、無需帳號的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需"
+"註冊的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點"
+"的 AI、無需帳號的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6726,9 +6888,10 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 "
-"DuckAssist UI)、隨選 (僅在點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁地顯示)。目前 "
-"DuckAssist 僅供美國 (英文) 地區使用。"
+"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 "
+"DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 DuckAssist UI)、隨選 (僅在"
+"點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁"
+"地顯示)。目前 DuckAssist 僅供美國 (英文) 地區使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6737,8 +6900,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
-"OpenAI 和 Anthropic 等聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這"
+"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6747,8 +6910,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
-"OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這"
+"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6760,8 +6923,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 "
-"AI 驅動的自然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，尚未確認準確性。"
+"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了"
+"完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 AI 驅動的自"
+"然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，"
+"尚未確認準確性。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6775,10 +6940,11 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist "
-""
-"是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。DuckAssist "
-"的回應始終直接連結至一個或兩個來源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
+"DuckAssist 是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完"
+"成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，"
+"根據找到的相關資訊產生簡短的答案。DuckAssist 的回應始終直接連結至一個或兩個來"
+"源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是"
+"從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6801,7 +6967,9 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
+"%3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6809,7 +6977,9 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
+"%3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6825,7 +6995,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
+msgstr ""
+"DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件"
+"傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6866,6 +7038,13 @@ msgctxt ""
 "list; the %s is the 1-based position in the list"
 msgid "DuckDuckGo Browser %s"
 msgstr "DuckDuckGo 瀏覽器 %1$s"
+
+# smartling.placeholder_format=C
+#. Names the trusted source an answer was grounded in. Shown with a verified badge instead of the AI model name when the response was built only from official DuckDuckGo help pages.
+msgctxt ""
+"Attribution shown in place of the model name in a Duck.ai assistant message"
+msgid "DuckDuckGo Help Pages"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. by opening https://duckduckgo.com/api it shows in the window title
@@ -6981,14 +7160,17 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr "DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資訊來匿名化這些報告。"
+msgstr ""
+"DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資"
+"訊來匿名化這些報告。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
+msgstr ""
+"DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7004,7 +7186,9 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr "DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤器，它們經常試圖在你造訪其他網站時追蹤你。"
+msgstr ""
+"DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤"
+"器，它們經常試圖在你造訪其他網站時追蹤你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7015,7 +7199,11 @@ msgid ""
 "use it to improve results for that search, and then we promptly throw it "
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
-msgstr "DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保護你的隱私%2$s。"
+msgstr ""
+"DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置"
+"上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我"
+"們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保"
+"護你的隱私%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7034,7 +7222,9 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr "DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更接近你的搜尋結果。%1$s瞭解更多%2$s。"
+msgstr ""
+"DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更"
+"接近你的搜尋結果。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7125,7 +7315,10 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr "當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18至20個字元。"
+msgstr ""
+"當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我"
+"們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18"
+"至20個字元。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7374,7 +7567,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保密。"
+msgstr ""
+"啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保"
+"密。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7535,7 +7730,9 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr "輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關密語下。"
+msgstr ""
+"輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關"
+"密語下。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7560,7 +7757,8 @@ msgstr "輸入文字"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
+msgstr ""
+"輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7663,10 +7861,25 @@ msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr "專為重視隱私的人精心打造的產品。"
 
 # smartling.placeholder_format=C
+#. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
+msgctxt ""
+"Status shown in place of the expiry date once a shared link has lapsed"
+msgid "Expired"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
 msgctxt "Text for the expired subscription label on the settings modal"
 msgid "Expired"
 msgstr "已過期"
+
+# smartling.placeholder_format=C
+#. %s is a localized short date, e.g. 'Apr 17, 2025'. Shown for links that have not expired yet.
+msgctxt ""
+"Expiry line under a link title in the Duck.ai shared links modal; %s is a "
+"localized date"
+msgid "Expires %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
@@ -7936,7 +8149,9 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的問題。"
+msgstr ""
+"像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的"
+"問題。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8173,7 +8388,8 @@ msgstr "多霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr "按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
+msgstr ""
+"按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8401,8 +8617,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> "
-"&gt;<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
+"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> &gt;"
+"<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8774,7 +8990,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
-msgstr "取得快速、無紀錄的 VPN、選配的進階 AI 對話、個人資訊移除，以及 Identity Theft Restoration 服務。"
+msgstr ""
+"取得快速、無紀錄的 VPN、選配的進階 AI 對話、個人資訊移除，以及 Identity "
+"Theft Restoration 服務。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -8782,7 +9000,8 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr "取得快速、無紀錄的 VPN、選配的進階 AI 對話，以及 Identity Theft Restoration。"
+msgstr ""
+"取得快速、無紀錄的 VPN、選配的進階 AI 對話，以及 Identity Theft Restoration。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -8790,7 +9009,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
+msgstr ""
+"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
+"隱私權保護。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8800,7 +9021,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
+msgstr ""
+"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
+"隱私權保護。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8843,7 +9066,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr "取得我們快速、不記錄活動的 VPN、可選擇存取具有更高聊天限制的進階 AI 模型，以及更多高級防護。"
+msgstr ""
+"取得我們快速、不記錄活動的 VPN、可選擇存取具有更高聊天限制的進階 AI 模型，以"
+"及更多高級防護。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -8852,15 +9077,16 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"取得我們安全的無紀錄 VPN、先進的 Duck.ai，Personal Information Removal，以及 Identity Theft "
-"Restoration。"
+"取得我們安全的無紀錄 VPN、先進的 Duck.ai，Personal Information Removal，以及 "
+"Identity Theft Restoration。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "取得我們安全、無日誌的 VPN、先進的 Duck.ai 以及 Identity Theft Restoration。"
+msgstr ""
+"取得我們安全、無日誌的 VPN、先進的 Duck.ai 以及 Identity Theft Restoration。"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -8960,8 +9186,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 %3$s聊天記錄 › Sync & Backup "
-"› 與另一裝置同步 › 複製文字代碼%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 "
+"%3$s聊天記錄 › Sync & Backup › 與另一裝置同步 › 複製文字代碼%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8970,8 +9196,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s聊天記錄 › Sync & Backup "
-"› 與另一裝置同步%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s"
+"聊天記錄 › Sync & Backup › 與另一裝置同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8981,8 +9207,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊天 › Sync & Backup › "
-"與其他裝置同步%4$s，然後掃描此代碼："
+"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊"
+"天 › Sync & Backup › 與其他裝置同步%4$s，然後掃描此代碼："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8992,8 +9218,16 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s聊天 › Sync & Backup › "
-"與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s"
+"聊天 › Sync & Backup › 與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
+
+# smartling.placeholder_format=C
+#. Path to the pairing code on the other device. Bold segments are UI path labels.
+msgctxt "Detail under the first numbered step on the Enter Code tab"
+msgid ""
+"Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
+"Device%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9007,7 +9241,8 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr "前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
+msgstr ""
+"前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9015,7 +9250,8 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr "前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
+msgstr ""
+"前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9100,6 +9336,12 @@ msgstr "瞭解了"
 msgctxt "Button on the subscription welcome modal"
 msgid "Got It"
 msgstr "瞭解了"
+
+# smartling.placeholder_format=C
+#. The user taps this to close the screen after their server data has been deleted.
+msgctxt "Button that dismisses the server-data-deleted success screen"
+msgid "Got It"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
@@ -9723,7 +9965,9 @@ msgstr "最近活動"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr "在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定為預設%6$s"
+msgstr ""
+"在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定"
+"為預設%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10081,7 +10325,9 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr "如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與隱私」%2$s。"
+msgstr ""
+"如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與"
+"隱私」%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10091,8 +10337,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > 網站設定 > "
-"位置%2$s，確認DuckDuckGo是被允許的存取位置。"
+"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > "
+"網站設定 > 位置%2$s，確認DuckDuckGo是被允許的存取位置。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10106,7 +10352,8 @@ msgstr "如果你繼續看到此錯誤，請聯絡 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
+msgstr ""
+"如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10114,7 +10361,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr "若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 %2$s 支援頁面。"
+msgstr ""
+"若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 "
+"%2$s 支援頁面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10122,7 +10371,9 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢復碼儲存成文字檔，儲存至您的裝置。"
+msgstr ""
+"如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢"
+"復碼儲存成文字檔，儲存至您的裝置。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -10284,7 +10535,9 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr "若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避免搜尋記錄外洩。%1$s瞭解更多%2$s。"
+msgstr ""
+"若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避"
+"免搜尋記錄外洩。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10294,7 +10547,9 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同步」。"
+msgstr ""
+"在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同"
+"步」。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10713,8 +10968,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad "
-"Network播送。點擊後會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收到任何報酬。"
+"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad Network播送。點擊後"
+"會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收"
+"到任何報酬。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10722,7 +10978,9 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr "比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安全。"
+msgstr ""
+"比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安"
+"全。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11026,6 +11284,12 @@ msgstr "瞭解%1$s更多%2$s"
 msgctxt "frontpage"
 msgid "Learn %sMore%s"
 msgstr "瞭解%1$s更多%2$s"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed Dax-in-solar-glasses logo on Aug 12, 2026; searches for information about the eclipse.
+msgctxt "Button in the eclipse logo modal (mobile)"
+msgid "Learn More"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button that opens a modal or page with additional information about a feature.
@@ -11657,6 +11921,13 @@ msgid "Manage"
 msgstr "管理"
 
 # smartling.placeholder_format=C
+#. Title-case button label. Opens a modal listing the share links created on this device.
+msgctxt ""
+"Button on the Shared Links settings row that opens the shared links modal"
+msgid "Manage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the sync settings page.
 msgctxt "Encrypted storage manage button"
 msgid "Manage"
@@ -11906,6 +12177,12 @@ msgstr "選單"
 msgctxt "maps_places"
 msgid "Menu"
 msgstr "選單"
+
+# smartling.placeholder_format=C
+#. Label below the shared conversation panel, between the shared messages and any follow-up messages the viewer adds. Tells the viewer that those follow-ups stay private.
+msgctxt "Divider under the shared-copy panel"
+msgid "Messages beyond this point are only visible to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12274,6 +12551,12 @@ msgid "More about Duck.ai"
 msgstr "更多關於 Duck.ai 的資訊"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the three-dot overflow menu on an assistant response action bar in Duck.ai. Announced by screen readers only — the visible control is the icon. Menu items can include Search the web, Extend reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for a menu button on a chat response"
+msgid "More actions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
 msgid "More at"
 msgstr "取得更多內容"
@@ -12466,6 +12749,12 @@ msgstr "暗"
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Muted red"
 msgstr "暗紅"
+
+# smartling.placeholder_format=C
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "My Devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
@@ -12707,8 +12996,9 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
-"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
+"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你失去"
+"網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應"
+"的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13529,7 +13819,33 @@ msgstr "隨需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設定%5$s"
+msgstr ""
+"在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設"
+"定%5$s"
+
+# smartling.placeholder_format=C
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s and scan this code:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
+"Sync With Another Device%s. Or scan the QR on your Recovery PDF."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13556,7 +13872,8 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr "附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
+msgstr ""
+"附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13918,7 +14235,8 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
+msgstr ""
+"即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13931,7 +14249,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr "我們快速、不記錄日誌的 VPN 提供更聰明且限制更高的 AI 聊天功能，以及更多頂級保護。一站式訂閱。"
+msgstr ""
+"我們快速、不記錄日誌的 VPN 提供更聰明且限制更高的 AI 聊天功能，以及更多頂級保"
+"護。一站式訂閱。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -13945,7 +14265,9 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr "我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功能。提供%1$siOS及Android%2$s版本。"
+msgstr ""
+"我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功"
+"能。提供%1$siOS及Android%2$s版本。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14197,7 +14519,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找回通關密語。"
+msgstr ""
+"我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找"
+"回通關密語。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14264,6 +14588,12 @@ msgid "Past year"
 msgstr "過去一年"
 
 # smartling.placeholder_format=C
+#. Label for the paste button docked in the code field on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
 msgctxt "Primary CTA on the Enter Code body"
 msgid "Paste"
@@ -14274,6 +14604,12 @@ msgstr "貼上"
 msgctxt "Button label that pastes the sync code from clipboard"
 msgid "Paste Sync Code"
 msgstr "貼上同步代碼"
+
+# smartling.placeholder_format=C
+#. Tells the user to paste the copied code into the field below.
+msgctxt "Second numbered step heading on the Enter Code tab"
+msgid "Paste it below"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
@@ -14327,6 +14663,20 @@ msgstr "永久關閉"
 msgctxt "language_name"
 msgid "Persian"
 msgstr "波斯語"
+
+# smartling.placeholder_format=C
+#. Shared headline of the Personal Information Removal instant answer shown on the search results page (US only), reused by the rotating slots whose heading is just the product name (the distinctive copy is in the body text).
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Personal Information Removal"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Explains that Personal Information Removal finds the user's info on data broker sites (companies that collect and sell personal information) and works to get it removed.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Personal Information Removal finds your info on data broker sites that are "
+"selling it. Then we work to get it removed for you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14397,8 +14747,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 "
-"%1$s搜尋設定%2$s。"
+"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常"
+"能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 %1$s搜尋設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14407,8 +14757,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能顯示並且通常能得出更好的答案。 "
-"欲調整此功能的運作方式或將其關閉，請造訪 %1$sDuckAssist 設定%2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
+"顯示並且通常能得出更好的答案。 欲調整此功能的運作方式或將其關閉，請造訪 "
+"%1$sDuckAssist 設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14418,8 +14769,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist "
-"更可能自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s DuckAssist 設定 %2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
+"自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s "
+"DuckAssist 設定 %2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14451,7 +14803,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr "選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
+msgstr ""
+"選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14467,7 +14820,8 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
+msgstr ""
+"選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14615,7 +14969,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非法。"
+msgstr ""
+"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非"
+"法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14623,7 +14979,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有害。"
+msgstr ""
+"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有"
+"害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15560,6 +15918,12 @@ msgid "Reading website…"
 msgstr "正在讀取網站…"
 
 # smartling.placeholder_format=C
+#. Shown next to a 'Learn more' link when hovering (desktop) or tapping (mobile) the special Dax-in-solar-glasses logo displayed on Aug 12, 2026. The link searches for information about the eclipse.
+msgctxt "Tooltip on the header logo on the day of the 2026 solar eclipse"
+msgid "Ready for the solar eclipse?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
 msgctxt "Label for reasoning mode in Duck.ai"
 msgid "Reasoning"
@@ -15654,7 +16018,9 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
+msgstr ""
+"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
+"中。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15662,7 +16028,9 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
+msgstr ""
+"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
+"中。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15671,7 +16039,9 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr "最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
+msgstr ""
+"最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲"
+"存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15740,6 +16110,12 @@ msgstr "復甦"
 msgctxt "Label above the recovery code on the joiner success screen"
 msgid "Recovery Code"
 msgstr "恢復碼"
+
+# smartling.placeholder_format=C
+#. Label preceding the recovery code description and Download Recovery Code link.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery Code"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -15946,7 +16322,8 @@ msgstr "重新載入 Duck.ai。"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr "按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
+msgstr ""
+"按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15989,6 +16366,12 @@ msgid "Remove %s"
 msgstr "移除 %1$s"
 
 # smartling.placeholder_format=C
+#. The user taps this to remove a device (other than the one they are using) so it can no longer sync.
+msgctxt "Button that starts removing one of the other devices from syncing"
+msgid "Remove Device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Asks the user to confirm revoking another device's sync session.
 msgctxt "Title for the destructive Remove Device confirmation modal"
 msgid "Remove Device?"
@@ -16029,6 +16412,18 @@ msgstr "移除文字選取"
 msgctxt "noresults"
 msgid "Remove unnecessary punctuation"
 msgstr "移除不必要的標點符號"
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info from the internet"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Invites the user to remove their personal information from the internet.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Remove your info online"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16099,14 +16494,18 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr "報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享給%1$s來協助改善其服務。"
+msgstr ""
+"報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享"
+"給%1$s來協助改善其服務。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
+msgstr ""
+"傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別"
+"身分的資訊。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16114,7 +16513,9 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr "傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
+msgstr ""
+"傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿"
+"名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16205,7 +16606,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回答受我們的 %1$s 服務條款%2$s約束。"
+msgstr ""
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回"
+"答受我們的 %1$s 服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16213,7 +16616,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist 受我們的%1$s服務條款%2$s約束。"
+msgstr ""
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist "
+"受我們的%1$s服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16223,8 +16628,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁內容生成，可能會有不準確之處。Search Assist 受我們的 "
-"%1$s服務條款%2$s 約束。"
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁"
+"內容生成，可能會有不準確之處。Search Assist 受我們的 %1$s服務條款%2$s 約束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16648,7 +17053,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更多內容。"
+msgstr ""
+"你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更"
+"多內容。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16692,6 +17099,12 @@ msgstr "以匿名方式將你的設定儲存至雲端"
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to Duck.ai"
 msgstr "向 Duck.ai 打聲招呼！"
+
+# smartling.placeholder_format=C
+#. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
+msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
+msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -16894,16 +17307,18 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相關內容，然後使用 AI "
-"生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在點按 Assist 時)、有時 (在高度相關時)，或經常 "
-"(在廣泛的搜尋中)。目前，Search Assist 功能僅供部分英語地區使用。"
+"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相"
+"關內容，然後使用 AI 生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在"
+"點按 Assist 時)、有時 (在高度相關時)，或經常 (在廣泛的搜尋中)。目前，Search "
+"Assist 功能僅供部分英語地區使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr "Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
+msgstr ""
+"Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16912,8 +17327,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網路%2$s以尋找相關內容，然後使用 AI "
-"根據找到的資訊生成簡短的答案。"
+"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網"
+"路%2$s以尋找相關內容，然後使用 AI 根據找到的資訊生成簡短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17033,7 +17448,9 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr "使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋「ducks」。"
+msgstr ""
+"使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋"
+"「ducks」。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17051,7 +17468,9 @@ msgstr "私密搜尋與封鎖追蹤器"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr "使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
+msgstr ""
+"使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋"
+"功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17070,8 +17489,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 Cloud Save "
-"將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資料，且你的通關密語永遠不會離開你的瀏覽器。"
+"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 "
+"Cloud Save 將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資"
+"料，且你的通關密語永遠不會離開你的瀏覽器。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17189,7 +17609,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步的裝置存取。"
+msgstr ""
+"以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步"
+"的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17197,7 +17619,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存取。"
+msgstr ""
+"以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存"
+"取。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17211,7 +17635,9 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到你的資料，連我們也不行。"
+msgstr ""
+"採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到"
+"你的資料，連我們也不行。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -17617,7 +18043,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有對話。"
+msgstr ""
+"向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有"
+"對話。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17638,6 +18066,13 @@ msgstr "塞爾維亞語（西里爾文）"
 msgctxt "language_name"
 msgid "Serbian (Latin)"
 msgstr "塞爾維亞語（拉丁文）"
+
+# smartling.placeholder_format=C
+#. Confirms that deleting the server data finished successfully.
+msgctxt ""
+"Title of the success screen shown after the server data has been deleted"
+msgid "Server data deleted"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Status label shown when the voice chat session has ended.
@@ -17732,7 +18167,8 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr "開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
+msgstr ""
+"開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17790,6 +18226,14 @@ msgid "Share"
 msgstr "分享"
 
 # smartling.placeholder_format=C
+#. Shown beside the Copy button under the QR code, only on devices whose browser can open a share sheet. It shares the same link the QR code contains, not a picture of the QR code.
+msgctxt ""
+"Button label that opens the system share sheet to send the sync code link to "
+"another app"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
@@ -17830,7 +18274,9 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr "與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透露你的精確位置。"
+msgstr ""
+"與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透"
+"露你的精確位置。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -17934,12 +18380,26 @@ msgid "Share your thoughts on the search box."
 msgstr "分享你對搜尋方塊的想法。"
 
 # smartling.placeholder_format=C
+#. Title-case label for the Duck.ai setting that opens the list of share links created on this device. The row has no description line.
+msgctxt "Title of the Shared Chat Links row on the Duck.ai chat settings page"
+msgid "Shared Chat Links"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header above the list of share links created on this device. Separate from the settings row label so the two can be worded differently.
+msgctxt "Header of the Duck.ai shared links modal"
+msgid "Shared chat links"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr "使用我們無記錄、快速的 VPN 來保護你的線上活動。 設定簡單，且可隨時輕鬆開啟或關閉。"
+msgstr ""
+"使用我們無記錄、快速的 VPN 來保護你的線上活動。 設定簡單，且可隨時輕鬆開啟或"
+"關閉。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18296,14 +18756,18 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr "提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影響私密搜尋。"
+msgstr ""
+"提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影"
+"響私密搜尋。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影響搜尋保護。"
+msgstr ""
+"提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影"
+"響搜尋保護。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18595,6 +19059,12 @@ msgstr "其他東西"
 msgctxt "duckai_migration"
 msgid "Something went wrong"
 msgstr "發生錯誤"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
+msgctxt "Generic toast for share view load failures"
+msgid "Something went wrong loading this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19427,6 +19897,12 @@ msgid "Switch model"
 msgstr "切換模型"
 
 # smartling.placeholder_format=C
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
@@ -19606,16 +20082,19 @@ msgid ""
 msgstr ""
 "同步恢復碼\n"
 "\n"
-"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在你無法存取某個裝置時恢復你的同步資料。\n"
+"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在"
+"你無法存取某個裝置時恢復你的同步資料。\n"
 "\n"
 "確保此資訊安全無虞。\n"
 "任何有權限存取此代碼的人都能存取你同步的資料。%1$s\n"
 "\n"
 "這段代碼是如何運作的？\n"
-"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & Backup」，然後選擇「恢復已同步的資料」\n"
+"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & "
+"Backup」，然後選擇「恢復已同步的資料」\n"
 "3. 複製上方的恢復代碼，並貼到顯示「將你的代碼貼在這裡」的地方\n"
 "\n"
-"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將從伺服器上刪除，且無法恢復。"
+"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將"
+"從伺服器上刪除，且無法恢復。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19672,6 +20151,13 @@ msgid "Synced Devices"
 msgstr "同步裝置"
 
 # smartling.placeholder_format=C
+#. Appears under the device name when the user opens the details for one of their devices. %s is replaced with a date.
+msgctxt ""
+"Shows the date a device last synced; %s is a date such as Apr 17, 2025"
+msgid "Synced on %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Syria"
 msgstr "敘利亞"
 
@@ -19704,6 +20190,12 @@ msgid "TV"
 msgstr "電視"
 
 # smartling.placeholder_format=C
+#. Accessible label announced by screen readers for the scrollable container around a data table in an AI chat response. Keyboard users can focus this container to scroll wide tables. Please keep the text as short as possible.
+msgctxt "AI Chat accessible label for a scrollable table in a response"
+msgid "Table"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Tahitian language
 msgctxt "language_name"
 msgid "Tahitian"
@@ -19734,7 +20226,9 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr "隨身帶著 Duck.ai。 無論身在何處，都能透過我們免費 App 的內建功能更快速地存取。"
+msgstr ""
+"隨身帶著 Duck.ai。 無論身在何處，都能透過我們免費 App 的內建功能更快速地存"
+"取。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -19742,7 +20236,9 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr "隨時隨地帶著 Duck.ai。 使用我們免費瀏覽器的內建功能，無論你在何處瀏覽都能更快速存取。"
+msgstr ""
+"隨時隨地帶著 Duck.ai。 使用我們免費瀏覽器的內建功能，無論你在何處瀏覽都能更快"
+"速存取。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19985,7 +20481,9 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr "這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
+msgstr ""
+"這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第"
+"三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20101,7 +20599,8 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
+msgstr ""
+"在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20133,7 +20632,9 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr "這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設搜尋引擎，藉此為你造訪的網站新增隱私保護。"
+msgstr ""
+"這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設"
+"搜尋引擎，藉此為你造訪的網站新增隱私保護。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20217,8 +20718,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %4$s "
-"取得更多資訊)。"
+"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準"
+"確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20227,7 +20728,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr "此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
+msgstr ""
+"此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令"
+"人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20235,7 +20738,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr "這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感的資訊。（更多資訊請參見%2$s）。"
+msgstr ""
+"這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感"
+"的資訊。（更多資訊請參見%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20245,8 +20750,24 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 "
-"(請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能"
+"會顯示不準確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
+
+# smartling.placeholder_format=C
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Label marking the current device in the synced devices list"
+msgid "This device"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Reassures the user that the most recent chats stay saved on this device even after they turn syncing off. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Body text of the dialog asking the user to confirm turning off syncing on "
+"the device they are using"
+msgid ""
+"This device will no longer be able to access your synced data on other "
+"devices. The last %s chats will still remain available in local storage."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20332,12 +20853,20 @@ msgid "This information isn’t useful"
 msgstr "這些資訊沒有用"
 
 # smartling.placeholder_format=C
+#. Header label at the top of the shared conversation panel in Duck.ai when someone opens a shared chat link. Tells the viewer that the messages shown are a copy of a shared chat.
+msgctxt "Label above messages in a shared chat view"
+msgid "This is a copy of a shared chat."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
 msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr "這只是一則範例聊天。 開啟選單（三個點），然後選擇「釘選」，將它保持在聊天的最上方！"
+msgstr ""
+"這只是一則範例聊天。 開啟選單（三個點），然後選擇「釘選」，將它保持在聊天的最"
+"上方！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20365,7 +20894,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留模式。"
+msgstr ""
+"此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留"
+"模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20373,7 +20904,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模式。"
+msgstr ""
+"此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模"
+"式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20409,7 +20942,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從任何瀏覽器存取。"
+msgstr ""
+"這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從"
+"任何瀏覽器存取。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20417,7 +20952,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI 輔助的答案。"
+msgstr ""
+"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
+"可能會再次看到 AI 輔助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20427,8 +20964,21 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI "
-"輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 AI 輔助答案。"
+"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
+"可能會再次看到 AI 輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 "
+"AI 輔助答案。"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
+msgctxt "Toast when share decryption fails"
+msgid "This shared chat could not be opened. The link may be incomplete."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
+msgctxt "Toast when a share link is missing or expired"
+msgid "This shared chat link is no longer available."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20467,8 +21017,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然可以在連接到 Sync & Backup "
-"的其他瀏覽器中存取您的聊天記錄。"
+"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然"
+"可以在連接到 Sync & Backup 的其他瀏覽器中存取您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20613,7 +21163,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖示。%4$s"
+msgstr ""
+"如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖"
+"示。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20622,7 +21174,9 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr "若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲存在您最初用於設定同步的裝置上。"
+msgstr ""
+"若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲"
+"存在您最初用於設定同步的裝置上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20630,7 +21184,9 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再試一次。"
+msgstr ""
+"欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再"
+"試一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20879,7 +21435,8 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
+msgstr ""
+"將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20887,7 +21444,8 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
+msgstr ""
+"將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21049,6 +21607,12 @@ msgid "Try Free"
 msgstr "免費試用"
 
 # smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try Free!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try Free!"
@@ -21160,6 +21724,12 @@ msgstr "免費試用"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid "Try for Free"
 msgstr "免費試用"
+
+# smartling.placeholder_format=C
+#. Call-to-action button label on the Personal Information Removal instant answer shown on the search results page (US only). Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid "Try for Free!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
@@ -21352,7 +21922,9 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr "想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設定。 %3$s瞭解更多%4$s"
+msgstr ""
+"想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設"
+"定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21360,7 +21932,9 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr "想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設定。 %3$s瞭解更多%4$s"
+msgstr ""
+"想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設"
+"定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21399,6 +21973,12 @@ msgid "Turkmenistan"
 msgstr "土庫曼"
 
 # smartling.placeholder_format=C
+#. The user taps this to turn off Sync & Backup on the device they are using.
+msgctxt "Button that confirms turning off syncing"
+msgid "Turn Off"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
 msgctxt "Destructive action that disconnects this device from Sync & Backup"
 msgid "Turn Off Sync & Backup"
@@ -21409,6 +21989,12 @@ msgstr "關閉 Sync & Backup"
 msgctxt "Secondary action that disables sync on this device only"
 msgid "Turn Off Sync & Backup"
 msgstr "關閉 Sync & Backup"
+
+# smartling.placeholder_format=C
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Turn Off Sync & Backup and Delete Server Data?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -21548,7 +22134,9 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延遲。"
+msgstr ""
+"在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延"
+"遲。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21799,7 +22387,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus 方案的使用上限。"
+msgstr ""
+"透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus "
+"方案的使用上限。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21874,6 +22464,12 @@ msgid "Unmute"
 msgstr "取消靜音"
 
 # smartling.placeholder_format=C
+#. Placeholder shown in the Duck.ai shared links list when the stored share record has an empty title.
+msgctxt "Fallback name for a shared link whose chat has no title"
+msgid "Untitled chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
 msgctxt "feedback form"
 msgid "Unverified information"
@@ -21907,6 +22503,12 @@ msgstr "更新"
 msgctxt "Old app version banner component in Duck.ai"
 msgid "Update Browser"
 msgstr "更新瀏覽器"
+
+# smartling.placeholder_format=C
+#. Error toast shown when a shared chat was created by a newer version of Duck.ai than the viewer's version supports. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Toast when a shared chat requires a newer version of Duck.ai"
+msgid "Update Duck.ai to view this shared chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that updates the user's current location on a map.
@@ -22169,7 +22771,9 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr "私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵害。對資訊保密。免費。不需要帳戶。"
+msgstr ""
+"私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵"
+"害。對資訊保密。免費。不需要帳戶。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22379,7 +22983,8 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
+msgstr ""
+"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -22387,7 +22992,9 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管理。"
+msgstr ""
+"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管"
+"理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22429,8 +23036,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & Backup%4$s > "
-"%5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22440,8 +23047,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & "
-"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
+"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & Backup」下選取"
+"「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22451,8 +23058,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設"
+"定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22462,8 +23069,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在「Sync & "
-"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
+"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在"
+"「Sync & Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 "
+"PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22658,7 +23266,9 @@ msgstr "在 Duck Player 中觀看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr "在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推播干擾。"
+msgstr ""
+"在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推"
+"播干擾。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22678,8 +23288,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube "
-"沒有任何關係。"
+"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內"
+"容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube 沒有任何關係。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22702,7 +23312,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo 分享此對話，以便我們調查並處理該問題。"
+msgstr ""
+"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo "
+"分享此對話，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22713,7 +23325,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的提示詞與回覆內容，以便我們調查並處理該問題。"
+msgstr ""
+"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的"
+"提示詞與回覆內容，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -22753,7 +23367,8 @@ msgstr "我們不會儲存你的個人資訊。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr "我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
+msgstr ""
+"我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22774,7 +23389,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
+msgstr ""
+"本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22813,7 +23429,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr "我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告商。"
+msgstr ""
+"我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告"
+"商。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22833,12 +23451,22 @@ msgid "We ended the chat due to inactivity. Want to try again?"
 msgstr "我們因為無活動而結束了聊天。想再試一次？"
 
 # smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We find and remove your personal info from data broker sites. Plus get a VPN "
+"and more."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
 msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr "我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智慧。"
+msgstr ""
+"我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智"
+"慧。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22870,7 +23498,17 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主意。"
+msgstr ""
+"我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主"
+"意。"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We regularly scan data broker sites for your personal info, and we share our "
+"progress with you in an easy-to-use dashboard."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22896,12 +23534,22 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr "我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立刻出現。"
+msgstr ""
+"我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立"
+"刻出現。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr "我們會在你瀏覽時，封鎖試圖收集你資料的追蹤器。"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"We'll scan data broker sites for your email, name, address, and more, and "
+"work to get anything we find about you removed."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23060,7 +23708,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr "歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
+msgstr ""
+"歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會"
+"用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23068,7 +23718,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr "歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
+msgstr ""
+"歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名"
+"化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23078,8 +23730,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這裡的所有聊天內容都是私密的，且永遠不會被 "
-"DuckDuckGo 儲存或用來訓練 AI 模型。"
+"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這"
+"裡的所有聊天內容都是私密的，且永遠不會被 DuckDuckGo 儲存或用來訓練 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23195,6 +23847,12 @@ msgid "What are some pros and cons of annuities?"
 msgstr "年金的優缺點是？"
 
 # smartling.placeholder_format=C
+#. Starts a new conversation asking Duck.ai to explain its benefits. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Prompt sent when a shared-chat viewer selects Learn More"
+msgid "What are the benefits of Duck.ai?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
 msgctxt "User prompt seeded by Learn More CTA"
 msgid ""
@@ -23205,8 +23863,9 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 DuckDuckGo 來源。將回應分成清晰的部分，並以 "
-"Duck.ai 整合和隱私保護為重點。對於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
+"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 "
+"DuckDuckGo 來源。將回應分成清晰的部分，並以 Duck.ai 整合和隱私保護為重點。對"
+"於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23741,13 +24400,23 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr "使用 Duck.ai，你的聊天內容都會經過匿名處理，且絕不會用於訓練 AI。 你可以隨時在「%1$s」選單中將其開啟或關閉。"
+msgstr ""
+"使用 Duck.ai，你的聊天內容都會經過匿名處理，且絕不會用於訓練 AI。 你可以隨時"
+"在「%1$s」選單中將其開啟或關閉。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
 msgstr "在維持供應商可見度的情況下"
+
+# smartling.placeholder_format=C
+#. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. Emphasizes that removal runs from the user's device; 'data broker sites' are companies that collect and sell personal information.
+msgctxt "DuckDuckGo Personal Information Removal instant answer"
+msgid ""
+"Works right from your device to remove your email, name, address, and more "
+"from data broker sites."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24066,7 +24735,8 @@ msgstr "你最多可以附加 %1$s 個文字選擇。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
+msgstr ""
+"你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24086,7 +24756,8 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr "你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
+msgstr ""
+"你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24229,12 +24900,21 @@ msgid "You have 1 attempt left."
 msgstr "你還可以嘗試1次。"
 
 # smartling.placeholder_format=C
+#. Shown instead of the rows when the device has no share links. Scoped to this device on purpose — links created elsewhere can't be listed or deleted here.
+msgctxt ""
+"Empty state shown inside the list container of the Duck.ai shared links modal"
+msgid "You have no shared chat links."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
 msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高出 2 倍的使用上限。"
+msgstr ""
+"您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高"
+"出 2 倍的使用上限。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24242,7 +24922,9 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr "你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 DuckDuckGo 訂閱保護功能。"
+msgstr ""
+"你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 "
+"DuckDuckGo 訂閱保護功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24263,7 +24945,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr ""
+"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
+"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24272,7 +24956,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr ""
+"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
+"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24299,7 +24985,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr "你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏覽。應用程式已經安裝完畢，而且可以："
+msgstr ""
+"你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏"
+"覽。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24386,7 +25074,9 @@ msgctxt "Sync file storage limit modal description"
 msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
-msgstr "您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr ""
+"您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的"
+"聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24395,7 +25085,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats. Delete the %s "
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
-msgstr "您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr ""
+"您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件"
+"聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24408,7 +25100,9 @@ msgstr "你的儲存空間已用完"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr "YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/Google追蹤。"
+msgstr ""
+"YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/"
+"Google追蹤。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24420,6 +25114,23 @@ msgstr "YouTube隱私警示"
 msgctxt "video-license"
 msgid "YouTube Standard"
 msgstr "標準YouTube授權"
+
+# smartling.placeholder_format=C
+#. Reassures the user that a limited number of recent chats stay saved on the listed devices after deleting. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt ""
+"Second body paragraph in the Delete Server Data confirmation modal, above "
+"the device list"
+msgid ""
+"Your %s most recent chats will be available in local storage on these "
+"browsers:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
+msgctxt ""
+"Description shown under the title on the Sync & Backup settings screen"
+msgid "Your Duck.ai chats are being synced with end-to-end encryption."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24445,13 +25156,23 @@ msgid "Your actual location remains private."
 msgstr "你的實際位置仍將保密。"
 
 # smartling.placeholder_format=C
+#. Explains the main consequence of deleting all server data: the backup is removed and every device is signed out of syncing.
+msgctxt "First body paragraph in the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
 msgctxt "Body copy for the Delete Server Data confirmation modal"
 msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
+msgstr ""
+"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
+"中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24460,7 +25181,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
+msgstr ""
+"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
+"中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24524,14 +25247,16 @@ msgstr "您的聊天內容是私密的，且絕不會用於訓練 AI 模型"
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr ""
+"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr ""
+"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24559,7 +25284,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr "您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些步驟保留您的聊天記錄。"
+msgstr ""
+"您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些"
+"步驟保留您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24598,7 +25325,8 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
+msgstr ""
+"你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24640,7 +25368,10 @@ msgid ""
 "known as %sSHA-2%s. Only the key and associated settings file leave your "
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
-msgstr "我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔案。DuckDuckGo不會知道你的通關密語。"
+msgstr ""
+"我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。"
+"只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔"
+"案。DuckDuckGo不會知道你的通關密語。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24654,7 +25385,9 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr "你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者無法將你的對話與你連結起來。"
+msgstr ""
+"你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者"
+"無法將你的對話與你連結起來。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24698,7 +25431,9 @@ msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
-msgstr "你的設定已儲存，但清除 Cookie 將會重設這些設定。啟用 %1$sDuckDuckGo No AI%2$s 擴充套件以使其永久生效。"
+msgstr ""
+"你的設定已儲存，但清除 Cookie 將會重設這些設定。啟用 %1$sDuckDuckGo No "
+"AI%2$s 擴充套件以使其永久生效。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -24707,8 +25442,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No AI%2$s 擴充套件以使其永久生效。 "
-"%3$s瞭解更多%4$s"
+"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No "
+"AI%2$s 擴充套件以使其永久生效。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -24727,7 +25462,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr "你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得更全面的保護。應用程式已經安裝完畢，而且可以："
+msgstr ""
+"你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得"
+"更全面的保護。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -24743,7 +25480,8 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr "您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
+msgstr ""
+"您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to translation catalogs with no runtime logic; risk is incomplete translations showing English or blank strings in some locales until follow-up translation work lands.
> 
> **Overview**
> Adds a batch of new **gettext strings** to `duckduckgo.pot` and rolls them into locale `duckduckgo.po` files (e.g. Afrikaans filled in; several Arabic locales still have empty `msgstr` for the new entries).
> 
> Most of the new copy supports **Duck.ai shared chats** (e.g. **Add to My Chats**, shared-link management modal, expiry/error toasts, promo banner) and **Sync & Backup** flows (device list labels, enter-code steps, recovery links, delete server data confirmations).
> 
> Also adds strings for **Personal Information Removal** SERP instant answers, plus smaller UI items such as **2nd opinion**, Chrome NTP **Ask anything privately**, eclipse logo tooltip, and accessibility labels for response tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68cbf82c53b56aebdbbc72d6d27b6bf490f95b6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->